### PR TITLE
lua: allow the VM registry to grow

### DIFF
--- a/lua/engine.go
+++ b/lua/engine.go
@@ -116,7 +116,18 @@ func (e *Engine) Init() error {
 		e.L.Close()
 	}
 
-	e.L = glua.NewState()
+	// The registry (data stack) must be able to grow: table.concat
+	// pushes every element before joining, so serializing a large
+	// table needs slots proportional to its entry count. The ceiling
+	// bounds runaway scripts (~16 MB, allocated only on demand) and
+	// exhausting it raises the same catchable "registry overflow" a
+	// fixed-size registry would. Growth is linear, so a small step
+	// would mean thousands of realloc+copy cycles on a big concat.
+	e.L = glua.NewState(glua.Options{
+		RegistrySize:     1024 * 20,
+		RegistryMaxSize:  1024 * 1024,
+		RegistryGrowStep: 4096,
+	})
 
 	e.host.TimerCancelAll()
 

--- a/lua/engine_test.go
+++ b/lua/engine_test.go
@@ -674,3 +674,23 @@ func TestPickerShowPassesOptions(t *testing.T) {
 		t.Errorf("expected dismiss_on_space to default to false, got %+v", host.PickerCalls[1])
 	}
 }
+
+// TestRegistryGrowsForLargeConcat verifies the VM can serialize large
+// tables. gopher-lua's table.concat pushes every element onto the data
+// stack before joining, so a fixed-size registry fails on tables past a
+// few thousand entries (e.g. CBOR-encoding a mob database) even though
+// building or decoding the same table works fine.
+func TestRegistryGrowsForLargeConcat(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	err := engine.DoString("bigconcat", `
+		local t = {}
+		for i = 1, 20000 do t[i] = "chunk_" .. i end
+		local blob = table.concat(t)
+		assert(#blob > 0)
+	`)
+	if err != nil {
+		t.Fatalf("large table.concat failed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #52.

gopher-lua creates its data stack (the "registry") with a fixed 5120 slots by default, and growth is disabled. Any single operation that needs more slots fails with `registry overflow` no matter how much memory is available. `table.concat` pushes every element onto the stack before joining, so serializing a table past ~2500 entries — e.g. CBOR-encoding a mob database — always failed, while decoding the same data worked because it builds tables incrementally.

This creates the VM with a growable registry:

- initial size 20480 slots (~320 KB)
- growth up to 1M slots (~16 MB ceiling, allocated only on demand, freed on `/reload`)
- grow step 4096: gopher-lua grows linearly, and the default step of 32 causes thousands of realloc+copy cycles on a large concat (316 ms vs 105 ms for a 20k-entry encode)

Exhausting the ceiling raises the same catchable `registry overflow` error and leaves the VM usable, so runaway scripts stay bounded. A 7 MB / 43k-entry CBOR database round-trips with roughly 10x headroom under these settings; the ceiling supports a single concat over ~500k entries.

Includes a regression test that fails against the previous fixed-size registry.