### PR TITLE
tui: pane line wrapping, per-pane scrolling, row width clipping

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/yuin/gopher-lua v1.1.1
 )
@@ -14,7 +15,6 @@ require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -136,29 +136,39 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.input.SetCursor(int(msg))
 		return m, nil
 
-	// Pane scrolling (from Lua)
+	// Pane scrolling (from Lua). "main" is the output viewport; any
+	// other name scrolls that pane's own buffer. Unknown panes are
+	// ignored rather than auto-created.
 	case ui.PaneScrollUpMsg:
 		if msg.Name == "main" {
 			m.viewport.ScrollUp(msg.Lines)
 			m.updateScrollState()
+		} else if m.panes.Exists(msg.Name) {
+			m.panes.Get(msg.Name).ScrollUp(msg.Lines)
 		}
 		return m, nil
 	case ui.PaneScrollDownMsg:
 		if msg.Name == "main" {
 			m.viewport.ScrollDown(msg.Lines)
 			m.updateScrollState()
+		} else if m.panes.Exists(msg.Name) {
+			m.panes.Get(msg.Name).ScrollDown(msg.Lines)
 		}
 		return m, nil
 	case ui.PaneScrollToTopMsg:
 		if msg.Name == "main" {
 			m.viewport.GotoTop()
 			m.updateScrollState()
+		} else if m.panes.Exists(msg.Name) {
+			m.panes.Get(msg.Name).ScrollToTop()
 		}
 		return m, nil
 	case ui.PaneScrollToBottomMsg:
 		if msg.Name == "main" {
 			m.viewport.GotoBottom()
 			m.updateScrollState()
+		} else if m.panes.Exists(msg.Name) {
+			m.panes.Get(msg.Name).ScrollToBottom()
 		}
 		return m, nil
 	}

--- a/ui/tui/widget/bar.go
+++ b/ui/tui/widget/bar.go
@@ -49,7 +49,7 @@ func (b *Bar) View() string {
 		if rightPad < 1 {
 			rightPad = 1
 		}
-		return left + strings.Repeat(" ", leftPad) + center + strings.Repeat(" ", rightPad) + right
+		return clipRow(left+strings.Repeat(" ", leftPad)+center+strings.Repeat(" ", rightPad)+right, b.width)
 	}
 
 	// Two-part layout
@@ -57,7 +57,7 @@ func (b *Bar) View() string {
 	if pad < 1 {
 		pad = 1
 	}
-	return left + strings.Repeat(" ", pad) + right
+	return clipRow(left+strings.Repeat(" ", pad)+right, b.width)
 }
 
 // SetSize implements Widget.

--- a/ui/tui/widget/pane.go
+++ b/ui/tui/widget/pane.go
@@ -1,8 +1,10 @@
 package widget
 
 import (
+	"fmt"
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mmcdole/rune/ui/tui/style"
 	"github.com/mmcdole/rune/ui/tui/util"
 )
@@ -11,13 +13,21 @@ import (
 var _ Widget = (*Pane)(nil)
 
 // Pane represents a named buffer that can be shown/hidden.
+//
+// Lines are stored as written (logical lines) and soft-wrapped to the
+// pane width at render time, so a resize re-fits everything. Scrolling
+// is tracked as a logical-line offset from the newest line; while
+// scrolled the view stays anchored on the same history, new writes are
+// counted, and the header shows a scroll indicator.
 type Pane struct {
-	Name    string
-	Lines   []string
-	Visible bool
-	height  int // Number of lines to show when visible
-	styles  style.Styles
-	width   int
+	Name     string
+	Lines    []string
+	Visible  bool
+	height   int // Number of content lines to show when visible
+	styles   style.Styles
+	width    int
+	offset   int // logical lines scrolled back from the newest (0 = live)
+	newLines int // writes that arrived while scrolled
 }
 
 // NewPane creates a new pane widget.
@@ -31,6 +41,50 @@ func NewPane(name string, styles style.Styles) *Pane {
 	}
 }
 
+// wrapLine soft-wraps one logical line to the given width, returning
+// at least one row. ANSI codes and wide runes are handled.
+func wrapLine(line string, width int) []string {
+	if width < 1 {
+		width = 1
+	}
+	if util.VisibleLen(line) <= width {
+		return []string{line}
+	}
+	return strings.Split(ansi.Wrap(line, width, ""), "\n")
+}
+
+// visibleRows renders exactly p.height rows of wrapped content for the
+// current scroll position. The window is anchored at the logical line
+// end = len(Lines)-offset; when a deep scroll leaves it underfull, it
+// extends forward so the pane stays full whenever the buffer allows.
+func (p *Pane) visibleRows() []string {
+	end := len(p.Lines) - p.offset
+	if end < 0 {
+		end = 0
+	}
+
+	var rows []string
+	for i := end - 1; i >= 0 && len(rows) < p.height; i-- {
+		rows = append(wrapLine(p.Lines[i], p.width), rows...)
+	}
+
+	if len(rows) >= p.height {
+		rows = rows[len(rows)-p.height:]
+	} else {
+		for i := end; i < len(p.Lines) && len(rows) < p.height; i++ {
+			rows = append(rows, wrapLine(p.Lines[i], p.width)...)
+		}
+		if len(rows) > p.height {
+			rows = rows[:p.height]
+		}
+	}
+
+	for len(rows) < p.height {
+		rows = append(rows, "")
+	}
+	return rows
+}
+
 // View implements Widget.
 func (p *Pane) View() string {
 	if !p.Visible {
@@ -39,28 +93,23 @@ func (p *Pane) View() string {
 
 	var parts []string
 
-	// Header
-	title := p.styles.PaneHeader.Render(" " + p.Name + " ")
+	// Header, with a scroll indicator while off the live tail
+	// (mirrors the status bar's SCROLL/LIVE vocabulary).
+	label := " " + p.Name + " "
+	if p.offset > 0 {
+		if p.newLines > 0 {
+			label = fmt.Sprintf(" %s · scroll +%d ", p.Name, p.newLines)
+		} else {
+			label = " " + p.Name + " · scroll "
+		}
+	}
+	title := p.styles.PaneHeader.Render(label)
 	titlePad := p.width - util.VisibleLen(title)
 	if titlePad > 0 {
 		title += p.styles.PaneBorder.Render(strings.Repeat("─", titlePad))
 	}
 	parts = append(parts, title)
-
-	// Content (last N lines)
-	start := 0
-	if len(p.Lines) > p.height {
-		start = len(p.Lines) - p.height
-	}
-
-	for i := 0; i < p.height; i++ {
-		lineIdx := start + i
-		if lineIdx < len(p.Lines) {
-			parts = append(parts, p.Lines[lineIdx])
-		} else {
-			parts = append(parts, "")
-		}
-	}
+	parts = append(parts, p.visibleRows()...)
 
 	// Bottom border
 	parts = append(parts, p.styles.PaneBorder.Render(strings.Repeat("─", p.width)))
@@ -87,22 +136,74 @@ func (p *Pane) PreferredHeight() int {
 	return p.height + 2 // content + header + border
 }
 
-// Write appends a line to the pane.
+// Write appends a line to the pane. While scrolled, the view stays
+// anchored on the same history (the offset grows with the buffer) and
+// the new line is counted for the header indicator.
 func (p *Pane) Write(text string) {
 	p.Lines = append(p.Lines, text)
+	if p.offset > 0 {
+		p.offset++
+		p.newLines++
+	}
 	if len(p.Lines) > 1000 {
 		p.Lines = p.Lines[len(p.Lines)-500:]
+		p.clampOffset()
 	}
 }
 
-// Toggle toggles visibility.
+func (p *Pane) clampOffset() {
+	max := len(p.Lines) - 1
+	if max < 0 {
+		max = 0
+	}
+	if p.offset > max {
+		p.offset = max
+	}
+	if p.offset <= 0 {
+		p.offset = 0
+		p.newLines = 0
+	}
+}
+
+// ScrollUp scrolls back by n logical lines.
+func (p *Pane) ScrollUp(n int) {
+	p.offset += n
+	p.clampOffset()
+}
+
+// ScrollDown scrolls forward by n logical lines; reaching the newest
+// line returns the pane to live tailing.
+func (p *Pane) ScrollDown(n int) {
+	p.offset -= n
+	p.clampOffset()
+}
+
+// ScrollToTop jumps to the oldest line.
+func (p *Pane) ScrollToTop() {
+	p.offset = len(p.Lines) - 1
+	p.clampOffset()
+}
+
+// ScrollToBottom returns to live tailing.
+func (p *Pane) ScrollToBottom() {
+	p.offset = 0
+	p.newLines = 0
+}
+
+// Toggle toggles visibility. Hiding a pane returns it to the live
+// tail, so re-showing it never opens onto stale history.
 func (p *Pane) Toggle() {
 	p.Visible = !p.Visible
+	if !p.Visible {
+		p.ScrollToBottom()
+	}
 }
 
 // Clear empties the pane.
 func (p *Pane) Clear() {
 	p.Lines = p.Lines[:0]
+	p.offset = 0
+	p.newLines = 0
 }
 
 // PaneManager handles multiple named panes.

--- a/ui/tui/widget/pane_test.go
+++ b/ui/tui/widget/pane_test.go
@@ -1,0 +1,193 @@
+package widget
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mmcdole/rune/ui/tui/style"
+	"github.com/mmcdole/rune/ui/tui/util"
+)
+
+// newTestPane returns a visible pane sized to width x (content+2),
+// matching how the layout sizes docked panes.
+func newTestPane(t *testing.T, width, contentHeight int) *Pane {
+	t.Helper()
+	p := NewPane("test", style.DefaultStyles())
+	p.Visible = true
+	p.SetSize(width, contentHeight+2)
+	return p
+}
+
+// contentRows strips the header and bottom border from View.
+func contentRows(t *testing.T, p *Pane) []string {
+	t.Helper()
+	rows := strings.Split(p.View(), "\n")
+	if len(rows) < 3 {
+		t.Fatalf("view too short: %d rows", len(rows))
+	}
+	return rows[1 : len(rows)-1]
+}
+
+func TestPaneWrapsLongLines(t *testing.T) {
+	p := newTestPane(t, 20, 4)
+	p.Write("one two three four five six seven")
+
+	rows := contentRows(t, p)
+	for i, r := range rows {
+		if util.VisibleLen(r) > 20 {
+			t.Errorf("row %d exceeds width: %q (%d cols)", i, r, util.VisibleLen(r))
+		}
+	}
+	joined := strings.Join(rows, " ")
+	joined = strings.Join(strings.Fields(joined), " ")
+	if joined != "one two three four five six seven" {
+		t.Errorf("wrapped content mangled: %q", joined)
+	}
+}
+
+func TestPaneTailShowsNewestRows(t *testing.T) {
+	p := newTestPane(t, 40, 3)
+	for i := 1; i <= 10; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+
+	rows := contentRows(t, p)
+	want := []string{"line 8", "line 9", "line 10"}
+	for i, w := range want {
+		if rows[i] != w {
+			t.Errorf("row %d = %q, want %q", i, rows[i], w)
+		}
+	}
+}
+
+func TestPaneWrappedTailCountsVisualRows(t *testing.T) {
+	// One long line wraps to more rows than the pane height: the pane
+	// must show the newest rows of it, not blank out.
+	p := newTestPane(t, 10, 2)
+	p.Write("aaaa bbbb cccc dddd eeee")
+
+	rows := contentRows(t, p)
+	if strings.TrimSpace(rows[0]) == "" || strings.TrimSpace(rows[1]) == "" {
+		t.Errorf("expected the newest wrapped rows, got %q", rows)
+	}
+	if !strings.Contains(rows[1], "eeee") {
+		t.Errorf("last row should hold the end of the message, got %q", rows[1])
+	}
+}
+
+func TestPaneScrollUpShowsHistoryAndIndicator(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 10; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+
+	p.ScrollUp(5)
+	rows := contentRows(t, p)
+	if rows[0] != "line 4" || rows[1] != "line 5" {
+		t.Errorf("scrolled view = %q, want lines 4-5", rows)
+	}
+	if header := strings.Split(p.View(), "\n")[0]; !strings.Contains(header, "scroll") {
+		t.Errorf("header should show scroll indicator, got %q", header)
+	}
+}
+
+func TestPaneWritesWhileScrolledFreezeViewAndCount(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 6; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.ScrollUp(3)
+	before := contentRows(t, p)
+
+	p.Write("line 7")
+	p.Write("line 8")
+
+	after := contentRows(t, p)
+	if before[0] != after[0] || before[1] != after[1] {
+		t.Errorf("view should stay anchored while scrolled: %q -> %q", before, after)
+	}
+	if header := strings.Split(p.View(), "\n")[0]; !strings.Contains(header, "+2") {
+		t.Errorf("header should count new lines, got %q", header)
+	}
+
+	p.ScrollToBottom()
+	rows := contentRows(t, p)
+	if rows[1] != "line 8" {
+		t.Errorf("bottom should show the newest line, got %q", rows)
+	}
+	if header := strings.Split(p.View(), "\n")[0]; strings.Contains(header, "scroll") {
+		t.Errorf("indicator should clear at bottom, got %q", header)
+	}
+}
+
+func TestPaneScrollClamps(t *testing.T) {
+	p := newTestPane(t, 40, 3)
+	for i := 1; i <= 5; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+
+	p.ScrollUp(1000)
+	rows := contentRows(t, p)
+	if rows[0] != "line 1" {
+		t.Errorf("over-scroll should clamp to the top, got %q", rows)
+	}
+	// Deep scroll keeps the window full by extending forward.
+	if rows[1] != "line 2" || rows[2] != "line 3" {
+		t.Errorf("scrolled-to-top window should stay full, got %q", rows)
+	}
+
+	p.ScrollDown(1000)
+	rows = contentRows(t, p)
+	if rows[2] != "line 5" {
+		t.Errorf("scroll down past the end should return to live, got %q", rows)
+	}
+}
+
+func TestPaneToggleOffResetsScroll(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 6; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.ScrollUp(3)
+	p.Toggle() // hide
+	p.Toggle() // show again
+
+	rows := contentRows(t, p)
+	if rows[1] != "line 6" {
+		t.Errorf("re-shown pane should be at the live tail, got %q", rows)
+	}
+}
+
+func TestPaneEmptyAndClear(t *testing.T) {
+	p := newTestPane(t, 40, 3)
+	rows := contentRows(t, p)
+	for i, r := range rows {
+		if r != "" {
+			t.Errorf("empty pane row %d should be blank, got %q", i, r)
+		}
+	}
+
+	p.Write("something")
+	p.ScrollUp(1)
+	p.Clear()
+	rows = contentRows(t, p)
+	if strings.TrimSpace(strings.Join(rows, "")) != "" {
+		t.Errorf("cleared pane should be blank, got %q", rows)
+	}
+}
+
+func TestClipRowTruncatesOverlongRows(t *testing.T) {
+	long := strings.Repeat("x", 50)
+	clipped := clipRow(long, 20)
+	if util.VisibleLen(clipped) != 20 {
+		t.Errorf("clipped to %d cols, want 20", util.VisibleLen(clipped))
+	}
+	if clipRow("short", 20) != "short" {
+		t.Error("short rows must pass through untouched")
+	}
+	styled := "\x1b[1;32m" + strings.Repeat("y", 50) + "\x1b[m"
+	if got := util.VisibleLen(clipRow(styled, 20)); got != 20 {
+		t.Errorf("ANSI row clipped to %d cols, want 20", got)
+	}
+}

--- a/ui/tui/widget/viewport.go
+++ b/ui/tui/widget/viewport.go
@@ -1,6 +1,22 @@
 package widget
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mmcdole/rune/ui/tui/util"
+)
+
+// clipRow hard-truncates one row to the given width (ANSI-aware).
+// Every widget row must fit the terminal width: an overlong row wraps
+// at the terminal, adds a phantom physical line, and scrolls the whole
+// frame - corrupting the layout for everything above it.
+func clipRow(s string, width int) string {
+	if width < 1 || util.VisibleLen(s) <= width {
+		return s
+	}
+	return ansi.Truncate(s, width, "")
+}
 
 // Compile-time check that Viewport implements Widget
 var _ Widget = (*Viewport)(nil)
@@ -111,7 +127,7 @@ func (v *Viewport) View() string {
 			if contentHeight > 0 {
 				b.WriteByte('\n')
 			}
-			b.WriteString(v.prompt)
+			b.WriteString(clipRow(v.prompt, v.width))
 		}
 		v.cachedView = b.String()
 		v.cacheValid = true
@@ -142,12 +158,12 @@ func (v *Viewport) View() string {
 		if emptyLines > 0 || i > startIdx {
 			b.WriteByte('\n')
 		}
-		b.WriteString(v.buffer.At(i))
+		b.WriteString(clipRow(v.buffer.At(i), v.width))
 	}
 
 	if hasPrompt {
 		b.WriteByte('\n')
-		b.WriteString(v.prompt)
+		b.WriteString(clipRow(v.prompt, v.width))
 	}
 
 	v.cachedView = b.String()

--- a/website/src/content/docs/interface/panes.md
+++ b/website/src/content/docs/interface/panes.md
@@ -23,19 +23,24 @@ rune.ui.layout({
 A docked pane renders a title header and a bottom border, which use two of
 its `height` lines. Panes start hidden; `toggle` shows them. A hidden pane
 keeps accumulating writes (the buffer is capped at 1000 lines), so toggling
-it back shows the recent history.
+it back shows the recent history. Lines longer than the pane width
+soft-wrap, and re-fit when the terminal resizes.
 
-Panes always show their newest lines; per-pane scrolling is not
-implemented. The `rune.pane.scroll_*` functions act on the main output
-viewport under the name `"main"`. This is how the default
-PageUp/PageDown/Home/End binds work:
+## Scrolling
+
+Every pane scrolls its own buffer; the special name `"main"` is the
+output viewport (that's what the default PageUp/PageDown/Home/End
+binds target). Aim a pane with binds of your own:
 
 ```lua
-rune.pane.scroll_up("main", 20)
-rune.pane.scroll_down("main", 20)
-rune.pane.scroll_to_top("main")
-rune.pane.scroll_to_bottom("main")
+rune.bind("shift+pageup",   function() rune.pane.scroll_up("chat", 5) end)
+rune.bind("shift+pagedown", function() rune.pane.scroll_down("chat", 5) end)
 ```
+
+While scrolled, the pane freezes on the history you're reading and its
+header shows `chat · scroll +N` as new lines land; `scroll_down` past
+the end (or `scroll_to_bottom`, or hiding the pane) returns it to live
+tailing.
 
 ## The mirror pattern
 

--- a/website/src/content/docs/reference/api/pane.md
+++ b/website/src/content/docs/reference/api/pane.md
@@ -23,16 +23,32 @@ rune.pane.scroll_to_bottom(name)       -- jump back to live
 Panes are push-based: you write lines as events happen, and the pane
 displays them — the opposite of [bars](/reference/api/ui/), which
 pull content from a render function. The buffer holds 1000 lines and
-auto-trims to the newest 500 when exceeded.
+auto-trims to the newest 500 when exceeded. Lines longer than the pane
+width soft-wrap at render time, so they re-fit on resize.
 
-Docked panes always show their newest lines; per-pane scrolling is not
-implemented. The `scroll_*` functions act only on the main output
-viewport, under the name `"main"` — that's how the default
-PageUp/PageDown/Home/End binds work:
+## Scrolling
+
+The `scroll_*` functions work on any pane by name. The special name
+`"main"` is the output viewport — that's what the default
+PageUp/PageDown/Home/End binds target:
 
 ```lua
-rune.pane.scroll_up("main", 20)
-rune.pane.scroll_to_bottom("main")
+rune.pane.scroll_up("main", 20)     -- the output viewport
+rune.pane.scroll_up("chat", 5)      -- a named pane's own buffer
+```
+
+A scrolled pane freezes on the history you're reading: new writes keep
+landing in the buffer and the pane's header shows
+`name · scroll +N` until you return with `scroll_down` or
+`scroll_to_bottom`. Hiding a pane (`toggle`) also returns it to the
+live tail. Scrolling counts logical lines (as written), not wrapped
+rows.
+
+Aim scrolling with binds:
+
+```lua
+rune.bind("shift+pageup",   function() rune.pane.scroll_up("chat", 5) end)
+rune.bind("shift+pagedown", function() rune.pane.scroll_down("chat", 5) end)
 ```
 
 :::note


### PR DESCRIPTION
## Problem

Pane widgets emit stored lines verbatim. A line longer than the pane width gets wrapped by the terminal itself, which adds a phantom physical row and scrolls the whole frame — the layout above the overflow slides off screen (a pane's header row disappearing is the visible symptom). The same failure exists for overlong lines in the main viewport and for oversized bar strings. Multi-line trigger spans (#7) made this easy to hit, since they deliberately join wrapped server messages into single long lines.

Separately, `rune.pane.scroll_up/down/to_top/to_bottom(name, ...)` accepted a pane name but silently did nothing unless the name was `"main"` — panes had no scroll state at all, despite buffering 1000 lines.

## Changes

All at render time, so a terminal resize re-fits everything; buffers keep logical lines as written.

- **Pane soft-wrap**: `Pane.View` wraps each stored line to the pane width (ANSI-aware, word-boundary, `charmbracelet/x/ansi` — promoted from indirect to direct dependency) and shows the last N visual rows.
- **Per-pane scrolling**: the scroll messages route to the named pane's own buffer; `"main"` keeps meaning the output viewport. The offset counts logical lines. While scrolled the view stays anchored (the offset grows as writes land), new arrivals are counted, and the pane header shows `name · scroll +N`, mirroring the status bar's SCROLL/LIVE vocabulary. Scrolling past the end, `scroll_to_bottom`, or hiding the pane returns it to live tailing; `clear` resets everything.
- **Row clipping**: viewport rows, the prompt line, and composed bar strings are hard-truncated to the terminal width, so no single row can corrupt the frame. This only affects lines wider than the terminal, which servers don't send. Soft-wrapped rendering for the main viewport would change its scroll accounting and is left out deliberately.

No API changes: the scroll functions now do what their signatures always advertised.

## Testing

- `ui/tui/widget/pane_test.go` (new): wrapping within width and content preservation, tail view, wrapped-tail when one line exceeds the pane height, scroll + header indicator, anchored view and `+N` count for writes while scrolled, clamping at both ends with a full window at the top, toggle-off resetting scroll, clear, and ANSI-aware row clipping.
- Verified in a live tmux session: a 150-column line in the viewport no longer displaces the pane header; a long pane line wraps across rows; `scroll_up` freezes the pane with the indicator, a write while scrolled shows `+1`, and `scroll_to_bottom` returns to the live tail.
- `go test ./...` and the docs build pass.

## Docs

`reference/api/pane` and the panes guide drop the scroll-only-works-on-main caveat and document wrapping, the scroll indicator, and the bind pattern for aiming scroll keys at a pane.