### PR TITLE
tui: split and word-wrap output into scrollback rows

### DIFF
--- a/ui/messages.go
+++ b/ui/messages.go
@@ -8,12 +8,14 @@ type UIEvent interface {
 	uiEvent() // unexported marker method - only this package can implement
 }
 
-// PrintLineMsg represents a line to append to scrollback.
+// PrintLineMsg carries output text to append to scrollback. The text
+// may contain newlines; the TUI splits and wraps it into rows.
 // Used for all output: server lines, Lua prints, etc.
 type PrintLineMsg string
 
-// EchoLineMsg represents a local echo (user input, already styled by
-// the Lua "echo" hook) to append to scrollback.
+// EchoLineMsg carries a local echo (user input, already styled by the
+// Lua "echo" hook) to append to scrollback. Like PrintLineMsg, the
+// text may contain newlines.
 type EchoLineMsg string
 
 // PromptMsg represents a server prompt (partial line without newline).

--- a/ui/tui/layout.go
+++ b/ui/tui/layout.go
@@ -83,6 +83,8 @@ func (m *Model) View() string {
 	if viewportHeight < 1 {
 		viewportHeight = 1
 	}
+	// The viewport spans the full terminal width; splitRows wraps
+	// appended rows to the same m.width.
 	m.viewport.SetSize(m.width, viewportHeight)
 
 	var parts []string

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -53,13 +53,13 @@ type Model struct {
 	}
 
 	// State
-	lastPrompt   string
-	width        int
-	height       int
-	inputChan    chan<- input.Submission
-	outbound     chan<- ui.UIEvent
-	initialized  bool
-	pendingLines []string
+	lastPrompt  string
+	width       int
+	height      int
+	inputChan   chan<- input.Submission
+	outbound    chan<- ui.UIEvent
+	initialized bool
+	pendingRows []string
 	// flushScheduled is true while a batch-window tick is outstanding.
 	// At most one tick is ever in flight: it is armed only on the
 	// idle->hot transition and re-armed only from handleTick while
@@ -195,7 +195,7 @@ func (m *Model) handleWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 // echo already flushed eagerly) ends the chain - back to zero wakeups.
 func (m *Model) handleTick() (tea.Model, tea.Cmd) {
 	m.flushScheduled = false
-	if len(m.pendingLines) == 0 {
+	if len(m.pendingRows) == 0 {
 		return m, nil
 	}
 	m.flushPending()
@@ -203,13 +203,13 @@ func (m *Model) handleTick() (tea.Model, tea.Cmd) {
 	return m, doTick()
 }
 
-// flushPending appends all batched server lines to the scrollback.
+// flushPending appends all batched server rows to the scrollback.
 func (m *Model) flushPending() {
-	if len(m.pendingLines) == 0 {
+	if len(m.pendingRows) == 0 {
 		return
 	}
-	m.appendLines(m.pendingLines)
-	m.pendingLines = nil
+	m.appendRows(m.pendingRows...)
+	m.pendingRows = nil
 }
 
 func (m *Model) handleConfigUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -257,22 +257,22 @@ func (m *Model) syncBars(content map[string]ui.BarContent) {
 func (m *Model) handleServerOutput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case ui.PrintLineMsg:
-		cleanLine := util.ExpandTabs(util.FilterClearSequences(string(msg)))
+		rows := splitRows(util.FilterClearSequences(string(msg)), m.width)
 		if m.flushScheduled {
 			// Inside a batch window: coalesce with the burst.
-			m.pendingLines = append(m.pendingLines, cleanLine)
+			m.pendingRows = append(m.pendingRows, rows...)
 			return m, nil
 		}
 		// Idle: render this line now and open a batch window so a
 		// following burst coalesces instead of rendering line-by-line.
-		m.appendLines([]string{cleanLine})
+		m.appendRows(rows...)
 		m.flushScheduled = true
 		return m, doTick()
 	case ui.EchoLineMsg:
 		// Flush batched server lines first so the echo cannot render
 		// ahead of output that arrived before it.
 		m.flushPending()
-		m.appendLines([]string{util.ExpandTabs(string(msg))})
+		m.appendMessage(string(msg))
 	case ui.PromptMsg:
 		text := util.ExpandTabs(string(msg))
 		if text != m.lastPrompt {
@@ -321,12 +321,32 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m *Model) appendLines(lines []string) {
-	for _, line := range lines {
-		m.scrollback.Append(line)
+// splitRows shapes a message into physical scrollback rows: one row
+// per line break, tabs expanded per row so columns restart on every
+// row, rows wider than the terminal word-wrapped. Rows are final at
+// append time; a resize does not rewrap old output.
+func splitRows(msg string, width int) []string {
+	if !strings.ContainsAny(msg, "\r\n") {
+		return util.WrapLine(util.ExpandTabs(msg), width)
 	}
-	m.viewport.OnNewLines(len(lines))
+	var rows []string
+	for _, line := range util.SplitLines(msg) {
+		rows = append(rows, util.WrapLine(util.ExpandTabs(line), width)...)
+	}
+	return rows
+}
+
+func (m *Model) appendRows(rows ...string) {
+	for _, row := range rows {
+		m.scrollback.Append(row)
+	}
+	m.viewport.OnNewRows(len(rows))
 	m.updateScrollState()
+}
+
+// appendMessage shapes text into rows and appends them.
+func (m *Model) appendMessage(text string) {
+	m.appendRows(splitRows(text, m.width)...)
 }
 
 // sendLine offers a submitted input snapshot to the session. It rejects
@@ -336,7 +356,7 @@ func (m *Model) sendLine(submission input.Submission) bool {
 	if submission.Mode == input.ModeVerbatim {
 		lineCount := 1 + strings.Count(submission.Text, "\n")
 		if len(submission.Text) > maxVerbatimBytes || lineCount > maxVerbatimLines {
-			m.appendLines([]string{text.Red("[WARNING] Verbatim input not sent - limit is 1000 lines or 256 KiB")})
+			m.appendMessage(text.Red("[WARNING] Verbatim input not sent - limit is 1000 lines or 256 KiB"))
 			return false
 		}
 	}
@@ -344,7 +364,7 @@ func (m *Model) sendLine(submission input.Submission) bool {
 	case m.inputChan <- submission:
 		return true
 	default:
-		m.appendLines([]string{text.Red("[WARNING] Input not sent - engine lagging")})
+		m.appendMessage(text.Red("[WARNING] Input not sent - engine lagging"))
 		return false
 	}
 }

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -184,6 +184,84 @@ func TestEchoFlushesPendingServerLines(t *testing.T) {
 	}
 }
 
+// wantScrollback asserts the scrollback holds exactly want, in order.
+func wantScrollback(t *testing.T, m *Model, want ...string) {
+	t.Helper()
+	if got := m.scrollback.Count(); got != len(want) {
+		t.Fatalf("scrollback has %d rows, want %d", got, len(want))
+	}
+	for i, w := range want {
+		if got := m.scrollback.At(i); got != w {
+			t.Fatalf("scrollback[%d] = %q, want %q", i, got, w)
+		}
+	}
+}
+
+// TestMultiLinePrintSplitsIntoRows pins issue #49: a Print carrying
+// embedded newlines must become one scrollback row per line, with
+// lone CR and CRLF treated as line breaks.
+func TestMultiLinePrintSplitsIntoRows(t *testing.T) {
+	m := newBareModel(t)
+
+	next, _ := m.Update(ui.PrintLineMsg("row 1\rrow 2\r\nrow 3"))
+	m = next.(*Model)
+
+	wantScrollback(t, m, "row 1", "row 2", "row 3")
+}
+
+// TestMultiLinePrintSplitsInsideBatchWindow verifies the batched path
+// splits too: a multi-line Print arriving inside an open window lands
+// as individual rows when the tick flushes.
+func TestMultiLinePrintSplitsInsideBatchWindow(t *testing.T) {
+	m := newBareModel(t)
+
+	next, _ := m.Update(ui.PrintLineMsg("first")) // immediate, opens window
+	m = next.(*Model)
+	next, _ = m.Update(ui.PrintLineMsg("row 1\nrow 2")) // batched
+	m = next.(*Model)
+	next, _ = m.Update(tickMsg{})
+	m = next.(*Model)
+
+	wantScrollback(t, m, "first", "row 1", "row 2")
+}
+
+// TestOverlongPrintWordWrapsToWidth pins issue #49: a line wider than
+// the terminal word-wraps into multiple rows at the last space rather
+// than being clipped. The model is 80 columns wide (newBareModel).
+func TestOverlongPrintWordWrapsToWidth(t *testing.T) {
+	m := newBareModel(t)
+
+	head := strings.Repeat("x", 60)
+	tail := strings.Repeat("y", 30)
+	next, _ := m.Update(ui.PrintLineMsg(head + " " + tail))
+	m = next.(*Model)
+
+	wantScrollback(t, m, head, tail)
+}
+
+// TestOverlongUnbreakableWordHardWraps verifies a single word wider
+// than the terminal is broken at the width rather than clipped.
+func TestOverlongUnbreakableWordHardWraps(t *testing.T) {
+	m := newBareModel(t)
+
+	next, _ := m.Update(ui.EchoLineMsg(strings.Repeat("z", 100)))
+	m = next.(*Model)
+
+	wantScrollback(t, m, strings.Repeat("z", 80), strings.Repeat("z", 20))
+}
+
+// TestMultiLineEchoSplitsIntoRows verifies the echo path splits like
+// Print, and that tab columns restart on each row rather than carrying
+// across the whole message.
+func TestMultiLineEchoSplitsIntoRows(t *testing.T) {
+	m := newBareModel(t)
+
+	next, _ := m.Update(ui.EchoLineMsg("> dump\na\tb"))
+	m = next.(*Model)
+
+	wantScrollback(t, m, "> dump", "a       b")
+}
+
 func TestEchoExpandsPreservedTabsBeforeScrollback(t *testing.T) {
 	m := newBareModel(t)
 

--- a/ui/tui/util/ansi.go
+++ b/ui/tui/util/ansi.go
@@ -3,6 +3,7 @@ package util
 import (
 	"strings"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/mattn/go-runewidth"
 	"github.com/mmcdole/rune/text"
 )
@@ -10,6 +11,29 @@ import (
 // VisibleLen returns the visible display width of a string (excluding ANSI codes).
 func VisibleLen(s string) int {
 	return runewidth.StringWidth(text.StripANSI(s))
+}
+
+// SplitLines splits text into lines, treating lone CR and CRLF as
+// line breaks.
+func SplitLines(s string) []string {
+	if !strings.ContainsAny(s, "\r\n") {
+		return []string{s}
+	}
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return strings.Split(s, "\n")
+}
+
+// WrapLine soft-wraps one line into rows of at most width columns,
+// returning at least one row. ANSI codes and wide runes are handled. A
+// line that fits, or a width below 1, passes through unchanged. The
+// byte-length check is a fast bound: a rune's display width never
+// exceeds its byte count.
+func WrapLine(line string, width int) []string {
+	if width < 1 || len(line) <= width || VisibleLen(line) <= width {
+		return []string{line}
+	}
+	return strings.Split(ansi.Wrap(line, width, ""), "\n")
 }
 
 // FilterClearSequences removes ANSI sequences that would clear the screen.

--- a/ui/tui/util/ansi_test.go
+++ b/ui/tui/util/ansi_test.go
@@ -1,6 +1,9 @@
 package util
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestExpandTabs(t *testing.T) {
 	tests := []struct {
@@ -26,4 +29,65 @@ func TestExpandTabs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSplitLines(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []string
+	}{
+		{"Single", "abc", []string{"abc"}},
+		{"LF", "a\nb", []string{"a", "b"}},
+		{"CRLF", "a\r\nb", []string{"a", "b"}},
+		{"LoneCR", "a\rb", []string{"a", "b"}},
+		{"Mixed", "a\rb\r\nc\nd", []string{"a", "b", "c", "d"}},
+		{"TrailingLF", "a\n", []string{"a", ""}},
+		{"Empty", "", []string{""}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SplitLines(tt.in); !slices.Equal(got, tt.want) {
+				t.Errorf("SplitLines(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestWrapLine(t *testing.T) {
+	// 10 visible columns in 19 bytes: the byte-length fast path must
+	// not decide for a styled line, only the visible width may.
+	styled := "\x1b[31mxxxxxxxxxx\x1b[0m"
+	tests := []struct {
+		name  string
+		line  string
+		width int
+		want  []string
+	}{
+		{"Fits", "abc", 10, []string{"abc"}},
+		{"ExactFit", "abcde", 5, []string{"abcde"}},
+		{"WidthUnknown", "aaaaaaaaaa", 0, []string{"aaaaaaaaaa"}},
+		{"StyledFitsDespiteBytes", styled, 12, []string{styled}},
+		{"WrapsAtSpace", "aaaa bbb", 5, []string{"aaaa", "bbb"}},
+		{"HardBreaksWord", "aaaaaa", 4, []string{"aaaa", "aa"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := WrapLine(tt.line, tt.width); !slices.Equal(got, tt.want) {
+				t.Errorf("WrapLine(%q, %d) = %q, want %q", tt.line, tt.width, got, tt.want)
+			}
+		})
+	}
+
+	t.Run("StyledOverlongWrapsWithinWidth", func(t *testing.T) {
+		rows := WrapLine("\x1b[31maaaa bbb\x1b[0m", 5)
+		if len(rows) != 2 {
+			t.Fatalf("expected 2 rows, got %d: %q", len(rows), rows)
+		}
+		for i, r := range rows {
+			if VisibleLen(r) > 5 {
+				t.Errorf("row %d exceeds width: %q (%d cols)", i, r, VisibleLen(r))
+			}
+		}
+	})
 }

--- a/ui/tui/widget/pane.go
+++ b/ui/tui/widget/pane.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/charmbracelet/x/ansi"
 	"github.com/mmcdole/rune/ui/tui/style"
 	"github.com/mmcdole/rune/ui/tui/util"
 )
@@ -41,18 +40,6 @@ func NewPane(name string, styles style.Styles) *Pane {
 	}
 }
 
-// wrapLine soft-wraps one logical line to the given width, returning
-// at least one row. ANSI codes and wide runes are handled.
-func wrapLine(line string, width int) []string {
-	if width < 1 {
-		width = 1
-	}
-	if util.VisibleLen(line) <= width {
-		return []string{line}
-	}
-	return strings.Split(ansi.Wrap(line, width, ""), "\n")
-}
-
 // visibleRows renders exactly p.height rows of wrapped content for the
 // current scroll position. The window is anchored at the logical line
 // end = len(Lines)-offset; when a deep scroll leaves it underfull, it
@@ -65,14 +52,14 @@ func (p *Pane) visibleRows() []string {
 
 	var rows []string
 	for i := end - 1; i >= 0 && len(rows) < p.height; i-- {
-		rows = append(wrapLine(p.Lines[i], p.width), rows...)
+		rows = append(util.WrapLine(p.Lines[i], p.width), rows...)
 	}
 
 	if len(rows) >= p.height {
 		rows = rows[len(rows)-p.height:]
 	} else {
 		for i := end; i < len(p.Lines) && len(rows) < p.height; i++ {
-			rows = append(rows, wrapLine(p.Lines[i], p.width)...)
+			rows = append(rows, util.WrapLine(p.Lines[i], p.width)...)
 		}
 		if len(rows) > p.height {
 			rows = rows[:p.height]
@@ -136,14 +123,17 @@ func (p *Pane) PreferredHeight() int {
 	return p.height + 2 // content + header + border
 }
 
-// Write appends a line to the pane. While scrolled, the view stays
-// anchored on the same history (the offset grows with the buffer) and
-// the new line is counted for the header indicator.
+// Write appends text as logical lines, one per line break. While
+// scrolled, the view stays anchored on the same history (the offset
+// grows with the buffer) and new lines are counted for the header
+// indicator.
 func (p *Pane) Write(text string) {
-	p.Lines = append(p.Lines, util.ExpandTabs(text))
-	if p.offset > 0 {
-		p.offset++
-		p.newLines++
+	for _, line := range util.SplitLines(text) {
+		p.Lines = append(p.Lines, util.ExpandTabs(line))
+		if p.offset > 0 {
+			p.offset++
+			p.newLines++
+		}
 	}
 	if len(p.Lines) > 1000 {
 		p.Lines = p.Lines[len(p.Lines)-500:]

--- a/ui/tui/widget/pane_test.go
+++ b/ui/tui/widget/pane_test.go
@@ -29,6 +29,48 @@ func contentRows(t *testing.T, p *Pane) []string {
 	return rows[1 : len(rows)-1]
 }
 
+// TestPaneMultilineWriteWhileScrolled verifies a multi-line write
+// counts each segment: the scrolled view stays anchored and the
+// header indicator reflects every new line.
+func TestPaneMultilineWriteWhileScrolled(t *testing.T) {
+	p := newTestPane(t, 40, 2)
+	for i := 1; i <= 6; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+	p.ScrollUp(3)
+	before := contentRows(t, p)
+
+	p.Write("line 7\nline 8")
+
+	after := contentRows(t, p)
+	if before[0] != after[0] || before[1] != after[1] {
+		t.Fatalf("scrolled view moved: before %q, after %q", before, after)
+	}
+	if p.newLines != 2 {
+		t.Fatalf("newLines = %d, want 2", p.newLines)
+	}
+}
+
+// TestPaneMultilineWriteSplitsIntoLines pins issue #49 for panes: a
+// write containing newlines stores one logical line per segment, and
+// the rendered view keeps its budgeted height.
+func TestPaneMultilineWriteSplitsIntoLines(t *testing.T) {
+	p := newTestPane(t, 40, 5)
+	p.Write("a\rb\r\nc\nd")
+
+	if len(p.Lines) != 4 {
+		t.Fatalf("expected 4 logical lines, got %d: %q", len(p.Lines), p.Lines)
+	}
+	for i, line := range p.Lines {
+		if strings.ContainsAny(line, "\r\n") {
+			t.Fatalf("stored line %d contains a line break: %q", i, line)
+		}
+	}
+	if rows := contentRows(t, p); len(rows) != 5 {
+		t.Fatalf("view content height = %d rows, want the budgeted 5", len(rows))
+	}
+}
+
 func TestPaneWrapsLongLines(t *testing.T) {
 	p := newTestPane(t, 20, 4)
 	p.Write("one two three four five six seven")

--- a/ui/tui/widget/viewport.go
+++ b/ui/tui/widget/viewport.go
@@ -29,7 +29,8 @@ const (
 	ModeScrolled
 )
 
-// ScrollbackBuffer is a ring buffer for storing terminal output lines.
+// ScrollbackBuffer is a ring buffer of physical rows of terminal
+// output; each entry renders as exactly one row.
 type ScrollbackBuffer struct {
 	lines    []string
 	head     int
@@ -49,9 +50,9 @@ func NewScrollbackBuffer(capacity int) *ScrollbackBuffer {
 	}
 }
 
-// Append adds a line to the buffer.
-func (sb *ScrollbackBuffer) Append(line string) {
-	sb.lines[sb.tail] = line
+// Append adds a row to the buffer.
+func (sb *ScrollbackBuffer) Append(row string) {
+	sb.lines[sb.tail] = row
 	sb.tail = (sb.tail + 1) % sb.capacity
 
 	if sb.count < sb.capacity {
@@ -61,12 +62,12 @@ func (sb *ScrollbackBuffer) Append(line string) {
 	}
 }
 
-// Count returns the number of lines.
+// Count returns the number of rows.
 func (sb *ScrollbackBuffer) Count() int {
 	return sb.count
 }
 
-// At retrieves a line by logical index (0 = oldest).
+// At retrieves a row by index (0 = oldest).
 func (sb *ScrollbackBuffer) At(i int) string {
 	if i < 0 || i >= sb.count {
 		return ""
@@ -186,8 +187,8 @@ func (v *Viewport) PreferredHeight() int {
 	return v.height
 }
 
-// OnNewLines is called when lines are added.
-func (v *Viewport) OnNewLines(count int) {
+// OnNewRows is called when rows are appended to the buffer.
+func (v *Viewport) OnNewRows(count int) {
 	switch v.mode {
 	case ModeLive:
 		v.cacheValid = false

--- a/ui/tui/widget/viewport_test.go
+++ b/ui/tui/widget/viewport_test.go
@@ -14,7 +14,7 @@ func newTestViewport(width, height int, lines ...string) (*Viewport, *Scrollback
 	v.SetSize(width, height)
 	for _, l := range lines {
 		buf.Append(l)
-		v.OnNewLines(1)
+		v.OnNewRows(1)
 	}
 	return v, buf
 }
@@ -91,9 +91,9 @@ func TestViewportScrollAnchorsWhileNewLinesArrive(t *testing.T) {
 	before := viewRows(v)
 
 	buf.Append("seven")
-	v.OnNewLines(1)
+	v.OnNewRows(1)
 	buf.Append("eight")
-	v.OnNewLines(1)
+	v.OnNewRows(1)
 
 	after := viewRows(v)
 	for i := range before {


### PR DESCRIPTION
Multi-line prints and echoes were stored as a single scrollback entry and hard-clipped to the terminal width, so everything past the first row was invisible — e.g. `rune.echo()` of a serialized table dump showed only its first line. Fixes #49.

Scrollback entries are now physical rows, shaped at append time:

- Messages split on line breaks: `\n`, `\r\n`, and lone `\r`.
- Rows wider than the terminal word-wrap at the last space, with a hard break for unbreakable words. Tabs expand per row so columns restart on every line.
- `Pane.Write` splits the same way, so a stored pane line is always newline-free and the rendered pane keeps its budgeted height.
- Both paths share the new `util.SplitLines` and `util.WrapLine` (hoisted from the pane's private wrapper).
- All scrollback producers go through one shaping funnel (`appendMessage`); vocabulary renames (`appendRows`, `pendingRows`, `OnNewRows`) match the physical-row model.

Wrapping happens at append, so a resize doesn't rewrap old output — same tradeoff Mudlet, MUSHclient, and blightmud make (survey in #49). #50 tracks logical-line storage with render-time wrap if reflow is ever wanted.

Tests: ten new — viewport split (immediate + batched paths), word-wrap and hard-break with exact rows, tab-column restart, pane multi-line write (plain and while scrolled), and unit tables for `SplitLines`/`WrapLine` including the styled-line fast-path edge. No e2e scenario: the harness mocks the UI at the `ui.UI` boundary, below where this bug lives, so coverage is pinned at the model/widget/util layers per docs/testing.md.