### PR TITLE
docs: add Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A modern MUD client built with Go and Lua.
 Rune combines Go's performance and concurrency with Lua's flexibility for scripting. The architecture follows a kernel philosophy: Go handles I/O, memory, and concurrency while Lua handles logic, features, and presentation.
 
 Guides, cookbook recipes, and the full API reference live at **[runemud.com](https://runemud.com)**.
+Questions, ideas, and feedback are welcome in the **[Rune Discord](https://discord.gg/gNZkrJ2jHe)**.
 
 ## Features
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
       title: 'ᚱune',
       description: 'A fast, modern MUD client with careful terminal ergonomics and a Lua API that goes all the way down.',
       social: [
+        { icon: 'discord', label: 'Discord', href: 'https://discord.gg/gNZkrJ2jHe' },
         { icon: 'github', label: 'GitHub', href: 'https://github.com/mmcdole/rune' },
       ],
       customCss: ['./src/styles/custom.css'],

--- a/website/src/components/HeaderLinks.astro
+++ b/website/src/components/HeaderLinks.astro
@@ -1,6 +1,6 @@
 ---
 // SocialIcons override: prepend the section nav to the header's right
-// cluster, then render the default icons (GitHub).
+// cluster, then render the configured community/social icons.
 import Default from '@astrojs/starlight/components/SocialIcons.astro';
 
 const raw = import.meta.env.BASE_URL;


### PR DESCRIPTION
## Summary

- add a Discord icon to the website header social links
- add the community invite to the README
- update the custom header component comment

## Verification

- `cd website && npm run build`