### PR TITLE
cli: add config directory override

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,9 @@ Data-flow: `"output"`, `"prompt"`, `"echo"` support returning `false` to gag or 
 
 Full reference: `website/src/content/docs/reference/api/` (one page per namespace; published at runemud.com/reference/api/). It is mechanically complete: a new public `rune.*` function must be added there or `lua/api_docs_coverage_test.go` fails. Go primitives (`rune._*`) are internal. Slash commands are registry-based; `/help` is generated from the registry.
 
-User scripts auto-load from `~/.config/rune/init.lua` at startup.
+User scripts auto-load from `<config-dir>/init.lua` at startup. The default is
+`~/.config/rune`; `--config-dir` overrides `RUNE_CONFIG_DIR`, which overrides
+the platform default.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,10 @@ rune.gmcp.on("Char.Vitals", function(data)
 end)
 ```
 
+Everything Rune reads and writes — scripts, saved worlds, state, and
+logs — lives in `~/.config/rune`. Use `rune --config-dir <dir>` or
+`RUNE_CONFIG_DIR=<dir>` to keep it in a different directory.
+
 The [scripting basics](https://runemud.com/getting-started/scripting-basics/)
 guide picks up from here.
 

--- a/cmd/rune/main.go
+++ b/cmd/rune/main.go
@@ -17,52 +17,51 @@ import (
 	"github.com/mmcdole/rune/version"
 )
 
-// classifyArgs separates positional CLI args into Lua scripts and a
-// connection target. Args ending in .lua (or containing a path
-// separator) are scripts; the rest form a connect target - a saved
-// world name, "host port", "host:port", or a scheme-prefixed address,
-// resolved through the same path as /connect after boot.
-func classifyArgs(args []string) (scripts []string, target string, err error) {
-	var targetParts []string
-	for _, arg := range args {
-		switch {
-		case strings.Contains(arg, "://"):
-			// Scheme-prefixed address (tls://host:port) - the slashes
-			// are not a filesystem path.
-			targetParts = append(targetParts, arg)
-		case strings.HasSuffix(arg, ".lua") || strings.ContainsAny(arg, `/\`):
-			scripts = append(scripts, arg)
-		default:
-			targetParts = append(targetParts, arg)
-		}
-	}
+// connectTarget validates and joins the optional connection target: a
+// saved world name, "host port", "host:port", or a scheme-prefixed
+// address.
+func connectTarget(args []string) (string, error) {
 	// /connect accepts up to "host port tls" - three words. More than
 	// that is not a connection target anyone meant to type.
-	if len(targetParts) > 3 {
-		return nil, "", fmt.Errorf("too many arguments: %q", strings.Join(targetParts, " "))
+	if len(args) > 3 {
+		return "", fmt.Errorf("too many arguments: %q", strings.Join(args, " "))
 	}
-	return scripts, strings.Join(targetParts, " "), nil
+	return strings.Join(args, " "), nil
 }
 
-func main() {
-	showVersion := flag.Bool("version", false, "print version and exit")
-	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(),
-			`usage: rune [host [port] | host:port | world] [script.lua ...]
+func usageText(defaultDir string) string {
+	return fmt.Sprintf(`usage: rune [--config-dir <dir>] [world | address]
 
-A MUD client. With a connection target, rune connects on startup:
+A MUD client. A world is a saved world name (see /world). An address
+may be "host:port", "host port" (optionally followed by tls), or a
+scheme-prefixed address such as "tls://host:port" or
+"tls+insecure://host:port".
 
+Examples:
+
+  rune arctic
   rune mud.example.com 4000
   rune mud.example.com 4000 tls
   rune tls://mud.example.com:4000
-  rune arctic                        connect to a saved world (see /world)
 
-Arguments ending in .lua (or containing a path separator) are loaded
-as Lua scripts after init.lua. Config lives in %s.
+Everything Rune reads and writes - init.lua, store.json, worlds, and
+logs - lives in %s. Use --config-dir or RUNE_CONFIG_DIR to
+keep it in a different directory.
 
 Options:
-`, config.Dir())
-		flag.PrintDefaults()
+  --config-dir <dir>  Directory for all of Rune's files.
+                      (default: %s)
+  --version           Print version and exit.
+  -h, --help          Show this help.
+`, defaultDir, defaultDir)
+}
+
+func main() {
+	defaultDir := config.Dir()
+	showVersion := flag.Bool("version", false, "print version and exit")
+	configDir := flag.String("config-dir", "", "directory for all of Rune's files")
+	flag.Usage = func() {
+		fmt.Fprint(flag.CommandLine.Output(), usageText(defaultDir))
 	}
 	flag.Parse()
 
@@ -71,7 +70,7 @@ Options:
 		return
 	}
 
-	scripts, target, err := classifyArgs(flag.Args())
+	target, err := connectTarget(flag.Args())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		flag.Usage()
@@ -85,8 +84,7 @@ Options:
 	tuiInstance := tui.NewBubbleTeaUI()
 	sess := session.New(tcpClient, tuiInstance, session.Config{
 		CoreScripts:   lua.CoreScripts,
-		ConfigDir:     config.Dir(),
-		UserScripts:   scripts,
+		ConfigDir:     config.ResolveDir(*configDir),
 		ConnectTarget: target,
 	})
 

--- a/cmd/rune/main_test.go
+++ b/cmd/rune/main_test.go
@@ -1,34 +1,32 @@
 package main
 
 import (
+	"strings"
 	"testing"
 )
 
-func TestClassifyArgs(t *testing.T) {
+func TestConnectTarget(t *testing.T) {
 	cases := []struct {
-		name    string
-		args    []string
-		scripts []string
-		target  string
-		wantErr bool
+		name        string
+		args        []string
+		target      string
+		errContains string
 	}{
-		{"empty", nil, nil, "", false},
-		{"host port", []string{"mud.example.com", "4000"}, nil, "mud.example.com 4000", false},
-		{"host port tls", []string{"mud.example.com", "4000", "tls"}, nil, "mud.example.com 4000 tls", false},
-		{"host:port", []string{"mud.example.com:4000"}, nil, "mud.example.com:4000", false},
-		{"scheme address", []string{"tls://mud.example.com:4000"}, nil, "tls://mud.example.com:4000", false},
-		{"world name", []string{"arctic"}, nil, "arctic", false},
-		{"script only", []string{"combat.lua"}, []string{"combat.lua"}, "", false},
-		{"script by path", []string{"scripts/combat"}, []string{"scripts/combat"}, "", false},
-		{"scripts and target", []string{"combat.lua", "arctic", "ui.lua"},
-			[]string{"combat.lua", "ui.lua"}, "arctic", false},
-		{"too many words", []string{"a", "b", "c", "d"}, nil, "", true},
+		{"empty", nil, "", ""},
+		{"host port", []string{"mud.example.com", "4000"}, "mud.example.com 4000", ""},
+		{"host port tls", []string{"mud.example.com", "4000", "tls"}, "mud.example.com 4000 tls", ""},
+		{"host:port", []string{"mud.example.com:4000"}, "mud.example.com:4000", ""},
+		{"scheme address", []string{"tls://mud.example.com:4000"}, "tls://mud.example.com:4000", ""},
+		{"world name", []string{"arctic"}, "arctic", ""},
+		{"too many words", []string{"a", "b", "c", "d"}, "", "too many arguments"},
 	}
 	for _, c := range cases {
-		scripts, target, err := classifyArgs(c.args)
-		if c.wantErr {
+		target, err := connectTarget(c.args)
+		if c.errContains != "" {
 			if err == nil {
 				t.Errorf("%s: expected error", c.name)
+			} else if !strings.Contains(err.Error(), c.errContains) {
+				t.Errorf("%s: error = %q, want it to contain %q", c.name, err, c.errContains)
 			}
 			continue
 		}
@@ -39,15 +37,21 @@ func TestClassifyArgs(t *testing.T) {
 		if target != c.target {
 			t.Errorf("%s: target = %q, want %q", c.name, target, c.target)
 		}
-		if len(scripts) != len(c.scripts) {
-			t.Errorf("%s: scripts = %v, want %v", c.name, scripts, c.scripts)
-			continue
-		}
-		for i := range scripts {
-			if scripts[i] != c.scripts[i] {
-				t.Errorf("%s: scripts = %v, want %v", c.name, scripts, c.scripts)
-				break
-			}
+	}
+}
+
+func TestUsageTextNamesWorldAndAddress(t *testing.T) {
+	usage := usageText("/tmp/rune-config")
+	if !strings.Contains(usage, "rune [--config-dir <dir>] [world | address]") {
+		t.Errorf("usage synopsis does not name world and address:\n%s", usage)
+	}
+	if !strings.Contains(usage, "--config-dir <dir>") ||
+		!strings.Contains(usage, "(default: /tmp/rune-config)") {
+		t.Errorf("usage does not show config-dir and its effective default:\n%s", usage)
+	}
+	for _, form := range []string{"host:port", "host port", "tls://host:port"} {
+		if !strings.Contains(usage, form) {
+			t.Errorf("usage does not explain address form %q:\n%s", form, usage)
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,9 +6,23 @@ import (
 	"runtime"
 )
 
-// Dir returns the rune configuration directory.
-// Respects XDG_CONFIG_HOME on Unix, APPDATA on Windows.
+// Dir returns the rune configuration directory. RUNE_CONFIG_DIR takes
+// precedence over the platform default.
 func Dir() string {
+	return ResolveDir("")
+}
+
+// ResolveDir applies the precedence for Rune's configuration
+// directory: a non-empty CLI value wins, followed by RUNE_CONFIG_DIR,
+// then the platform default.
+func ResolveDir(cliDir string) string {
+	if cliDir != "" {
+		return cliDir
+	}
+	if envDir := os.Getenv("RUNE_CONFIG_DIR"); envDir != "" {
+		return envDir
+	}
+
 	var base string
 
 	if runtime.GOOS == "windows" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,14 @@
+package config
+
+import "testing"
+
+func TestResolveDirPrecedence(t *testing.T) {
+	t.Setenv("RUNE_CONFIG_DIR", "/env/rune")
+
+	if got := ResolveDir(""); got != "/env/rune" {
+		t.Errorf("environment directory = %q, want /env/rune", got)
+	}
+	if got := ResolveDir("/flag/rune"); got != "/flag/rune" {
+		t.Errorf("flag directory = %q, want /flag/rune", got)
+	}
+}

--- a/session/boot_test.go
+++ b/session/boot_test.go
@@ -11,7 +11,7 @@ import (
 // bootSessionInDir builds and boots a session against a caller-owned
 // config dir without failing the test on boot errors - these tests
 // exist precisely to exercise boot with broken user scripts.
-func bootSessionInDir(t *testing.T, dir string, userScripts ...string) (*Session, *mockNetwork, *mockUI) {
+func bootSessionInDir(t *testing.T, dir string) (*Session, *mockNetwork, *mockUI) {
 	t.Helper()
 
 	net := newMockNetwork()
@@ -19,7 +19,6 @@ func bootSessionInDir(t *testing.T, dir string, userScripts ...string) (*Session
 	s := New(net, uiMock, Config{
 		CoreScripts: lua.CoreScripts,
 		ConfigDir:   dir,
-		UserScripts: userScripts,
 	})
 	if err := s.boot(); err != nil {
 		t.Fatalf("boot must not fail on user-script errors: %v", err)
@@ -66,31 +65,6 @@ func TestBrokenInitLuaStillBootsFully(t *testing.T) {
 
 	if printed := uiMock.drainPrinted(); !contains(printed, "[Script Error] init.lua") {
 		t.Errorf("script failure not reported, got %v", printed)
-	}
-	assertFullyBooted(t, s, net, uiMock)
-}
-
-// TestBrokenCLIScriptStillBootsFully verifies a bad CLI script arg
-// (including a nonexistent file) is reported per script while the
-// others still load.
-func TestBrokenCLIScriptStillBootsFully(t *testing.T) {
-	dir := t.TempDir()
-	good := filepath.Join(dir, "good.lua")
-	if err := os.WriteFile(good, []byte(`rune.alias.exact("k", "kill")`), 0o644); err != nil {
-		t.Fatal(err)
-	}
-
-	s, net, uiMock := bootSessionInDir(t, dir, filepath.Join(dir, "missing.lua"), good)
-
-	if printed := uiMock.drainPrinted(); !contains(printed, "[Script Error]") {
-		t.Errorf("missing script not reported, got %v", printed)
-	}
-
-	// The script after the broken one still loaded
-	net.connected = true
-	userInput(s, "k rat")
-	if sent := net.drainSent(); len(sent) != 1 || sent[0] != "kill rat" {
-		t.Errorf("later script did not load: sent %v", sent)
 	}
 	assertFullyBooted(t, s, net, uiMock)
 }

--- a/session/session.go
+++ b/session/session.go
@@ -43,8 +43,7 @@ var _ Network = (*network.TCPClient)(nil)
 // Config holds session configuration
 type Config struct {
 	CoreScripts   embed.FS // Embedded core Lua scripts
-	ConfigDir     string   // Path to ~/.config/rune
-	UserScripts   []string // CLI script arguments
+	ConfigDir     string   // Directory for all of Rune's files (init.lua, store.json, worlds, logs)
 	ConnectTarget string   // CLI connect target (world, host port, or address)
 }
 
@@ -302,7 +301,7 @@ func (s *Session) boot() error {
 	// user's first init.lua would otherwise skip the ready hook and
 	// the binds/layout push, leaving a half-dead client. Each failure
 	// is reported individually and the rest of boot proceeds.
-	s.loadUserScripts()
+	s.loadUserScript()
 	s.engine.CallHook("ready")
 	s.pushBindsAndLayout()
 	s.pushBarUpdates()
@@ -354,21 +353,14 @@ func (s *Session) loadCoreScripts() error {
 	return nil
 }
 
-// loadUserScripts loads init.lua and CLI-specified scripts. Failures
-// are reported per script and never propagate: the client must come
+// loadUserScript loads init.lua. A failure never propagates: the client must come
 // up fully functional (binds, bars, ready hook) around a broken user
 // script, so the user can fix it and /reload.
-func (s *Session) loadUserScripts() {
+func (s *Session) loadUserScript() {
 	initPath := filepath.Join(s.config.ConfigDir, "init.lua")
 	if _, err := os.Stat(initPath); err == nil {
 		if err := s.engine.DoFile(initPath); err != nil {
 			s.reportScriptError("init.lua", err)
-		}
-	}
-
-	for _, path := range s.config.UserScripts {
-		if err := s.engine.DoFile(path); err != nil {
-			s.reportScriptError(path, err)
 		}
 	}
 }

--- a/website/src/content/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/getting-started/installation.mdx
@@ -45,6 +45,24 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 
 Nothing is created until it's needed; a fresh install is just the binary.
 
+## Use a different config directory
+
+Pass `--config-dir` to keep everything Rune reads and writes in a
+different directory:
+
+```sh
+rune --config-dir ~/muds/tank aardwolf
+```
+
+Rune reads `init.lua`, `store.json`, world data, and logs from that directory.
+`RUNE_CONFIG_DIR` provides the same override for shell profiles and launchers:
+
+```sh
+RUNE_CONFIG_DIR=~/muds/tank rune aardwolf
+```
+
+When both are set, `--config-dir` wins.
+
 ## Next
 
 [Your First Session](/getting-started/first-session/) covers

--- a/website/src/content/docs/reference/api/core.md
+++ b/website/src/content/docs/reference/api/core.md
@@ -120,9 +120,10 @@ first load, and should return a table of exports.
 ## Data fields
 
 `rune.config_dir` and `rune.version` are plain strings set by the
-client. `rune.debug` is yours to flip — while it's `true`, `rune.dbg`
-prints its message with a `[dbg]` prefix; otherwise it's silent, so
-you can leave debug calls in place:
+client. `rune.config_dir` reflects `--config-dir`, `RUNE_CONFIG_DIR`, or
+the platform default, in that order. Set `rune.debug` to `true` to make
+`rune.dbg` print messages with a `[dbg]` prefix. When it is `false`,
+`rune.dbg` does nothing:
 
 ```lua
 rune.debug = true


### PR DESCRIPTION
Closes #47.

- Add `--config-dir <dir>` and `RUNE_CONFIG_DIR`; the flag takes precedence.
- Use the selected directory for `init.lua`, durable state, worlds, and logs.
- Define command arguments as `world | address`.
- Update `--help`, installation docs, and API docs.

Tests:

- `go test ./...`
- `go vet ./...`
- `go test -race ./test/e2e`
- `npm run build` in `website/`
- Built CLI and TUI verification for help text and config precedence