### PR TITLE
session: fix duplicate lines from partial prompt snapshots

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -216,10 +216,9 @@ func (s *Session) handleEvent(ev event.Event) {
 		s.ui.SetPrompt("")
 
 	case event.NetPrompt:
-		// Commit previous prompt to scrollback before showing new one
-		if s.lastPrompt != "" {
-			s.ui.Print(s.lastPrompt)
-		}
+		// Prompt events are cumulative snapshots of the current unterminated
+		// network line. A later snapshot replaces the overlay; committing the
+		// earlier one would turn socket read boundaries into visible lines.
 		payload := string(ev.Payload.(event.Line))
 		line := text.NewLine(payload)
 		modified := s.engine.OnPrompt(line)

--- a/session/session.go
+++ b/session/session.go
@@ -216,9 +216,13 @@ func (s *Session) handleEvent(ev event.Event) {
 		s.ui.SetPrompt("")
 
 	case event.NetPrompt:
-		// Prompt events are cumulative snapshots of the current unterminated
-		// network line. A later snapshot replaces the overlay; committing the
-		// earlier one would turn socket read boundaries into visible lines.
+		// A prompt snapshot replaces the overlay and is never committed to
+		// scrollback here. In unterminated mode snapshots are cumulative
+		// peeks of the growing line, so committing a superseded one would
+		// turn socket read boundaries into visible lines (issue #25); a
+		// GA/EOR prompt superseding another is a repaint and gets the same
+		// treatment. Only input submission commits the active prompt
+		// (handleSubmission).
 		payload := string(ev.Payload.(event.Line))
 		line := text.NewLine(payload)
 		modified := s.engine.OnPrompt(line)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -58,8 +58,9 @@ func contains(list []string, substr string) bool {
 // suite in test/e2e/scenarios/. The tests here assert synchronous internals
 // the scenario vocabulary cannot express.
 
-// A prompt must be committed to scrollback exactly once: when input is
-// submitted while it is displayed, or when a newer prompt replaces it.
+// A prompt must be committed to scrollback exactly once, when input is
+// submitted while it is displayed. New prompt snapshots replace the overlay,
+// and a completed server line clears it without committing it.
 func TestPromptCommitOrdering(t *testing.T) {
 	s, net, uiMock := newTestSession(t)
 	net.connected = true
@@ -72,11 +73,30 @@ func TestPromptCommitOrdering(t *testing.T) {
 		t.Fatalf("prompt committed to scrollback too early: %v", printed)
 	}
 
-	// Submitting input commits the pending prompt before processing
+	// A growing unterminated line produces cumulative prompt snapshots. The
+	// latest snapshot replaces the overlay without committing the earlier one.
+	serverPrompt(s, "HP:100> ready")
+	if prompts := uiMock.drainPrompts(); len(prompts) != 1 || prompts[0] != "HP:100> ready" {
+		t.Fatalf("expected updated prompt overlay, got %v", prompts)
+	}
+	if printed := uiMock.drainPrinted(); len(printed) != 0 {
+		t.Fatalf("superseded prompt snapshot committed to scrollback: %v", printed)
+	}
+
+	// Submitting input commits only the latest pending prompt before processing.
 	userInput(s, "north")
 	printed := uiMock.drainPrinted()
-	if !contains(printed, "HP:100>") {
-		t.Errorf("expected pending prompt committed on input, got %v", printed)
+	promptCount := 0
+	for _, line := range printed {
+		if line == "HP:100>" {
+			t.Errorf("superseded prompt snapshot committed on input: %v", printed)
+		}
+		if line == "HP:100> ready" {
+			promptCount++
+		}
+	}
+	if promptCount != 1 {
+		t.Errorf("latest prompt committed %d times on input, want 1; got %v", promptCount, printed)
 	}
 
 	// A full server line ends the prompt overlay

--- a/test/e2e/prompt_fragmentation_test.go
+++ b/test/e2e/prompt_fragmentation_test.go
@@ -1,0 +1,53 @@
+package e2e
+
+import "testing"
+
+// TestFragmentedLineDoesNotCommitPromptSnapshots reproduces the VikingMUD
+// inventory corruption reported by Moreldir on 2026-07-12. Viking's wizard
+// I command builds one logical row with several write() calls. When those
+// writes arrive in separate socket reads, Rune exposes the growing tail as
+// prompt snapshots before the terminating CRLF arrives.
+//
+// Each wait is a causal barrier: the next fragment is not written until the
+// live client has displayed the preceding snapshot. This makes the read
+// fragmentation deterministic without timing assumptions.
+func TestFragmentedLineDoesNotCommitPromptSnapshots(t *testing.T) {
+	c := newClient(t, "")
+	c.connect()
+
+	partial := "E2E-I-0:"
+	complete := partial + " /players/test/item#1 <-> a test item."
+
+	c.mud.write([]byte(partial))
+	c.waitFor("first fragmented-line prompt snapshot", func() bool {
+		return c.ui.promptContains(partial)
+	})
+
+	c.mud.write([]byte(complete[len(partial):]))
+	c.waitFor("completed fragmented-line prompt snapshot", func() bool {
+		return c.ui.promptContains(complete)
+	})
+
+	// Terminate the fragmented line and follow it with a marker. Seeing the
+	// marker in scrollback proves all preceding network/session events ran.
+	c.mud.write([]byte("\r\nE2E-I-SYNC\r\n"))
+	c.waitFor("fragmented-line sync marker", func() bool {
+		return c.ui.printedContains("E2E-I-SYNC")
+	})
+
+	var partialCount, completeCount int
+	printed := c.ui.printedSnapshot()
+	for _, line := range printed {
+		switch line {
+		case partial:
+			partialCount++
+		case complete:
+			completeCount++
+		}
+	}
+
+	if partialCount != 0 || completeCount != 1 {
+		t.Fatalf("fragmented line produced partial=%d complete=%d, want partial=0 complete=1; scrollback=%q",
+			partialCount, completeCount, printed)
+	}
+}

--- a/test/e2e/prompt_fragmentation_test.go
+++ b/test/e2e/prompt_fragmentation_test.go
@@ -2,8 +2,9 @@ package e2e
 
 import "testing"
 
-// TestFragmentedLineDoesNotCommitPromptSnapshots reproduces the VikingMUD
-// inventory corruption reported by Moreldir on 2026-07-12. Viking's wizard
+// TestFragmentedLineDoesNotCommitPromptSnapshots reproduces issue #25: the
+// VikingMUD inventory corruption reported by Moreldir on 2026-07-12. Viking's
+// wizard
 // I command builds one logical row with several write() calls. When those
 // writes arrive in separate socket reads, Rune exposes the growing tail as
 // prompt snapshots before the terminating CRLF arrives.

--- a/test/e2e/prompt_fragmentation_test.go
+++ b/test/e2e/prompt_fragmentation_test.go
@@ -5,7 +5,7 @@ import "testing"
 // TestFragmentedLineDoesNotCommitPromptSnapshots reproduces issue #25: the
 // VikingMUD inventory corruption reported by Moreldir on 2026-07-12. Viking's
 // wizard
-// I command builds one logical row with several write() calls. When those
+// "I" command builds one logical row with several write() calls. When those
 // writes arrive in separate socket reads, Rune exposes the growing tail as
 // prompt snapshots before the terminating CRLF arrives.
 //


### PR DESCRIPTION
Fixes #25.

Superseded prompt snapshots now update the prompt overlay without being appended to scrollback. The active prompt is still committed when the user submits input.

Adds session-level coverage and a deterministic TCP fragmentation regression.

Tests:
- go test ./...
- go test -race ./test/e2e
- Windows amd64 cross-build