### PR TITLE
tui: restore mouse scrolling after closing external editor

### DIFF
--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -232,7 +232,13 @@ func (b *BubbleTeaUI) OpenEditor(initial string) (string, bool) {
 	err = cmd.Run()
 
 	// Resume TUI
-	if restoreErr := b.program.RestoreTerminal(); err == nil && restoreErr != nil {
+	restoreErr := b.program.RestoreTerminal()
+	if restoreErr == nil {
+		// Bubble Tea disables mouse reporting in ReleaseTerminal but does
+		// not restore it in RestoreTerminal.
+		b.program.Send(tea.EnableMouseCellMotion())
+	}
+	if err == nil && restoreErr != nil {
 		err = restoreErr
 	}
 


### PR DESCRIPTION
Bubble Tea disables mouse reporting when Rune releases the terminal for the external editor, but does not re-enable it when the terminal is restored. As a result, wheel input is interpreted as Up/Down keys and recalls command history.

This change re-enables cell-motion mouse reporting after RestoreTerminal succeeds. Existing editor and terminal restoration error handling is unchanged.

Tests: `go test ./...`

Closes #18