### PR TITLE
ci: add coverage reporting and quality checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      go-dependencies:
+        patterns: ["*"]
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns: ["*"]
+
+  - package-ecosystem: npm
+    directory: "/website"
+    schedule:
+      interval: weekly
+    groups:
+      website-dependencies:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,17 +5,100 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  quality:
+    name: quality
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
       - name: gofmt
         run: test -z "$(gofmt -l .)"
       - name: vet
         run: go vet ./...
+      - name: staticcheck
+        run: go run honnef.co/go/tools/cmd/staticcheck@v0.7.0 ./...
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
       - name: test
-        run: go test -race ./...
+        run: go test -race -shuffle=on -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...
+      - name: Save coverage report
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage
+          path: coverage.out
+          if-no-files-found: error
+          retention-days: 7
+
+  coverage:
+    name: coverage-upload
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download coverage report
+        uses: actions/download-artifact@v8
+        with:
+          name: coverage
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          use_oidc: true
+          files: coverage.out
+          disable_search: true
+          fail_ci_if_error: true
+
+  vulncheck:
+    name: vulncheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: govulncheck
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
+
+  build:
+    name: build (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        goos: [linux, darwin, windows]
+        goarch: [amd64, arm64]
+    env:
+      CGO_ENABLED: 0
+      GOOS: ${{ matrix.goos }}
+      GOARCH: ${{ matrix.goarch }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+      - name: Build
+        run: go build -trimpath -o "${RUNNER_TEMP}/rune" ./cmd/rune

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,20 +4,20 @@ on:
   push:
     tags: ["v*"]
 
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@v7
         with:
           version: "~> v2"
           args: release --clean

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,40 +7,52 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  pull_request:
+    paths:
+      - "website/**"
+      - ".github/workflows/website.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
-  group: pages
+  group: website-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   build:
+    name: website-build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: website/package-lock.json
       - name: Build site
         working-directory: website
         run: |
           npm ci
           npm run build
-      - uses: actions/upload-pages-artifact@v3
+      - if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/dist
 
   deploy:
+    if: github.event_name != 'pull_request'
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A modern MUD client built with Go and Lua.
 
+[![CI](https://github.com/mmcdole/rune/actions/workflows/ci.yml/badge.svg)](https://github.com/mmcdole/rune/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/mmcdole/rune/graph/badge.svg)](https://codecov.io/gh/mmcdole/rune)
+
 Rune combines Go's performance and concurrency with Lua's flexibility for scripting. The architecture follows a kernel philosophy: Go handles I/O, memory, and concurrency while Lua handles logic, features, and presentation.
 
 ## Features

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,18 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: true
+
+github_checks:
+  annotations: true

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mmcdole/rune
 
-go 1.25.4
+go 1.26.5
 
 require (
 	github.com/charmbracelet/bubbles v0.21.0

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -145,8 +145,7 @@ func TestTickStopsWhenOutputGoesQuiet(t *testing.T) {
 		t.Fatal("expected tick with pending lines to re-arm the window")
 	}
 
-	next, cmd = m.Update(tickMsg{})
-	m = next.(*Model)
+	_, cmd = m.Update(tickMsg{})
 	if cmd != nil {
 		t.Fatal("expected tick with nothing pending to stop the chain")
 	}


### PR DESCRIPTION
The CI workflow now reports formatting and static analysis, shuffled race tests with cross-package coverage, reachable vulnerability scanning, and builds for all six release targets. Coverage is uploaded to Codecov through OIDC and remains informational.

The Go version is updated to 1.26.5 so govulncheck runs against the current patched standard library. The one existing Staticcheck finding in a TUI test is removed.

Website changes now build on pull requests without deploying, release and website workflows use current action versions and narrower permissions, and Dependabot groups weekly Go, Actions, and website dependency updates.

Validation:

- `go test -race -shuffle=on -coverpkg=./... -coverprofile=coverage.out -covermode=atomic ./...` (76.8%)
- `staticcheck ./...`
- `govulncheck ./...`
- Linux, macOS, and Windows builds on amd64 and arm64
- `actionlint`
- `npm ci && npm run build`