### PR TITLE
ui: add rune.pane.show/hide for explicit pane visibility

### DIFF
--- a/lua/api_ui.go
+++ b/lua/api_ui.go
@@ -49,6 +49,14 @@ func (e *Engine) registerPaneFuncs() {
 		return 0
 	}))
 
+	// rune._pane.set_visible(name, visible): Show or hide a pane
+	e.L.SetField(paneTable, "set_visible", e.L.NewFunction(func(L *glua.LState) int {
+		name := L.CheckString(1)
+		visible := L.CheckBool(2)
+		e.host.PaneSetVisible(name, visible)
+		return 0
+	}))
+
 	// rune._pane.clear(name): Clear pane contents
 	e.L.SetField(paneTable, "clear", e.L.NewFunction(func(L *glua.LState) int {
 		name := L.CheckString(1)

--- a/lua/core/95_ui.lua
+++ b/lua/core/95_ui.lua
@@ -20,6 +20,14 @@ function rune.pane.toggle(name)
     rune._pane.toggle(name)
 end
 
+function rune.pane.show(name)
+    rune._pane.set_visible(name, true)
+end
+
+function rune.pane.hide(name)
+    rune._pane.set_visible(name, false)
+end
+
 function rune.pane.clear(name)
     rune._pane.clear(name)
 end

--- a/lua/host.go
+++ b/lua/host.go
@@ -25,6 +25,7 @@ type Host interface {
 	PaneCreate(name string)
 	PaneWrite(name, text string)
 	PaneToggle(name string)
+	PaneSetVisible(name string, visible bool)
 	PaneClear(name string)
 	ShowPicker(opts ui.ShowPickerMsg)
 	GetInput() string

--- a/lua/mock_host_test.go
+++ b/lua/mock_host_test.go
@@ -1,6 +1,7 @@
 package lua
 
 import (
+	"strconv"
 	"sync"
 	"time"
 
@@ -155,6 +156,12 @@ func (m *MockHost) PaneToggle(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PaneCalls = append(m.PaneCalls, struct{ Op, Name, Data string }{"toggle", name, ""})
+}
+
+func (m *MockHost) PaneSetVisible(name string, visible bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PaneCalls = append(m.PaneCalls, struct{ Op, Name, Data string }{"set_visible", name, strconv.FormatBool(visible)})
 }
 
 func (m *MockHost) PaneClear(name string) {

--- a/lua/pane_test.go
+++ b/lua/pane_test.go
@@ -1,0 +1,35 @@
+package lua
+
+import "testing"
+
+// rune.pane.show/hide are idempotent setters over one Go primitive;
+// what can silently break is the wrapper-to-flag mapping, so pin it.
+func TestPaneShowHideReachHostWithVisibility(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	script := `
+		rune.pane.create("chat")
+		rune.pane.show("chat")
+		rune.pane.hide("chat")
+		rune.pane.toggle("chat")
+	`
+	if err := engine.DoString("test", script); err != nil {
+		t.Fatalf("script failed: %v", err)
+	}
+
+	want := []struct{ Op, Name, Data string }{
+		{"create", "chat", ""},
+		{"set_visible", "chat", "true"},
+		{"set_visible", "chat", "false"},
+		{"toggle", "chat", ""},
+	}
+	if len(host.PaneCalls) != len(want) {
+		t.Fatalf("got %d pane calls, want %d: %v", len(host.PaneCalls), len(want), host.PaneCalls)
+	}
+	for i, w := range want {
+		if host.PaneCalls[i] != w {
+			t.Errorf("call %d: got %v, want %v", i, host.PaneCalls[i], w)
+		}
+	}
+}

--- a/session/lua_ui.go
+++ b/session/lua_ui.go
@@ -27,6 +27,11 @@ func (s *Session) PaneToggle(name string) {
 	s.ui.TogglePane(name)
 }
 
+// PaneSetVisible implements lua.Host.
+func (s *Session) PaneSetVisible(name string, visible bool) {
+	s.ui.SetPaneVisible(name, visible)
+}
+
 // PaneClear implements lua.Host.
 func (s *Session) PaneClear(name string) {
 	s.ui.ClearPane(name)

--- a/session/mocks_test.go
+++ b/session/mocks_test.go
@@ -181,11 +181,12 @@ func (m *mockUI) pushedBinds() map[string]bool {
 	return m.bindsPushed
 }
 
-func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg) {}
-func (m *mockUI) CreatePane(name string)           {}
-func (m *mockUI) WritePane(name, text string)      {}
-func (m *mockUI) TogglePane(name string)           {}
-func (m *mockUI) ClearPane(name string)            {}
+func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg)         {}
+func (m *mockUI) CreatePane(name string)                   {}
+func (m *mockUI) WritePane(name, text string)              {}
+func (m *mockUI) TogglePane(name string)                   {}
+func (m *mockUI) SetPaneVisible(name string, visible bool) {}
+func (m *mockUI) ClearPane(name string)                    {}
 
 func (m *mockUI) InputSetCursor(pos int)                   {}
 func (m *mockUI) OpenEditor(initial string) (string, bool) { return "", false }

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -212,6 +212,7 @@ func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg)            {}
 func (m *mockUI) CreatePane(name string)                      {}
 func (m *mockUI) WritePane(name, text string)                 {}
 func (m *mockUI) TogglePane(name string)                      {}
+func (m *mockUI) SetPaneVisible(name string, visible bool)    {}
 func (m *mockUI) ClearPane(name string)                       {}
 func (m *mockUI) InputSetCursor(pos int)                      {}
 func (m *mockUI) OpenEditor(initial string) (string, bool)    { return "", false }

--- a/ui/interface.go
+++ b/ui/interface.go
@@ -27,6 +27,7 @@ type UI interface {
 	CreatePane(name string)
 	WritePane(name, text string)
 	TogglePane(name string)
+	SetPaneVisible(name string, visible bool)
 	ClearPane(name string)
 
 	// Input primitives for Lua

--- a/ui/messages.go
+++ b/ui/messages.go
@@ -30,6 +30,12 @@ type PaneToggleMsg struct {
 	Name string
 }
 
+// PaneSetVisibleMsg shows or hides a named pane.
+type PaneSetVisibleMsg struct {
+	Name    string
+	Visible bool
+}
+
 // PaneCreateMsg creates a new named pane.
 type PaneCreateMsg struct {
 	Name string

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -122,7 +122,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m.handleServerOutput(msg)
 
 	// Pane operations
-	case ui.PaneCreateMsg, ui.PaneWriteMsg, ui.PaneToggleMsg, ui.PaneClearMsg:
+	case ui.PaneCreateMsg, ui.PaneWriteMsg, ui.PaneToggleMsg, ui.PaneSetVisibleMsg, ui.PaneClearMsg:
 		return m.handlePaneMsg(msg)
 
 	// Input control
@@ -291,6 +291,8 @@ func (m *Model) handlePaneMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.panes.Write(msg.Name, msg.Text)
 	case ui.PaneToggleMsg:
 		m.panes.Toggle(msg.Name)
+	case ui.PaneSetVisibleMsg:
+		m.panes.SetVisible(msg.Name, msg.Visible)
 	case ui.PaneClearMsg:
 		m.panes.Clear(msg.Name)
 	}

--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -145,6 +145,11 @@ func (b *BubbleTeaUI) TogglePane(name string) {
 	b.send(ui.PaneToggleMsg{Name: name})
 }
 
+// SetPaneVisible shows or hides a named pane.
+func (b *BubbleTeaUI) SetPaneVisible(name string, visible bool) {
+	b.send(ui.PaneSetVisibleMsg{Name: name, Visible: visible})
+}
+
 // ClearPane clears the contents of a named pane.
 func (b *BubbleTeaUI) ClearPane(name string) {
 	b.send(ui.PaneClearMsg{Name: name})

--- a/ui/tui/widget/pane.go
+++ b/ui/tui/widget/pane.go
@@ -190,23 +190,18 @@ func (p *Pane) ScrollToBottom() {
 	p.newLines = 0
 }
 
-// SetVisible shows or hides the pane; setting the current state is a
-// no-op, so showing an already-visible pane keeps its scroll position.
-// Hiding returns the pane to the live tail, so re-showing it never
-// opens onto stale history.
+// SetVisible shows or hides the pane. Visibility never touches scroll
+// state: a pane hidden on the live tail reopens live, a scrolled pane
+// reopens anchored where it was (Write keeps the anchor as the buffer
+// grows, and clampOffset pins it to the oldest line if trimming
+// removes the history it pointed at).
 func (p *Pane) SetVisible(visible bool) {
-	if p.Visible == visible {
-		return
-	}
 	p.Visible = visible
-	if !visible {
-		p.ScrollToBottom()
-	}
 }
 
 // Toggle toggles visibility.
 func (p *Pane) Toggle() {
-	p.SetVisible(!p.Visible)
+	p.Visible = !p.Visible
 }
 
 // Clear empties the pane.

--- a/ui/tui/widget/pane.go
+++ b/ui/tui/widget/pane.go
@@ -190,13 +190,23 @@ func (p *Pane) ScrollToBottom() {
 	p.newLines = 0
 }
 
-// Toggle toggles visibility. Hiding a pane returns it to the live
-// tail, so re-showing it never opens onto stale history.
-func (p *Pane) Toggle() {
-	p.Visible = !p.Visible
-	if !p.Visible {
+// SetVisible shows or hides the pane; setting the current state is a
+// no-op, so showing an already-visible pane keeps its scroll position.
+// Hiding returns the pane to the live tail, so re-showing it never
+// opens onto stale history.
+func (p *Pane) SetVisible(visible bool) {
+	if p.Visible == visible {
+		return
+	}
+	p.Visible = visible
+	if !visible {
 		p.ScrollToBottom()
 	}
+}
+
+// Toggle toggles visibility.
+func (p *Pane) Toggle() {
+	p.SetVisible(!p.Visible)
 }
 
 // Clear empties the pane.
@@ -245,6 +255,13 @@ func (pm *PaneManager) Write(name, text string) {
 func (pm *PaneManager) Toggle(name string) {
 	if pane, exists := pm.panes[name]; exists {
 		pane.Toggle()
+	}
+}
+
+// SetVisible shows or hides a pane.
+func (pm *PaneManager) SetVisible(name string, visible bool) {
+	if pane, exists := pm.panes[name]; exists {
+		pane.SetVisible(visible)
 	}
 }
 

--- a/ui/tui/widget/pane_test.go
+++ b/ui/tui/widget/pane_test.go
@@ -159,6 +159,41 @@ func TestPaneToggleOffResetsScroll(t *testing.T) {
 	}
 }
 
+func TestPaneSetVisibleHideResetsScroll(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 6; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.ScrollUp(3)
+	p.SetVisible(false)
+	p.SetVisible(true)
+
+	rows := contentRows(t, p)
+	if rows[1] != "line 6" {
+		t.Errorf("re-shown pane should be at the live tail, got %q", rows)
+	}
+}
+
+func TestPaneSetVisibleIsIdempotent(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 6; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.ScrollUp(3)
+	p.SetVisible(true) // already visible: must not touch scroll
+
+	rows := contentRows(t, p)
+	if rows[0] != "line 2" {
+		t.Errorf("show on a visible pane should keep its scroll position, got %q", rows)
+	}
+
+	p.SetVisible(false)
+	p.SetVisible(false) // already hidden: still hidden, still live
+	if p.Visible {
+		t.Error("pane should remain hidden")
+	}
+}
+
 func TestPaneEmptyAndClear(t *testing.T) {
 	p := newTestPane(t, 40, 3)
 	rows := contentRows(t, p)

--- a/ui/tui/widget/pane_test.go
+++ b/ui/tui/widget/pane_test.go
@@ -144,53 +144,66 @@ func TestPaneScrollClamps(t *testing.T) {
 	}
 }
 
-func TestPaneToggleOffResetsScroll(t *testing.T) {
-	p := newTestPane(t, 40, 2)
-	for i := 1; i <= 6; i++ {
-		p.Write(fmt.Sprintf("line %d", i))
-	}
-	p.ScrollUp(3)
-	p.Toggle() // hide
-	p.Toggle() // show again
-
-	rows := contentRows(t, p)
-	if rows[1] != "line 6" {
-		t.Errorf("re-shown pane should be at the live tail, got %q", rows)
-	}
-}
-
-func TestPaneSetVisibleHideResetsScroll(t *testing.T) {
+// Visibility never touches scroll state. A pane hidden while scrolled
+// reopens on the same history, even as writes land while it is hidden.
+func TestPaneHiddenWhileScrolledKeepsPosition(t *testing.T) {
 	p := newTestPane(t, 40, 2)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
 	p.ScrollUp(3)
 	p.SetVisible(false)
+	p.Write("line 7")
 	p.SetVisible(true)
 
 	rows := contentRows(t, p)
-	if rows[1] != "line 6" {
-		t.Errorf("re-shown pane should be at the live tail, got %q", rows)
+	if rows[0] != "line 2" {
+		t.Errorf("re-shown pane should keep its scroll anchor, got %q", rows)
+	}
+
+	p.Toggle() // hide
+	p.Toggle() // show again
+	rows = contentRows(t, p)
+	if rows[0] != "line 2" {
+		t.Errorf("toggle must not touch scroll state either, got %q", rows)
 	}
 }
 
-func TestPaneSetVisibleIsIdempotent(t *testing.T) {
+// A pane on the live tail when hidden stays in follow mode, so
+// reopening shows the newest lines.
+func TestPaneHiddenOnTailReopensLive(t *testing.T) {
 	p := newTestPane(t, 40, 2)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
-	p.ScrollUp(3)
-	p.SetVisible(true) // already visible: must not touch scroll
+	p.SetVisible(false)
+	p.Write("line 7")
+	p.SetVisible(true)
 
 	rows := contentRows(t, p)
-	if rows[0] != "line 2" {
-		t.Errorf("show on a visible pane should keep its scroll position, got %q", rows)
+	if rows[1] != "line 7" {
+		t.Errorf("pane hidden on the tail should reopen live, got %q", rows)
 	}
+}
 
+// If trimming removes the history a hidden pane was anchored on, the
+// anchor clamps to the oldest remaining line instead of jumping to
+// the tail.
+func TestPaneHiddenAnchorClampsWhenTrimmed(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 6; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.ScrollUp(5)
 	p.SetVisible(false)
-	p.SetVisible(false) // already hidden: still hidden, still live
-	if p.Visible {
-		t.Error("pane should remain hidden")
+	for i := 7; i <= 1001; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.SetVisible(true)
+
+	rows := contentRows(t, p)
+	if rows[0] != "line 502" {
+		t.Errorf("trimmed anchor should clamp to the oldest remaining line, got %q", rows)
 	}
 }
 

--- a/website/src/content/docs/interface/panes.md
+++ b/website/src/content/docs/interface/panes.md
@@ -6,7 +6,9 @@ description: Named output buffers you can dock in the layout, write to from trig
 ```lua
 rune.pane.create("chat")                    -- optional; write auto-creates
 rune.pane.write("chat", styled_text)
-rune.pane.toggle("chat")                    -- show/hide (panes start hidden)
+rune.pane.toggle("chat")                    -- flip visibility (panes start hidden)
+rune.pane.show("chat")                      -- or set it outright
+rune.pane.hide("chat")
 rune.pane.clear("chat")
 ```
 

--- a/website/src/content/docs/interface/panes.md
+++ b/website/src/content/docs/interface/panes.md
@@ -41,10 +41,7 @@ rune.bind("shift+pagedown", function() rune.pane.scroll_down("chat", 5) end)
 
 While scrolled, the pane freezes on the history you're reading and its
 header shows `chat · scroll +N` as new lines land; `scroll_down` past
-the end (or `scroll_to_bottom`) returns it to live tailing. Hiding a
-pane doesn't touch its scroll position: hide it on the live tail and
-it reopens live, hide it while scrolled back and it reopens where you
-left it.
+the end (or `scroll_to_bottom`) returns it to live tailing.
 
 ## The mirror pattern
 

--- a/website/src/content/docs/interface/panes.md
+++ b/website/src/content/docs/interface/panes.md
@@ -41,8 +41,10 @@ rune.bind("shift+pagedown", function() rune.pane.scroll_down("chat", 5) end)
 
 While scrolled, the pane freezes on the history you're reading and its
 header shows `chat · scroll +N` as new lines land; `scroll_down` past
-the end (or `scroll_to_bottom`, or hiding the pane) returns it to live
-tailing.
+the end (or `scroll_to_bottom`) returns it to live tailing. Hiding a
+pane doesn't touch its scroll position: hide it on the live tail and
+it reopens live, hide it while scrolled back and it reopens where you
+left it.
 
 ## The mirror pattern
 

--- a/website/src/content/docs/reference/api/pane.md
+++ b/website/src/content/docs/reference/api/pane.md
@@ -42,10 +42,11 @@ rune.pane.scroll_up("chat", 5)      -- a named pane's own buffer
 A scrolled pane freezes on the history you're reading: new writes keep
 landing in the buffer and the pane's header shows
 `name · scroll +N` until you return with `scroll_down` or
-`scroll_to_bottom`. Hiding a pane (`hide` or `toggle`) also returns it
-to the live tail; `show` on an already-visible pane leaves the scroll
-position alone. Scrolling counts logical lines (as written), not
-wrapped rows.
+`scroll_to_bottom`. Visibility is independent of scrolling: a pane
+hidden on the live tail reopens live, and a pane hidden while scrolled
+reopens where you left it (clamped to the oldest remaining line if the
+buffer trimmed past that spot while hidden). Scrolling counts logical
+lines (as written), not wrapped rows.
 
 Aim scrolling with binds:
 

--- a/website/src/content/docs/reference/api/pane.md
+++ b/website/src/content/docs/reference/api/pane.md
@@ -12,7 +12,9 @@ introduction, see [Panes](/interface/panes/).
 ```lua
 rune.pane.create(name)                 -- create a pane (optional; writes auto-create)
 rune.pane.write(name, text)            -- append a line
-rune.pane.toggle(name)                 -- show/hide the pane
+rune.pane.show(name)                   -- make visible (no-op if already shown)
+rune.pane.hide(name)                   -- make hidden (no-op if already hidden)
+rune.pane.toggle(name)                 -- flip visibility
 rune.pane.clear(name)                  -- empty the buffer
 rune.pane.scroll_up(name, lines?)      -- scroll back (default 1 line)
 rune.pane.scroll_down(name, lines?)    -- scroll forward (default 1 line)
@@ -40,9 +42,10 @@ rune.pane.scroll_up("chat", 5)      -- a named pane's own buffer
 A scrolled pane freezes on the history you're reading: new writes keep
 landing in the buffer and the pane's header shows
 `name · scroll +N` until you return with `scroll_down` or
-`scroll_to_bottom`. Hiding a pane (`toggle`) also returns it to the
-live tail. Scrolling counts logical lines (as written), not wrapped
-rows.
+`scroll_to_bottom`. Hiding a pane (`hide` or `toggle`) also returns it
+to the live tail; `show` on an already-visible pane leaves the scroll
+position alone. Scrolling counts logical lines (as written), not
+wrapped rows.
 
 Aim scrolling with binds:
 
@@ -53,8 +56,10 @@ rune.bind("shift+pagedown", function() rune.pane.scroll_down("chat", 5) end)
 
 :::note
 A pane displays only when the layout names it — see
-[Layout & UI](/interface/layout/). `toggle` shows and hides a pane
-that has a dock slot.
+[Layout & UI](/interface/layout/). `show`, `hide`, and `toggle` all
+operate on a pane that has a dock slot. Use `show`/`hide` when you
+need a definite end state (a trigger forcing a pane open), `toggle`
+when a key flips it.
 :::
 
 The usual shape is a trigger that writes plus a bind that toggles:

--- a/website/src/content/docs/reference/api/pane.md
+++ b/website/src/content/docs/reference/api/pane.md
@@ -42,11 +42,8 @@ rune.pane.scroll_up("chat", 5)      -- a named pane's own buffer
 A scrolled pane freezes on the history you're reading: new writes keep
 landing in the buffer and the pane's header shows
 `name · scroll +N` until you return with `scroll_down` or
-`scroll_to_bottom`. Visibility is independent of scrolling: a pane
-hidden on the live tail reopens live, and a pane hidden while scrolled
-reopens where you left it (clamped to the oldest remaining line if the
-buffer trimmed past that spot while hidden). Scrolling counts logical
-lines (as written), not wrapped rows.
+`scroll_to_bottom`. Scrolling counts logical lines (as written), not
+wrapped rows.
 
 Aim scrolling with binds:
 


### PR DESCRIPTION
Fixes #33. Fixes #35.

Adds `rune.pane.show(name)` and `rune.pane.hide(name)` as idempotent visibility setters alongside `toggle`. Rather than exposing a visibility query (which would need a synchronous round trip against the one-way Session -> UI message flow), the setters make the query unnecessary: "if not visible, show it" is just `show`.

Follows the usual boundary shape: one Go primitive, `rune._pane.set_visible(name, bool)`, plumbed as `PaneSetVisibleMsg` through the same path as toggle; the public names are Lua wrappers in `95_ui.lua`.

This also resolves #35 by decoupling visibility from scroll state. Hiding a pane no longer resets it to the live tail (which `toggle` historically did):

- a pane hidden while on the live tail stays in follow mode and reopens live
- a pane hidden while scrolled reopens anchored on the same history, with the `scroll +N` header counting writes that arrived while hidden
- if buffer trimming removes the anchored history while hidden, the anchor clamps to the oldest remaining line instead of jumping to the tail

No new state was needed for this: offset 0 already is follow mode, `Write` already maintains the anchor as the buffer grows, and `clampOffset` already handles trimming. The change is removing the `ScrollToBottom` call from the hide path. Scripts that want a definite live tail on show can call `rune.pane.scroll_to_bottom` first.

Tests cover the three visibility/scroll interactions at the widget layer (scrolled-keeps-position, tail-reopens-live, trimmed-anchor-clamps) plus a Lua-layer test pinning the show/hide -> visibility flag mapping through MockHost. Verified by hand in tmux: a pane hidden while scrolled reopens on the same lines showing `scroll +1` for a write that arrived while hidden; a pane hidden on the tail reopens showing the newest lines.

Docs updated on the `rune.pane` reference page and the panes guide.