### PR TITLE
gmcp: query negotiation state from the connection instead of caching it in Lua

### DIFF
--- a/lua/api_gmcp.go
+++ b/lua/api_gmcp.go
@@ -48,6 +48,14 @@ func (e *Engine) registerGMCPFuncs() {
 		return 1
 	}))
 
+	// rune._gmcp.is_active(): whether GMCP is negotiated on the
+	// current connection. Queried live so it cannot go stale across
+	// /reload (see Host.GMCPActive).
+	e.L.SetField(gmcp, "is_active", e.L.NewFunction(func(L *glua.LState) int {
+		L.Push(glua.LBool(e.host.GMCPActive()))
+		return 1
+	}))
+
 	// rune._gmcp.send_raw(package, json?): sends the JSON text
 	// verbatim (no validation) - the debugging escape hatch used by
 	// "/gmcp send". Returns true, or nil + error message.

--- a/lua/core/70_gmcp.lua
+++ b/lua/core/70_gmcp.lua
@@ -12,7 +12,6 @@ local green, red, yellow, dim =
 
 rune.gmcp = {}
 
-local enabled = false
 local subscriptions = {} -- package -> version (what Core.Supports.Set sends)
 
 -- Core.Supports.Set replaces the server-side set wholesale, so send
@@ -108,9 +107,12 @@ function rune.gmcp.send_raw(package, raw)
     return rune._gmcp.send_raw(package, raw)
 end
 
--- True once the server has negotiated GMCP on this connection.
+-- True while GMCP is negotiated on the current connection. Queried
+-- live from Go rather than cached here: negotiation is connection-
+-- lifetime state, and a VM-lifetime copy would go stale across
+-- /reload (the gmcp_enabled edge fires once per connection).
 function rune.gmcp.is_enabled()
-    return enabled
+    return rune._gmcp.is_active()
 end
 
 -- Subscribe to server packages ("Char", "Room", ...). Takes effect
@@ -118,7 +120,7 @@ end
 -- version defaults to 1.
 function rune.gmcp.subscribe(package, version)
     subscriptions[package] = version or 1
-    if enabled then
+    if rune._gmcp.is_active() then
         send_supports()
     end
 end
@@ -128,7 +130,7 @@ function rune.gmcp.unsubscribe(package)
         return
     end
     subscriptions[package] = nil
-    if enabled then
+    if rune._gmcp.is_active() then
         send_supports()
     end
 end
@@ -177,14 +179,9 @@ end
 -- ourselves and declare subscriptions. Visible and overridable - hide
 -- or replace it like any named hook.
 rune.hooks.on("gmcp_enabled", function()
-    enabled = true
     rune._gmcp.send("Core.Hello", { client = "Rune", version = rune.version })
     send_supports()
 end, { name = "gmcp-hello", priority = 100 })
-
-rune.hooks.on("disconnected", function()
-    enabled = false
-end, { name = "gmcp-reset", priority = 100 })
 
 -- /gmcp - status, or send a raw message for debugging
 rune.command.add("gmcp", function(args)
@@ -204,7 +201,7 @@ rune.command.add("gmcp", function(args)
         return
     end
 
-    local status = enabled and green("negotiated") or dim("not negotiated")
+    local status = rune._gmcp.is_active() and green("negotiated") or dim("not negotiated")
     rune.echo(green("[GMCP]") .. " " .. status)
     local subs = {}
     for package, version in pairs(subscriptions) do

--- a/lua/gmcp_test.go
+++ b/lua/gmcp_test.go
@@ -173,6 +173,9 @@ func TestGMCPHandshakeAndSubscriptions(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Go fires gmcp_enabled only after the option is active on the
+	// connection; mirror that ordering.
+	host.GMCPNegotiated = true
 	engine.CallHook("gmcp_enabled")
 
 	if len(host.GMCPSends) < 2 {
@@ -198,10 +201,47 @@ func TestGMCPHandshakeAndSubscriptions(t *testing.T) {
 		t.Errorf("re-sent supports = %v", host.GMCPSends)
 	}
 
-	// is_enabled resets on disconnect
-	engine.CallHook("disconnected")
+	// is_enabled mirrors the connection: false once GMCP is down
+	host.GMCPNegotiated = false
 	if err := engine.DoString("check", `assert(rune.gmcp.is_enabled() == false)`); err != nil {
 		t.Error(err)
+	}
+}
+
+// TestGMCPStateQueriedNotCached verifies negotiation state is read
+// live from the host rather than cached in the VM. A fresh Lua state
+// on a connection where GMCP is already up - exactly the situation
+// after /reload - must report enabled and send subscription changes
+// immediately, even though it never saw the gmcp_enabled edge.
+func TestGMCPStateQueriedNotCached(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	host.GMCPNegotiated = true
+
+	if err := engine.DoString("check", `assert(rune.gmcp.is_enabled() == true,
+		"is_enabled must reflect the connection, not a VM-lifetime cache")`); err != nil {
+		t.Error(err)
+	}
+
+	if err := engine.DoString("subscribe", `rune.gmcp.subscribe("Room")`); err != nil {
+		t.Fatal(err)
+	}
+	if len(host.GMCPSends) != 1 ||
+		host.GMCPSends[0].Package != "Core.Supports.Set" ||
+		host.GMCPSends[0].Data != `["Room 1"]` {
+		t.Errorf("subscribe on an active connection must send supports immediately, got %v", host.GMCPSends)
+	}
+
+	// While GMCP is down, subscriptions accumulate silently for the
+	// next handshake.
+	host.GMCPNegotiated = false
+	host.GMCPSends = nil
+	if err := engine.DoString("subscribe2", `rune.gmcp.subscribe("Char")`); err != nil {
+		t.Fatal(err)
+	}
+	if len(host.GMCPSends) != 0 {
+		t.Errorf("subscribe while inactive must not send, got %v", host.GMCPSends)
 	}
 }
 

--- a/lua/host.go
+++ b/lua/host.go
@@ -20,6 +20,12 @@ type Host interface {
 	// has not negotiated GMCP.
 	GMCPSend(pkg, data string) error
 
+	// GMCPActive reports whether GMCP is negotiated on the current
+	// connection (false when disconnected). Negotiation is a
+	// connection-lifetime fact, so Lua queries it live instead of
+	// caching it in the VM, where it would go stale across /reload.
+	GMCPActive() bool
+
 	// UI
 	Print(text string)
 	PaneCreate(name string)

--- a/lua/mock_host_test.go
+++ b/lua/mock_host_test.go
@@ -53,8 +53,9 @@ type MockHost struct {
 	StoreData map[string]string
 
 	// GMCP capture (see Host.GMCPSend)
-	GMCPSends []struct{ Package, Data string }
-	GMCPErr   error // when set, GMCPSend fails with this error
+	GMCPSends      []struct{ Package, Data string }
+	GMCPErr        error // when set, GMCPSend fails with this error
+	GMCPNegotiated bool  // what GMCPActive reports
 
 	// HTTP capture (see Host.HTTPRequest)
 	HTTPCalls []MockHTTPCall
@@ -122,6 +123,12 @@ func (m *MockHost) GMCPSend(pkg, data string) error {
 	}
 	m.GMCPSends = append(m.GMCPSends, struct{ Package, Data string }{pkg, data})
 	return nil
+}
+
+func (m *MockHost) GMCPActive() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.GMCPNegotiated
 }
 
 func (m *MockHost) Reload() {

--- a/network/client.go
+++ b/network/client.go
@@ -253,6 +253,15 @@ func (c *TCPClient) SetWindowSize(width, height int) {
 	}
 }
 
+// GMCPActive reports whether GMCP is negotiated on the current
+// connection. False when disconnected.
+func (c *TCPClient) GMCPActive() bool {
+	c.mu.Lock()
+	cx := c.current
+	c.mu.Unlock()
+	return cx != nil && cx.gmcpActive.Load()
+}
+
 // SendGMCP sends a GMCP message: "Package.SubPackage" plus optional
 // raw JSON. Returns an error when disconnected or when the server has
 // not negotiated GMCP.

--- a/session/gmcp_reload_test.go
+++ b/session/gmcp_reload_test.go
@@ -1,0 +1,76 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mmcdole/rune/event"
+)
+
+// TestGMCPStateSurvivesReloadMidConnection reproduces the /reload
+// regression: negotiation is a connection-lifetime fact, but it used
+// to be cached in the VM, so a reload mid-connection left the fresh
+// Lua state believing GMCP was down - is_enabled() lied and
+// subscription changes in the edited init.lua never reached the
+// server until reconnect. State must instead be queried from the
+// connection, making reload transparent.
+func TestGMCPStateSurvivesReloadMidConnection(t *testing.T) {
+	dir := t.TempDir()
+	writeInit := func(body string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, "init.lua"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	writeInit(`rune.gmcp.subscribe("Char")`)
+	s, net, uiMock := bootSessionInDir(t, dir)
+	uiMock.drainPrinted()
+
+	// Server negotiates GMCP on the live connection.
+	net.connected = true
+	net.gmcpActive = true
+	s.handleEvent(event.Event{Type: event.SysGMCPEnabled})
+
+	sent := net.drainGMCPSent()
+	if len(sent) < 2 || sent[0].Package != "Core.Hello" {
+		t.Fatalf("handshake must send Core.Hello then supports, got %v", sent)
+	}
+	if last := sent[len(sent)-1]; last.Package != "Core.Supports.Set" || last.Data != `["Char 1"]` {
+		t.Fatalf("initial supports = %v", sent)
+	}
+
+	// User edits init.lua (adds a package) and reloads mid-connection.
+	writeInit(strings.Join([]string{
+		`rune.gmcp.subscribe("Char")`,
+		`rune.gmcp.subscribe("Room")`,
+		`rune.echo("RELOAD-GMCP-UP=" .. tostring(rune.gmcp.is_enabled()))`,
+	}, "\n"))
+	s.Reload()
+	ev := <-s.events // reload is deferred via AsyncResult
+	s.handleEvent(ev)
+
+	// is_enabled() must stay truthful in the reloaded VM.
+	if printed := uiMock.drainPrinted(); !contains(printed, "RELOAD-GMCP-UP=true") {
+		t.Errorf("is_enabled() false after reload on a GMCP-active connection; printed: %v", printed)
+	}
+
+	// The subscription change must reach the server immediately - and
+	// Core.Hello must NOT be re-sent (once per connection, per spec).
+	sent = net.drainGMCPSent()
+	var lastSupports string
+	for _, msg := range sent {
+		if msg.Package == "Core.Hello" {
+			t.Errorf("Core.Hello re-sent on reload: %v", sent)
+		}
+		if msg.Package == "Core.Supports.Set" {
+			lastSupports = msg.Data
+		}
+	}
+	if lastSupports != `["Char 1","Room 1"]` {
+		t.Errorf("subscription change did not reach the server after reload; last supports = %q, sends = %v",
+			lastSupports, sent)
+	}
+}

--- a/session/gmcp_test.go
+++ b/session/gmcp_test.go
@@ -22,6 +22,9 @@ func TestGMCPEnabledTriggersHandshake(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The network layer flips gmcpActive before emitting the enabled
+	// notification; mirror that ordering.
+	net.gmcpActive = true
 	s.handleNetworkOutput(network.Output{Kind: network.OutputGMCPEnabled})
 
 	sent := net.drainGMCPSent()

--- a/session/lua_network.go
+++ b/session/lua_network.go
@@ -61,3 +61,8 @@ func (s *Session) Send(data string) error {
 func (s *Session) GMCPSend(pkg, data string) error {
 	return s.net.SendGMCP(pkg, data)
 }
+
+// GMCPActive implements lua.Host.
+func (s *Session) GMCPActive() bool {
+	return s.net.GMCPActive()
+}

--- a/session/mocks_test.go
+++ b/session/mocks_test.go
@@ -15,6 +15,7 @@ type mockNetwork struct {
 	mu          sync.Mutex
 	sent        []string
 	gmcpSent    []struct{ Package, Data string }
+	gmcpActive  bool
 	connected   bool
 	connectedTo []string // every Connect address, in order
 	connectErr  error
@@ -77,6 +78,12 @@ func (m *mockNetwork) SendGMCP(pkg, data string) error {
 	}
 	m.gmcpSent = append(m.gmcpSent, struct{ Package, Data string }{pkg, data})
 	return nil
+}
+
+func (m *mockNetwork) GMCPActive() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.gmcpActive
 }
 
 func (m *mockNetwork) SetWindowSize(width, height int) {

--- a/session/session.go
+++ b/session/session.go
@@ -32,6 +32,7 @@ type Network interface {
 	Disconnect()
 	Send(data string) error
 	SendGMCP(pkg, data string) error
+	GMCPActive() bool
 	SetWindowSize(width, height int)
 	Output() <-chan network.Output
 	LocalEchoEnabled() bool

--- a/test/e2e/scenarios/regressions/13-completion-input-cache.json
+++ b/test/e2e/scenarios/regressions/13-completion-input-cache.json
@@ -3,7 +3,7 @@
   "scenarios": [
     {
       "name": "typed words seed the tab-completion cache",
-      "issue": "found 2026-07 while building lua/input_test.go; fixed by moving _completion_input to priority 50",
+      "issue": "https://github.com/mmcdole/rune/pull/13",
       "steps": [
         { "connect": true },
         { "type": "brandish sword" },

--- a/test/e2e/scenarios/regressions/44-gmcp-reload-active-query.json
+++ b/test/e2e/scenarios/regressions/44-gmcp-reload-active-query.json
@@ -1,0 +1,21 @@
+{
+  "description": "Regression: /reload rebuilt Lua while preserving the network connection, leaving GMCP disabled in the fresh VM because negotiation state was cached in Lua.",
+  "scenarios": [
+    {
+      "name": "GMCP remains active across reload",
+      "issue": "https://github.com/mmcdole/rune/pull/44",
+      "init_lua": [
+        "if rune.session.get('gmcp-loaded') then rune.gmcp.subscribe('Room') else rune.session.set('gmcp-loaded', 'yes'); rune.gmcp.subscribe('Char') end",
+        "rune.hooks.on('reloaded', function() rune.echo('E2E-GMCP-RELOAD=' .. tostring(rune.gmcp.is_enabled())) end)"
+      ],
+      "steps": [
+        { "connect": true },
+        { "server_bytes": [255, 251, 201], "note": "IAC WILL GMCP" },
+        { "expect_sent": "Char 1", "note": "sync: initial GMCP handshake completed" },
+        { "type": "/reload" },
+        { "expect_printed": "E2E-GMCP-RELOAD=true" },
+        { "expect_sent": "Room 1", "note": "the reloaded script updates the live subscription set" }
+      ]
+    }
+  ]
+}

--- a/website/src/content/docs/reference/api/gmcp.md
+++ b/website/src/content/docs/reference/api/gmcp.md
@@ -15,7 +15,7 @@ rune.gmcp.send(package, value?)         -- send a JSON-able value
 rune.gmcp.send_raw(package, raw_json)   -- send pre-encoded JSON (debugging)
 rune.gmcp.subscribe(package, version?)  -- declare interest (Core.Supports.Set)
 rune.gmcp.unsubscribe(package)          -- withdraw interest
-rune.gmcp.is_enabled()                  -- true once GMCP is negotiated
+rune.gmcp.is_enabled()                  -- true while GMCP is negotiated
 rune.gmcp.list()                        -- all handlers, as /gmcp shows them
 ```
 
@@ -81,7 +81,10 @@ a debugging tool (`/gmcp send` uses it).
 (`"Char"`, `"Room"`, …); `version` defaults to 1. Subscriptions
 maintain `Core.Supports.Set` — the full set is re-sent on every
 change, per the spec — taking effect immediately when GMCP is up,
-otherwise at the next handshake.
+otherwise at the next handshake. This holds across `/reload` too:
+`is_enabled()` reflects the live connection, so a subscription added
+to `init.lua` reaches the server as soon as the reloaded script
+declares it.
 
 When the server negotiates GMCP, the `"gmcp_enabled"` event fires and
 the core handler named `gmcp-hello` sends


### PR DESCRIPTION
## Problem

`/reload` tears down the Lua VM and re-runs core scripts plus `init.lua` while the network connection stays up — but GMCP negotiation state was cached inside the VM. `70_gmcp.lua` kept a local `enabled` flag set by the `gmcp_enabled` hook, and Go fires that hook exactly once per connection (`gmcpActive.Swap(true)` in `network/client.go`). A reload mid-connection therefore left the fresh VM with `enabled = false` while GMCP was actually negotiated and flowing:

1. **`rune.gmcp.is_enabled()` lied** — it reported `false` on a connection where GMCP was up.
2. **Subscription changes silently no-oped** — `subscribe()` documents "takes effect immediately when GMCP is up," but after a mid-connection reload it saw `enabled = false` and skipped `Core.Supports.Set`. Adding a package to `init.lua` and reloading did nothing until reconnect, with no error.

The bug was masked in the common case because the server retains the subscription set from the original handshake, so reloading with *unchanged* subscriptions kept working by accident.

## Root cause

A lifetime mismatch: "is GMCP negotiated?" is a connection-lifetime fact owned by Go, but Lua held a VM-lifetime copy maintained only by edge events. A freshly booted VM has missed the edge, and any state communicated only by events breaks for subscribers created after the event fired.

## Fix

Delete the copy and query the owner. No new state, no persistence:

- New primitive `rune._gmcp.is_active()` reads the connection's existing `gmcpActive` state (`false` when disconnected, never raises).
- `rune.gmcp.is_enabled()` delegates to it — truthful by construction in every window.
- `subscribe()`/`unsubscribe()` gate `send_supports()` on the live query. Reload heals itself with no boot-time hook: as `init.lua` re-runs, each `subscribe()` sees the active connection and sends `Core.Supports.Set`, which is wholesale-replace and idempotent — the last call leaves the server holding exactly the declared set.
- `gmcp_enabled` stays a pure once-per-connection edge: user hooks (a common home for GMCP auto-login) never replay on `/reload`, and `Core.Hello` is never re-sent mid-connection, per spec. The `disconnected` reset handler is deleted along with the flag it existed to clear.

This follows the existing boundary conventions: Go registers one underscore primitive exposing transport truth, policy stays in Lua, and `boot()`-time correctness comes from re-deriving state rather than restoring it (same pattern as `pushBindsAndLayout`).

## Transparency

No public API changes; no user-script changes needed. The only observable differences are the two bugs disappearing.

## Testing

Written red-first at the lowest layers that can express the failure (the e2e scenario vocabulary can't express "edit init.lua mid-scenario, then /reload"):

- **`session/gmcp_reload_test.go`** (new, regression): boots with a subscribing `init.lua`, negotiates GMCP, edits the file to add a package, reloads mid-connection — asserts `is_enabled()` is true in the reloaded VM, the new package reaches the server in `Core.Supports.Set`, and `Core.Hello` is not re-sent.
- **`lua/gmcp_test.go`**: new `TestGMCPStateQueriedNotCached` — a fresh VM on an already-active connection (the post-reload situation) reports enabled and sends subscription changes immediately; while inactive, subscriptions accumulate silently for the next handshake.
- Existing handshake tests updated to mirror production ordering (the network layer flips `gmcpActive` before emitting the enabled notification).

`go test ./...` passes.