### PR TITLE
gmcp: tolerate raw control bytes inside GMCP JSON strings

### DIFF
--- a/lua/engine.go
+++ b/lua/engine.go
@@ -397,7 +397,7 @@ func (e *Engine) OnPrompt(line text.Line) string {
 
 // OnGMCP dispatches a GMCP message to Lua: the raw JSON is decoded
 // through the shared JSON bridge (api_store.go) so handlers receive a
-// real Lua value, plus the raw text for anyone who wants it.
+// real Lua value, plus the original raw text for anyone who wants it.
 // Malformed JSON is reported once and the message dropped - a broken
 // server message must not take anything else down.
 func (e *Engine) OnGMCP(pkg, raw string) {
@@ -412,7 +412,7 @@ func (e *Engine) OnGMCP(pkg, raw string) {
 	var value glua.LValue = glua.LNil
 	if raw != "" {
 		var decoded any
-		if err := json.Unmarshal([]byte(raw), &decoded); err != nil {
+		if err := json.Unmarshal([]byte(escapeRawJSONControlsInStrings(raw)), &decoded); err != nil {
 			e.reportError("gmcp "+pkg, fmt.Errorf("malformed JSON: %w", err))
 			return
 		}
@@ -428,6 +428,56 @@ func (e *Engine) OnGMCP(pkg, raw string) {
 	}); err != nil {
 		e.reportError("gmcp dispatch", err)
 	}
+}
+
+// escapeRawJSONControlsInStrings tolerates servers which put terminal control
+// bytes directly in JSON strings instead of encoding them. Aardwolf does this
+// with ANSI ESC bytes in colored Comm.Channel messages. Escaping them for the
+// decoder preserves the bytes in the decoded value; OnGMCP still passes the
+// original text to handlers as raw.
+//
+// Controls outside strings and controls following a JSON escape introducer are
+// left alone so otherwise malformed JSON remains malformed.
+func escapeRawJSONControlsInStrings(raw string) string {
+	const hex = "0123456789abcdef"
+
+	inString := false
+	escaped := false
+	last := 0
+	var repaired strings.Builder
+
+	for i := 0; i < len(raw); i++ {
+		c := raw[i]
+		if !inString {
+			if c == '"' {
+				inString = true
+			}
+			continue
+		}
+
+		if escaped {
+			escaped = false
+			continue
+		}
+		switch {
+		case c == '\\':
+			escaped = true
+		case c == '"':
+			inString = false
+		case c < 0x20:
+			repaired.WriteString(raw[last:i])
+			repaired.WriteString(`\u00`)
+			repaired.WriteByte(hex[c>>4])
+			repaired.WriteByte(hex[c&0x0f])
+			last = i + 1
+		}
+	}
+
+	if last == 0 {
+		return raw
+	}
+	repaired.WriteString(raw[last:])
+	return repaired.String()
 }
 
 // CallHook calls a hook event with string arguments.

--- a/lua/gmcp_test.go
+++ b/lua/gmcp_test.go
@@ -11,6 +11,58 @@ import (
 	"github.com/mmcdole/rune/version"
 )
 
+func TestEscapeRawJSONControlsInStrings(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "valid JSON is unchanged",
+			in:   `{"msg":"hello","n":1}`,
+			want: `{"msg":"hello","n":1}`,
+		},
+		{
+			name: "ANSI escapes inside a string are encoded",
+			in:   `{"msg":"` + "\x1b" + `[1;32mhello` + "\x1b" + `[0m"}`,
+			want: `{"msg":"\u001b[1;32mhello\u001b[0m"}`,
+		},
+		{
+			name: "all raw string controls are encoded",
+			in:   "{\"msg\":\"a\x00b\nc\td\"}",
+			want: `{"msg":"a\u0000b\u000ac\u0009d"}`,
+		},
+		{
+			name: "JSON whitespace outside strings is unchanged",
+			in:   "{\n\t\"msg\": \"hello\"\r}",
+			want: "{\n\t\"msg\": \"hello\"\r}",
+		},
+		{
+			name: "escaped quotes do not end the string",
+			in:   "{\"msg\":\"quoted \\\"word\\\" \x1b[0m\"}",
+			want: `{"msg":"quoted \"word\" \u001b[0m"}`,
+		},
+		{
+			name: "existing JSON escapes are unchanged",
+			in:   `{"msg":"\u001b[0m"}`,
+			want: `{"msg":"\u001b[0m"}`,
+		},
+		{
+			name: "control outside a string remains invalid",
+			in:   "{\"msg\":\"hello\"}\x1b",
+			want: "{\"msg\":\"hello\"}\x1b",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := escapeRawJSONControlsInStrings(tt.in); got != tt.want {
+				t.Errorf("escapeRawJSONControlsInStrings(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestGMCPDispatchDecodesAndMatchesCaseInsensitively verifies GMCP
 // handlers receive the decoded JSON value and that package matching
 // is case-insensitive per the spec.

--- a/test/e2e/scenarios/regressions/30-aardwolf-gmcp-color.json
+++ b/test/e2e/scenarios/regressions/30-aardwolf-gmcp-color.json
@@ -1,0 +1,27 @@
+{
+  "description": "Regression: Aardwolf includes raw ANSI escape bytes inside Comm.Channel JSON strings when server-side color is enabled. Strict JSON decoding rejected the message before GMCP handlers could receive it.",
+  "scenarios": [
+    {
+      "name": "Aardwolf colored channel messages reach GMCP handlers",
+      "issue": "https://github.com/mmcdole/rune/issues/30",
+      "init_lua": [
+        "rune.gmcp.on('Comm.Channel', function(data)",
+        "  local esc = string.char(27)",
+        "  if data.msg == esc .. '[1;32mHello' .. esc .. '[0m' then",
+        "    rune.echo('E2E-AARDWOLF-GMCP-COLOR')",
+        "  end",
+        "end)"
+      ],
+      "steps": [
+        { "connect": true },
+        { "server_bytes": [255, 251, 201], "note": "IAC WILL GMCP" },
+        { "expect_sent": "Core.Hello", "note": "sync: GMCP negotiation fully processed" },
+        {
+          "server_gmcp": "Comm.Channel {\"chan\":\"gossip\",\"msg\":\"\u001b[1;32mHello\u001b[0m\"}",
+          "note": "JSON decoding turns \\u001b into the raw ESC bytes Aardwolf sends on the wire"
+        },
+        { "expect_printed": "E2E-AARDWOLF-GMCP-COLOR" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #30.

Aardwolf embeds raw ANSI ESC bytes directly in JSON string values when server-side channel color is on, which is invalid JSON. The strict decode in `OnGMCP` rejected every colored `Comm.Channel` message as malformed, so GMCP handlers never saw them.

The fix escapes bare C0 control bytes found inside JSON string literals to `\u00XX` before decoding. The control bytes survive into the decoded value, and handlers still receive the untouched wire text as `raw`. Controls outside strings, or sitting right after an escape introducer, are deliberately left alone — repairing those would silently corrupt values, so JSON that was malformed for other reasons stays malformed and still gets reported and dropped.

Testing: table-driven unit tests for the repair function covering escaped quotes, pre-escaped sequences, and controls outside strings, plus an e2e regression scenario that sends a colored Aardwolf-style `Comm.Channel` frame over the fake MUD and asserts the handler receives the message with the ESC bytes intact.