### PR TITLE
tui: deliver window resize events on Windows

### DIFF
--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -79,12 +79,19 @@ func (b *BubbleTeaUI) Input() <-chan string {
 func (b *BubbleTeaUI) Run() error {
 	model := NewModel(b.inputChan, b.outbound)
 
-	b.program = tea.NewProgram(
-		model,
+	opts := []tea.ProgramOption{
 		tea.WithAltScreen(),
 		tea.WithMouseCellMotion(),
-		tea.WithInputTTY(),
-	)
+	}
+	// On Windows, resize events only arrive through the console input
+	// reader, which bubbletea engages only when the input is os.Stdin
+	// itself. WithInputTTY opens CONIN$ as a separate handle, so bubbletea
+	// silently falls back to its ANSI reader and window resizes (and
+	// native mouse events) are never delivered.
+	if runtime.GOOS != "windows" {
+		opts = append(opts, tea.WithInputTTY())
+	}
+	b.program = tea.NewProgram(model, opts...)
 
 	// Single goroutine drains message queue to Bubble Tea.
 	// This can block on Send() without affecting producers.


### PR DESCRIPTION
Fixes #1.

On Windows, bubbletea delivers `WindowSizeMsg` resize events only through its Windows Console API input reader, and it engages that reader only when the program's input is `os.Stdin` itself ([inputreader_windows.go](https://github.com/charmbracelet/bubbletea/blob/v1.3.10/inputreader_windows.go#L32)). We passed `tea.WithInputTTY()`, which on Windows opens `CONIN$` as a separate handle — so bubbletea silently fell back to its ANSI reader, which never emits resize (or native mouse) events.

The only size the UI ever saw was bubbletea's one-shot probe at startup, which explains both symptoms: growing the window leaves the layout at boot dimensions, and shrinking makes the renderer paint frames larger than the real window, blinking on every repaint.

**Fix**: keep `WithInputTTY` on Unix (where it just means `/dev/tty`; behavior unchanged) and let input default to `os.Stdin` on Windows so the console reader engages.

**Testing**: native and `GOOS=windows` builds pass, `go test ./...` passes. Windows behavior needs manual QA on a real console.