### PR TITLE
network: decode escaped IAC in telnet data

### DIFF
--- a/network/telnet.go
+++ b/network/telnet.go
@@ -383,13 +383,37 @@ type parsedSlice struct {
 func (p *Parser) process() []TelnetEvent {
 	var out []TelnetEvent
 	events := p.extract()
-	for _, ev := range events {
+	for i := 0; i < len(events); {
+		ev := events[i]
+		if ev.kind == evNone {
+			end := i + 1
+			total := len(ev.buf)
+			for end < len(events) && events[end].kind == evNone {
+				total += len(events[end].buf)
+				end++
+			}
+
+			data := ev.buf
+			if end > i+1 {
+				data = make([]byte, 0, total)
+				for _, part := range events[i:end] {
+					data = append(data, part.buf...)
+				}
+			}
+			if len(data) > 0 {
+				out = append(out, TelnetEvent{Kind: TelnetEventDataReceive, Data: data})
+			}
+			i = end
+			continue
+		}
+
 		switch ev.kind {
-		case evNone, evIAC, evNeg:
+		case evIAC, evNeg:
 			out = append(out, p.processCommand(ev.buf)...)
 		case evSub:
 			out = append(out, p.processSub(ev.buf, ev.remaining)...)
 		}
+		i++
 	}
 	return out
 }
@@ -426,8 +450,10 @@ func (p *Parser) extract() []parsedSlice {
 		case stateIAC:
 			switch val {
 			case CmdIAC:
-				// Double IAC = escaped literal 255, not a command
+				// Double IAC encodes one literal 255 data byte.
+				res = append(res, parsedSlice{kind: evNone, buf: buf[cmdBegin:i]})
 				state = stateNormal
+				cmdBegin = i + 1
 			case CmdGA, CmdEOR, CmdNOP:
 				res = append(res, parsedSlice{kind: evIAC, buf: buf[cmdBegin : i+1]})
 				state = stateNormal

--- a/network/telnet_test.go
+++ b/network/telnet_test.go
@@ -663,19 +663,59 @@ func TestLinemodeEnabled(t *testing.T) {
 }
 
 func TestDoubleIACInData(t *testing.T) {
+	tests := []struct {
+		name string
+		wire []byte
+		want []byte
+	}{
+		{
+			name: "middle of data",
+			wire: append(append([]byte("Hello"), CmdIAC, CmdIAC), []byte("World")...),
+			want: append(append([]byte("Hello"), CmdIAC), []byte("World")...),
+		},
+		{
+			name: "three byte input is not negotiation",
+			wire: []byte{CmdIAC, CmdIAC, OptEcho},
+			want: []byte{CmdIAC, OptEcho},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := NewParserDefault()
+			events := parser.Receive(tt.wire)
+			if len(events) != 1 {
+				t.Fatalf("events = %+v, want one data event", events)
+			}
+			if events[0].Kind != TelnetEventDataReceive {
+				t.Fatalf("event kind = %v, want DataReceive", events[0].Kind)
+			}
+			if !bytes.Equal(events[0].Data, tt.want) {
+				t.Errorf("data = %v, want %v", events[0].Data, tt.want)
+			}
+		})
+	}
+}
+
+func TestDoubleIACSplitAcrossReceives(t *testing.T) {
 	parser := NewParserDefault()
 
-	// Data with escaped IAC: "Hello\xff\xffWorld"
-	events := parser.Receive([]byte{72, 101, 108, 108, 111, 255, 255, 87, 111, 114, 108, 100})
+	events := parser.Receive(append([]byte("Hello"), CmdIAC))
+	if len(events) != 1 || events[0].Kind != TelnetEventDataReceive || string(events[0].Data) != "Hello" {
+		t.Fatalf("first receive events = %+v, want data Hello", events)
+	}
 
+	events = parser.Receive(append([]byte{CmdIAC}, []byte("World")...))
+	want := append([]byte{CmdIAC}, []byte("World")...)
 	if len(events) != 1 {
-		t.Fatalf("Expected 1 event, got %d: %+v", len(events), events)
+		t.Fatalf("second receive events = %+v, want one data event", events)
 	}
 	if events[0].Kind != TelnetEventDataReceive {
-		t.Errorf("Expected DataReceive, got %v", events[0].Kind)
+		t.Fatalf("event kind = %v, want DataReceive", events[0].Kind)
 	}
-	// The doubled IAC in data stream should pass through as-is in raw form
-	// (unescaping happens in subnegotiation payloads, not raw data)
+	if !bytes.Equal(events[0].Data, want) {
+		t.Errorf("data = %v, want %v", events[0].Data, want)
+	}
 }
 
 func TestIncompleteIAC(t *testing.T) {


### PR DESCRIPTION
## Summary

- Decode `IAC IAC` as one literal `0xFF` in normal Telnet data.
- Preserve adjacent data without treating short payloads as negotiation.
- Add byte-exact tests for same-read and split-read input.

## Validation

- `go test ./...`
- `go vet ./...`

Closes #54