### PR TITLE
ui: add rune.clipboard.set via OSC 52

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mmcdole/rune
 go 1.26.5
 
 require (
+	github.com/aymanbagabas/go-osc52/v2 v2.0.1
 	github.com/charmbracelet/bubbles v1.0.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
@@ -13,7 +14,6 @@ require (
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
-	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.4.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.15 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect

--- a/lua/api_ui.go
+++ b/lua/api_ui.go
@@ -20,6 +20,13 @@ func (e *Engine) registerUIInternalFuncs() {
 		e.host.OnConfigChange()
 		return 0
 	}))
+
+	// rune._ui.set_clipboard(text): ask the terminal to set the
+	// system clipboard (OSC 52).
+	e.L.SetField(internal, "set_clipboard", e.L.NewFunction(func(L *glua.LState) int {
+		e.host.ClipboardSet(L.CheckString(1))
+		return 0
+	}))
 }
 
 // registerPaneFuncs registers internal rune._pane.* primitives (wrapped by Lua)

--- a/lua/clipboard_test.go
+++ b/lua/clipboard_test.go
@@ -1,6 +1,52 @@
 package lua
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/mmcdole/rune/text"
+)
+
+// The docs example on the rune.clipboard reference page: a span
+// trigger collects a note, an alias copies it. Keep this in sync
+// with website/src/content/docs/reference/api/clipboard.md.
+func TestClipboardDocExampleCollectAndCopy(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	script := `
+		local note = ""
+
+		rune.trigger.starts("-- BEGIN NOTE", function(m, ctx)
+		    local collected = {}
+		    for _, line in ipairs(ctx.lines) do
+		        collected[#collected + 1] = line:clean()
+		    end
+		    note = table.concat(collected, "\n")
+		end, { span = { to = "^-- END NOTE", max = 40 } })
+
+		rune.alias.exact("copynote", function()
+		    rune.clipboard.set(note)
+		end)
+	`
+	if err := engine.DoString("test", script); err != nil {
+		t.Fatalf("setup failed: %v", err)
+	}
+
+	for _, line := range []string{
+		"-- BEGIN NOTE",
+		"meet at the crossroads",
+		"bring the key",
+		"-- END NOTE",
+	} {
+		engine.OnOutput(text.NewLine(line))
+	}
+	engine.OnInput("copynote")
+
+	want := "-- BEGIN NOTE\nmeet at the crossroads\nbring the key\n-- END NOTE"
+	if len(host.ClipboardCalls) != 1 || host.ClipboardCalls[0] != want {
+		t.Errorf("got clipboard calls %q, want [%q]", host.ClipboardCalls, want)
+	}
+}
 
 func TestClipboardSetReachesHost(t *testing.T) {
 	engine, host, cleanup := setupTest(t)

--- a/lua/clipboard_test.go
+++ b/lua/clipboard_test.go
@@ -1,0 +1,16 @@
+package lua
+
+import "testing"
+
+func TestClipboardSetReachesHost(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	if err := engine.DoString("test", `rune.clipboard.set("note contents")`); err != nil {
+		t.Fatalf("script failed: %v", err)
+	}
+
+	if len(host.ClipboardCalls) != 1 || host.ClipboardCalls[0] != "note contents" {
+		t.Errorf("got clipboard calls %q, want [\"note contents\"]", host.ClipboardCalls)
+	}
+}

--- a/lua/core/95_ui.lua
+++ b/lua/core/95_ui.lua
@@ -49,6 +49,18 @@ function rune.pane.scroll_to_bottom(name)
 end
 
 -- ============================================================
+-- CLIPBOARD
+-- ============================================================
+
+rune.clipboard = {}
+
+-- Copy text to the system clipboard. Uses OSC 52, so it works over
+-- SSH; the terminal emulator has to support it.
+function rune.clipboard.set(text)
+    rune._ui.set_clipboard(text)
+end
+
+-- ============================================================
 -- PANE SCROLLING BINDINGS
 -- ============================================================
 

--- a/lua/host.go
+++ b/lua/host.go
@@ -28,6 +28,7 @@ type Host interface {
 	PaneSetVisible(name string, visible bool)
 	PaneClear(name string)
 	ShowPicker(opts ui.ShowPickerMsg)
+	ClipboardSet(text string)
 	GetInput() string
 	SetInput(text string)
 	SetInputSubmission(submission input.Submission)

--- a/lua/mock_host_test.go
+++ b/lua/mock_host_test.go
@@ -26,6 +26,7 @@ type MockHost struct {
 	LoadCalls       []string
 	PaneCalls       []struct{ Op, Name, Data string }
 	PickerCalls     []ui.ShowPickerMsg
+	ClipboardCalls  []string
 	ScheduledTimers []struct {
 		ID       int
 		Duration time.Duration
@@ -184,6 +185,12 @@ func (m *MockHost) ShowPicker(opts ui.ShowPickerMsg) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PickerCalls = append(m.PickerCalls, opts)
+}
+
+func (m *MockHost) ClipboardSet(text string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.ClipboardCalls = append(m.ClipboardCalls, text)
 }
 
 func (m *MockHost) GetHistory() []string {

--- a/session/lua_ui.go
+++ b/session/lua_ui.go
@@ -37,6 +37,11 @@ func (s *Session) PaneClear(name string) {
 	s.ui.ClearPane(name)
 }
 
+// ClipboardSet implements lua.Host.
+func (s *Session) ClipboardSet(text string) {
+	s.ui.SetClipboard(text)
+}
+
 // ShowPicker implements lua.Host.
 func (s *Session) ShowPicker(opts ui.ShowPickerMsg) {
 	s.ui.ShowPicker(opts)

--- a/session/mocks_test.go
+++ b/session/mocks_test.go
@@ -182,6 +182,7 @@ func (m *mockUI) pushedBinds() map[string]bool {
 }
 
 func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg)         {}
+func (m *mockUI) SetClipboard(text string)                 {}
 func (m *mockUI) CreatePane(name string)                   {}
 func (m *mockUI) WritePane(name, text string)              {}
 func (m *mockUI) TogglePane(name string)                   {}

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -209,6 +209,7 @@ func (m *mockUI) UpdateBars(content map[string]ui.BarContent) {}
 func (m *mockUI) UpdateBinds(keys map[string]bool)            {}
 func (m *mockUI) UpdateLayout(top, bottom []ui.LayoutEntry)   {}
 func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg)            {}
+func (m *mockUI) SetClipboard(text string)                    {}
 func (m *mockUI) CreatePane(name string)                      {}
 func (m *mockUI) WritePane(name, text string)                 {}
 func (m *mockUI) TogglePane(name string)                      {}

--- a/ui/interface.go
+++ b/ui/interface.go
@@ -24,6 +24,7 @@ type UI interface {
 
 	// Components
 	ShowPicker(opts ShowPickerMsg)
+	SetClipboard(text string)
 	CreatePane(name string)
 	WritePane(name, text string)
 	TogglePane(name string)

--- a/ui/messages.go
+++ b/ui/messages.go
@@ -122,6 +122,10 @@ type ShowPickerMsg struct {
 	DismissOnSpace bool
 }
 
+// SetClipboardMsg asks the terminal to set the system clipboard
+// (OSC 52). Sent from Session when Lua calls rune.clipboard.set().
+type SetClipboardMsg string
+
 // SetInputMsg sets the input line content.
 // Sent from Session when Lua calls rune.input.set().
 type SetInputMsg string

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -1,9 +1,11 @@
 package tui
 
 import (
+	"os"
 	"strings"
 	"time"
 
+	osc52 "github.com/aymanbagabas/go-osc52/v2"
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/mmcdole/rune/input"
@@ -139,6 +141,13 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Input primitives (from Lua)
 	case ui.InputSetCursorMsg:
 		m.input.SetCursor(int(msg))
+		return m, nil
+
+	// Clipboard (from Lua). OSC 52 asks the terminal emulator to set
+	// the system clipboard; it renders nothing, so it bypasses the
+	// renderer and goes to the terminal on stderr.
+	case ui.SetClipboardMsg:
+		osc52.New(string(msg)).WriteTo(os.Stderr) //nolint:errcheck // best-effort: no way to report terminal-side failure
 		return m, nil
 
 	// Pane scrolling (from Lua). "main" is the output viewport; any

--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -177,6 +177,11 @@ func (b *BubbleTeaUI) ShowPicker(opts ui.ShowPickerMsg) {
 	b.send(opts)
 }
 
+// SetClipboard asks the terminal to set the system clipboard.
+func (b *BubbleTeaUI) SetClipboard(text string) {
+	b.send(ui.SetClipboardMsg(text))
+}
+
 // SetInput sets the input line content.
 func (b *BubbleTeaUI) SetInput(text string) {
 	b.send(ui.SetInputMsg(text))

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -94,6 +94,7 @@ export default defineConfig({
                 { label: 'rune.ui', slug: 'reference/api/ui' },
                 { label: 'rune.ui.picker', slug: 'reference/api/picker' },
                 { label: 'rune.pane', slug: 'reference/api/pane' },
+                { label: 'rune.clipboard', slug: 'reference/api/clipboard' },
               ],
             },
             { label: 'Slash Commands', slug: 'reference/slash-commands' },

--- a/website/src/content/docs/reference/api/clipboard.md
+++ b/website/src/content/docs/reference/api/clipboard.md
@@ -1,0 +1,46 @@
+---
+title: rune.clipboard
+description: Copy text to the system clipboard.
+---
+
+```lua
+rune.clipboard.set(text)               -- copy text to the system clipboard
+```
+
+The copy is done with OSC 52, an escape sequence that asks your
+terminal emulator to set the clipboard. Because the terminal does the
+work, it also works over SSH, with no clipboard tools needed on the
+remote machine.
+
+Support depends on your terminal. Modern emulators (kitty, alacritty,
+WezTerm, iTerm2, Windows Terminal, foot) handle it; some cap how much
+text one copy can carry. Inside tmux, `set-clipboard` must be `on` or
+`external` (the default) in the tmux config.
+
+A typical use is collecting something with triggers and copying it
+from an alias:
+
+```lua
+local note = {}
+local collecting = false
+
+rune.trigger.starts("-- BEGIN NOTE", function()
+    collecting, note = true, {}
+end)
+rune.trigger.starts("-- END NOTE", function()
+    collecting = false
+end)
+rune.trigger.regex(".*", function(m, ctx)
+    if collecting then note[#note + 1] = ctx.line:raw() end
+end)
+
+rune.alias.exact("copynote", function()
+    rune.clipboard.set(table.concat(note, "\n"))
+end)
+```
+
+There is no `rune.clipboard.get`. Most terminals refuse OSC 52 reads,
+since a server that could read your clipboard is a security problem.
+
+**Related:** [rune.trigger](/reference/api/trigger/) ·
+[rune.alias](/reference/api/alias/)

--- a/website/src/content/docs/reference/api/clipboard.md
+++ b/website/src/content/docs/reference/api/clipboard.md
@@ -17,25 +17,23 @@ WezTerm, iTerm2, Windows Terminal, foot) handle it; some cap how much
 text one copy can carry. Inside tmux, `set-clipboard` must be `on` or
 `external` (the default) in the tmux config.
 
-A typical use is collecting something with triggers and copying it
-from an alias:
+A typical use is collecting a block with a
+[multi-line trigger](/reference/api/trigger/#multi-line-triggers) and
+copying it from an alias:
 
 ```lua
-local note = {}
-local collecting = false
+local note = ""
 
-rune.trigger.starts("-- BEGIN NOTE", function()
-    collecting, note = true, {}
-end)
-rune.trigger.starts("-- END NOTE", function()
-    collecting = false
-end)
-rune.trigger.regex(".*", function(m, ctx)
-    if collecting then note[#note + 1] = ctx.line:raw() end
-end)
+rune.trigger.starts("-- BEGIN NOTE", function(m, ctx)
+    local collected = {}
+    for _, line in ipairs(ctx.lines) do
+        collected[#collected + 1] = line:clean()
+    end
+    note = table.concat(collected, "\n")
+end, { span = { to = "^-- END NOTE", max = 40 } })
 
 rune.alias.exact("copynote", function()
-    rune.clipboard.set(table.concat(note, "\n"))
+    rune.clipboard.set(note)
 end)
 ```
 


### PR DESCRIPTION
Fixes #36.

Adds `rune.clipboard.set(text)`, which copies text to the system clipboard by emitting OSC 52 and letting the terminal emulator do the work. No clipboard tools needed on the machine, and it works over SSH. Inside tmux it needs `set-clipboard` at `on` or `external` (the default).

Same shape as the other UI primitives: `rune._ui.set_clipboard` in Go, the public `rune.clipboard.set` wrapper in `95_ui.lua`, one message through the Session -> UI path, and the TUI writes the sequence to stderr so it stays out of the renderer's stdout stream. go-osc52 was already in the module graph via lipgloss and is now a direct dependency, so nothing new gets pulled in.

There is no `rune.clipboard.get`. Most terminals refuse OSC 52 reads for security reasons, and nothing in scripting seems to want it.

Docs add a `rune.clipboard` reference page with a collect-a-note-then-copy example built on a span trigger. A Lua-layer test runs that example verbatim against MockHost so it can't drift from the API, plus a smaller test pinning the text through to the host. Verified live in tmux with `set-clipboard on`: `/lua rune.clipboard.set("hello from rune")` landed in the tmux paste buffer.
