### PR TITLE
tui: fix ghost-column rendering (bare-CR line splitting + tab expansion)

### DIFF
--- a/network/telnet.go
+++ b/network/telnet.go
@@ -4,6 +4,7 @@ package network
 
 import (
 	"bytes"
+	"strings"
 	"sync"
 )
 
@@ -632,6 +633,14 @@ const (
 )
 
 // OutputBuffer buffers incoming data and splits it into lines.
+// Lines are delimited by \r\n, \n\r, \n, or a bare \r — the contract of the
+// original ExtractLines. Bare \r matters: muds return the carriage to
+// overwrite their pending prompt line, and an embedded \r that reaches the
+// UI renders the rest of the line over stale cells (ghost columns).
+// Fragmentation-safe: a \r that ends a read is held in the buffer until the
+// next read decides whether it pairs with a following \n, and a delimiter
+// pair split across reads is completed via pendingPartner instead of
+// emitting a spurious empty line.
 // The mutex is required: the read loop parses into the buffer while
 // the write loop calls InputSent to drop a pending prompt.
 type OutputBuffer struct {
@@ -639,6 +648,11 @@ type OutputBuffer struct {
 	buffer  bytes.Buffer
 	mode    TelnetMode
 	newData bool
+	// pendingPartner is the second byte of a delimiter pair whose first
+	// byte was already consumed at the end of a previous read ('\r' after
+	// an emitted \n, or '\n' after a held \r dropped by Prompt/InputSent).
+	// If the next read starts with it, it is swallowed.
+	pendingPartner byte
 }
 
 func NewOutputBuffer(mode TelnetMode) *OutputBuffer {
@@ -654,6 +668,15 @@ func (o *OutputBuffer) SetMode(mode TelnetMode) {
 func (o *OutputBuffer) Receive(data []byte) []string {
 	o.mu.Lock()
 	defer o.mu.Unlock()
+	if o.pendingPartner != 0 {
+		if len(data) > 0 && data[0] == o.pendingPartner {
+			data = data[1:]
+		}
+		o.pendingPartner = 0
+	}
+	if len(data) == 0 {
+		return nil
+	}
 	o.buffer.Write(data)
 	o.newData = true
 	buf := o.buffer.Bytes()
@@ -661,16 +684,26 @@ func (o *OutputBuffer) Receive(data []byte) []string {
 	last := 0
 
 	for i := 0; i < len(buf); i++ {
-		if i+1 < len(buf) {
-			if (buf[i] == '\r' && buf[i+1] == '\n') || (buf[i] == '\n' && buf[i+1] == '\r') {
-				lines = append(lines, string(buf[last:i]))
-				last = i + 2
-				i++
-				continue
-			}
-		}
-		if buf[i] == '\n' {
+		switch buf[i] {
+		case '\n':
 			lines = append(lines, string(buf[last:i]))
+			if i+1 < len(buf) && buf[i+1] == '\r' {
+				i++ // \n\r pair
+			} else if i+1 == len(buf) {
+				// the \r of an \n\r pair may arrive in the next read
+				o.pendingPartner = '\r'
+			}
+			last = i + 1
+		case '\r':
+			if i+1 == len(buf) {
+				// may be half of \r\n: hold it in the buffer until the
+				// next read shows its neighbor
+				break
+			}
+			lines = append(lines, string(buf[last:i]))
+			if buf[i+1] == '\n' {
+				i++ // \r\n pair
+			}
 			last = i + 1
 		}
 	}
@@ -685,6 +718,8 @@ func (o *OutputBuffer) Receive(data []byte) []string {
 }
 
 // Prompt returns any pending (unterminated) text. Clears buffer if consume is true.
+// A held trailing \r (a possible half of \r\n) is never part of the prompt
+// text; on consume its \n partner, if it arrives next, is still swallowed.
 func (o *OutputBuffer) Prompt(consume bool) string {
 	o.mu.Lock()
 	defer o.mu.Unlock()
@@ -692,9 +727,16 @@ func (o *OutputBuffer) Prompt(consume bool) string {
 		return ""
 	}
 	text := o.buffer.String()
+	heldCR := strings.HasSuffix(text, "\r")
+	if heldCR {
+		text = text[:len(text)-1]
+	}
 	if consume {
 		o.buffer.Reset()
 		o.newData = false
+		if heldCR {
+			o.pendingPartner = '\n'
+		}
 	}
 	return text
 }
@@ -711,6 +753,9 @@ func (o *OutputBuffer) InputSent() {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 	if o.mode == TelnetModeUnterminated {
+		if bytes.HasSuffix(o.buffer.Bytes(), []byte{'\r'}) {
+			o.pendingPartner = '\n' // dropped a held \r; swallow its pair
+		}
 		o.buffer.Reset()
 		o.newData = false
 	}
@@ -728,6 +773,7 @@ func (o *OutputBuffer) Clear() {
 	o.buffer.Reset()
 	o.mode = TelnetModeUnterminated
 	o.newData = false
+	o.pendingPartner = 0
 }
 
 // defaultCompatibility advertises ONLY options the client actually

--- a/network/telnet_test.go
+++ b/network/telnet_test.go
@@ -466,6 +466,12 @@ func TestOutputBufferNewlineVariants(t *testing.T) {
 		{"LF", "a\nb\n", []string{"a", "b"}},
 		{"LFCR", "a\n\rb\n\r", []string{"a", "b"}},
 		{"Mixed", "a\r\nb\nc\n\r", []string{"a", "b", "c"}},
+		// Bare \r is a line boundary (prompt overwrite), never embedded.
+		// Regression: dropped in 29cd00a; ghost-column rendering on muds
+		// that overwrite the prompt line (issue #14, regressions/14-bare-cr-ghost-columns.json).
+		{"BareCR", "prompt> \rline\r\n", []string{"prompt> ", "line"}},
+		{"BareCRRun", "a\r\rb\n", []string{"a", "", "b"}},
+		{"BlankLines", "a\r\n\r\nb\r\n", []string{"a", "", "b"}},
 	}
 
 	for _, tt := range tests {
@@ -482,6 +488,61 @@ func TestOutputBufferNewlineVariants(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// Delimiter pairs split across reads must neither delay lines nor emit
+// spurious empty ones, whatever the TCP fragmentation.
+func TestOutputBufferFragmentation(t *testing.T) {
+	tests := []struct {
+		name    string
+		packets []string
+		lines   []string // flattened across all Receive calls
+		prompt  string   // pending text afterwards
+	}{
+		{"CRLFSplit", []string{"abc\r", "\ndef\r\n"}, []string{"abc", "def"}, ""},
+		{"LFCRSplit", []string{"abc\n", "\rdef\n"}, []string{"abc", "def"}, ""},
+		{"BareCRThenText", []string{"abc\r", "def\r\n"}, []string{"abc", "def"}, ""},
+		{"HeldCRIsNotPrompt", []string{"abc\r"}, nil, "abc"},
+		{"CRLFBytewise", []string{"a", "\r", "\n", "b", "\r", "\n"}, []string{"a", "b"}, ""},
+		{"LFCRBytewise", []string{"a", "\n", "\r", "b", "\n"}, []string{"a", "b"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ob := NewOutputBuffer(TelnetModeUnterminated)
+			var lines []string
+			for _, p := range tt.packets {
+				lines = append(lines, ob.Receive([]byte(p))...)
+			}
+			if len(lines) != len(tt.lines) {
+				t.Fatalf("Expected lines %q, got %q", tt.lines, lines)
+			}
+			for i := range tt.lines {
+				if lines[i] != tt.lines[i] {
+					t.Errorf("Line %d: expected %q, got %q", i, tt.lines[i], lines[i])
+				}
+			}
+			if got := ob.Prompt(false); got != tt.prompt {
+				t.Errorf("Prompt: expected %q, got %q", tt.prompt, got)
+			}
+		})
+	}
+}
+
+// Consuming a prompt that ends in a held \r must still swallow the \n
+// half of the pair when it arrives in the next read.
+func TestOutputBufferPromptConsumeHeldCR(t *testing.T) {
+	ob := NewOutputBuffer(TelnetModeUnterminated)
+	if lines := ob.Receive([]byte("HP:10> \r")); len(lines) != 0 {
+		t.Fatalf("Expected no lines, got %q", lines)
+	}
+	if got := ob.Prompt(true); got != "HP:10> " {
+		t.Fatalf("Prompt: expected %q, got %q", "HP:10> ", got)
+	}
+	lines := ob.Receive([]byte("\nnext line\r\n"))
+	if len(lines) != 1 || lines[0] != "next line" {
+		t.Fatalf("Expected [next line], got %q", lines)
 	}
 }
 

--- a/test/e2e/scenarios/regressions/14-bare-cr-ghost-columns.json
+++ b/test/e2e/scenarios/regressions/14-bare-cr-ghost-columns.json
@@ -1,0 +1,70 @@
+{
+  "description": "Regression: OutputBuffer.Receive (since 29cd00a) dropped bare \\r as a line delimiter - the original ExtractLines split on \\n, \\r\\n, \\n\\r AND \\r. MUDs overwrite the pending prompt line with bare \\r; the embedded \\r reached the scrollback and the next line rendered at the tab stop over stale cells (ghost columns 0-7). Reported playing VikingMUD 2026-07-08 (tail CHANGES).",
+  "scenarios": [
+    {
+      "name": "bare CR is a line boundary, not an embedded control char",
+      "issue": "https://github.com/mmcdole/rune/issues/14",
+      "steps": [
+        {
+          "connect": true
+        },
+        {
+          "server_bytes": [
+            72,
+            80,
+            58,
+            49,
+            48,
+            48,
+            62,
+            32,
+            13,
+            9,
+            68,
+            101,
+            97,
+            100,
+            45,
+            102,
+            105,
+            108,
+            101,
+            32,
+            99,
+            108,
+            101,
+            97,
+            110,
+            117,
+            112,
+            44,
+            32,
+            112,
+            97,
+            114,
+            116,
+            32,
+            49,
+            13,
+            10
+          ],
+          "note": "mud overwrites its pending prompt with bare CR, then a tab-indented line"
+        },
+        {
+          "server_line": "sync marker",
+          "note": "sync: pipeline has advanced"
+        },
+        {
+          "expect_printed": "sync marker"
+        },
+        {
+          "expect_printed": "\tDead-file cleanup, part 1"
+        },
+        {
+          "expect_not_printed": "HP:100> \r\tDead-file",
+          "note": "the embedded-CR concatenation must not reach the scrollback"
+        }
+      ]
+    }
+  ]
+}

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -252,7 +252,7 @@ func (m *Model) syncBars(content map[string]ui.BarContent) {
 func (m *Model) handleServerOutput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case ui.PrintLineMsg:
-		cleanLine := util.FilterClearSequences(string(msg))
+		cleanLine := util.ExpandTabs(util.FilterClearSequences(string(msg)))
 		if m.flushScheduled {
 			// Inside a batch window: coalesce with the burst.
 			m.pendingLines = append(m.pendingLines, cleanLine)
@@ -267,9 +267,9 @@ func (m *Model) handleServerOutput(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Flush batched server lines first so the echo cannot render
 		// ahead of output that arrived before it.
 		m.flushPending()
-		m.appendLines([]string{string(msg)})
+		m.appendLines([]string{util.ExpandTabs(string(msg))})
 	case ui.PromptMsg:
-		text := string(msg)
+		text := util.ExpandTabs(string(msg))
 		if text != m.lastPrompt {
 			m.viewport.SetPrompt(text)
 			m.lastPrompt = text

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -343,5 +344,34 @@ func TestInlinePickerDismissesOnLuaEditWithSpace(t *testing.T) {
 	cancels := drainPickerCancels(outbound)
 	if len(cancels) != 1 || cancels[0].CallbackID != "cb1" {
 		t.Fatalf("expected one cancel for cb1, got %v", cancels)
+	}
+}
+
+// Regression #16: raw tabs must never reach the renderer. Bubbletea
+// repaints only changed rows; a row starting with \t makes the terminal
+// skip cells without erasing them, resurrecting the previous frame
+// (ghost columns). True paint verification is the manual tmux route -
+// this pins the model-layer guarantee that scrollback rows are tab-free.
+func TestPrintedTabsAreExpanded(t *testing.T) {
+	m := newTestModel(t)
+	next, _ := m.Update(ui.PrintLineMsg("\tDead-file cleanup"))
+	m = next.(*Model)
+	found := false
+	for i := 0; i < m.scrollback.Count(); i++ {
+		row := m.scrollback.At(i)
+		if row == "        Dead-file cleanup" {
+			found = true
+		}
+		if strings.Contains(row, "\t") {
+			t.Errorf("raw tab reached scrollback row %d: %q", i, row)
+		}
+	}
+	if !found {
+		t.Errorf("expanded row not found in scrollback")
+	}
+	next, _ = m.Update(ui.PromptMsg("HP\t> "))
+	m = next.(*Model)
+	if got := m.lastPrompt; got != "HP      > " {
+		t.Errorf("prompt = %q, want tab expanded", got)
 	}
 }

--- a/ui/tui/util/ansi.go
+++ b/ui/tui/util/ansi.go
@@ -22,3 +22,33 @@ func FilterClearSequences(line string) string {
 	line = strings.ReplaceAll(line, "\x1b[1;1H", "") // Move cursor to 1,1
 	return line
 }
+
+// tabStop is the classic terminal tab width.
+const tabStop = 8
+
+// ExpandTabs replaces each tab with spaces up to the next 8-column tab
+// stop, measured in visible cells (ANSI sequences are zero-width). A raw
+// \t must never reach the renderer: bubbletea repaints only rows that
+// changed, and a tab makes the terminal skip cells without erasing them,
+// resurrecting content from the previous frame as ghost columns.
+func ExpandTabs(line string) string {
+	if !strings.Contains(line, "\t") {
+		return line
+	}
+	var b strings.Builder
+	col := 0
+	for {
+		i := strings.IndexByte(line, '\t')
+		if i < 0 {
+			b.WriteString(line)
+			return b.String()
+		}
+		seg := line[:i]
+		b.WriteString(seg)
+		col += VisibleLen(seg)
+		pad := tabStop - col%tabStop
+		b.WriteString(strings.Repeat(" ", pad))
+		col += pad
+		line = line[i+1:]
+	}
+}

--- a/ui/tui/util/ansi_test.go
+++ b/ui/tui/util/ansi_test.go
@@ -1,0 +1,29 @@
+package util
+
+import "testing"
+
+func TestExpandTabs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"NoTab", "plain line", "plain line"},
+		{"LeadingTab", "\tindented", "        indented"},
+		{"MidLine", "ab\tcd", "ab      cd"},
+		{"AtStop", "12345678\tx", "12345678        x"},
+		{"Consecutive", "\t\tx", "                x"},
+		{"MultiStops", "a\tb\tc", "a       b       c"},
+		// ANSI sequences are zero-width: the tab stop is computed from
+		// visible cells, not byte position.
+		{"ANSIColored", "\x1b[31mab\x1b[0m\tc", "\x1b[31mab\x1b[0m      c"},
+		{"TabOnly", "\t", "        "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ExpandTabs(tt.in); got != tt.want {
+				t.Errorf("ExpandTabs(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/tui/widget/pane.go
+++ b/ui/tui/widget/pane.go
@@ -140,7 +140,7 @@ func (p *Pane) PreferredHeight() int {
 // anchored on the same history (the offset grows with the buffer) and
 // the new line is counted for the header indicator.
 func (p *Pane) Write(text string) {
-	p.Lines = append(p.Lines, text)
+	p.Lines = append(p.Lines, util.ExpandTabs(text))
 	if p.offset > 0 {
 		p.offset++
 		p.newLines++


### PR DESCRIPTION
Fixes #14, fixes #16. Supersedes #15 (same fixes, rebased onto main now that the test revamp has landed — this PR is 2 commits / 8 files).

Two composing defects behind the ghost-column rendering on tab-indented mud output (VikingMUD `tail CHANGES`):

**#14 — `network/`**: `OutputBuffer.Receive` (since 29cd00a) dropped bare `\r` from the line-delimiter contract; muds overwrite their pending prompt line with it, and the embedded `\r` reached triggers, logs, and the renderer. Restored, fragmentation-safe (held trailing `\r`, cross-read pair completion, `Prompt`/`InputSent`/`Clear` integration). Pinned by e2e regression scenario `14-bare-cr-ghost-columns.json` (written first, watched fail) + byte-exact unit tables down to bytewise delivery.

**#16 — `ui/tui/`**: no layer expanded `\t`; bubbletea repaints only changed rows, and a row starting with a tab skips cells without erasing them — resurrecting the previous frame in columns 0–7. `util.ExpandTabs` (ANSI-aware, 8-column stops) applied at every renderer text sink: server print, echo, prompt, pane writes. Pinned at the model layer (scrollback rows and prompt tab-free after `Update`) + unit table; per docs/testing.md, true paint verification is the manual tmux route — e2e runs a mock UI and cannot observe renderer behavior.

`go test ./...` green, e2e under `-race` green, vet/gofmt clean.