### PR TITLE
input: use byte offsets for Lua input cursors

### DIFF
--- a/input/cursor.go
+++ b/input/cursor.go
@@ -1,0 +1,38 @@
+package input
+
+import "unicode/utf8"
+
+// ClampByteCursor clamps pos to text and snaps it to a UTF-8 rune boundary.
+func ClampByteCursor(text string, pos int) int {
+	if pos < 0 {
+		return 0
+	}
+	if pos > len(text) {
+		return len(text)
+	}
+	for pos > 0 && pos < len(text) && !utf8.RuneStart(text[pos]) {
+		pos--
+	}
+	return pos
+}
+
+// RuneCursorToByte converts a zero-based rune offset to a byte offset.
+func RuneCursorToByte(text string, pos int) int {
+	if pos <= 0 {
+		return 0
+	}
+	for bytePos := range text {
+		if pos == 0 {
+			return bytePos
+		}
+		pos--
+	}
+	return len(text)
+}
+
+// ByteCursorToRune converts a zero-based byte offset to a rune offset.
+// Positions inside a UTF-8 sequence snap to the preceding rune boundary.
+func ByteCursorToRune(text string, pos int) int {
+	pos = ClampByteCursor(text, pos)
+	return utf8.RuneCountInString(text[:pos])
+}

--- a/input/cursor_test.go
+++ b/input/cursor_test.go
@@ -1,0 +1,66 @@
+package input
+
+import "testing"
+
+func TestClampByteCursor(t *testing.T) {
+	text := "café"
+	tests := []struct {
+		pos  int
+		want int
+	}{
+		{-1, 0},
+		{0, 0},
+		{3, 3},
+		{4, 3},
+		{5, 5},
+		{6, 5},
+	}
+
+	for _, tt := range tests {
+		if got := ClampByteCursor(text, tt.pos); got != tt.want {
+			t.Errorf("ClampByteCursor(%q, %d) = %d, want %d", text, tt.pos, got, tt.want)
+		}
+	}
+}
+
+func TestRuneCursorToByte(t *testing.T) {
+	text := "café"
+	tests := []struct {
+		pos  int
+		want int
+	}{
+		{-1, 0},
+		{0, 0},
+		{1, 1},
+		{3, 3},
+		{4, 5},
+		{5, 5},
+	}
+
+	for _, tt := range tests {
+		if got := RuneCursorToByte(text, tt.pos); got != tt.want {
+			t.Errorf("RuneCursorToByte(%q, %d) = %d, want %d", text, tt.pos, got, tt.want)
+		}
+	}
+}
+
+func TestByteCursorToRune(t *testing.T) {
+	text := "café"
+	tests := []struct {
+		pos  int
+		want int
+	}{
+		{-1, 0},
+		{0, 0},
+		{3, 3},
+		{4, 3},
+		{5, 4},
+		{6, 4},
+	}
+
+	for _, tt := range tests {
+		if got := ByteCursorToRune(text, tt.pos); got != tt.want {
+			t.Errorf("ByteCursorToRune(%q, %d) = %d, want %d", text, tt.pos, got, tt.want)
+		}
+	}
+}

--- a/lua/core/90_input.lua
+++ b/lua/core/90_input.lua
@@ -199,7 +199,7 @@ rune.history_nav = {
 
 -- ============================================================
 -- WORD NAVIGATION & EDITING
--- Logic in Lua, cursor control via Go primitives
+-- Cursor positions are UTF-8 byte offsets, matching Lua string operations.
 -- ============================================================
 
 -- Find previous word boundary

--- a/lua/host.go
+++ b/lua/host.go
@@ -40,6 +40,7 @@ type Host interface {
 	SetInputSubmission(submission input.Submission)
 
 	// Input primitives
+	// Cursor positions are zero-based UTF-8 byte offsets.
 	InputGetCursor() int
 	InputSetCursor(pos int)
 	OpenEditor(initial string) (string, bool)

--- a/lua/input_test.go
+++ b/lua/input_test.go
@@ -237,6 +237,35 @@ func TestWordNavigationAndDelete(t *testing.T) {
 	assertCursor(t, host, 12)
 }
 
+func TestWordNavigationAndDeleteWithMultibyteInput(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	host.SetInput("café brave world")
+
+	if err := engine.DoString("test", "rune.input.word_left()"); err != nil {
+		t.Fatal(err)
+	}
+	assertCursor(t, host, 12)
+
+	if err := engine.DoString("test", "rune.input.word_left()"); err != nil {
+		t.Fatal(err)
+	}
+	assertCursor(t, host, 6)
+
+	if err := engine.DoString("test", "rune.input.word_right()"); err != nil {
+		t.Fatal(err)
+	}
+	assertCursor(t, host, 12)
+
+	host.InputSetCursor(len("café brave world"))
+	if err := engine.DoString("test", "rune.input.delete_word()"); err != nil {
+		t.Fatal(err)
+	}
+	assertInput(t, host, "café brave ")
+	assertCursor(t, host, 12)
+}
+
 func TestClearInputBinds(t *testing.T) {
 	engine, host, cleanup := setupTest(t)
 	defer cleanup()
@@ -376,4 +405,19 @@ func TestCompletionMidLineInsertsWithoutTrailingSpace(t *testing.T) {
 	// Mid-line completions get no trailing space.
 	assertInput(t, host, "kill goblin now")
 	assertCursor(t, host, 11)
+}
+
+func TestCompletionMidLineWithMultibyteInput(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	engine.OnOutput(text.NewLine("goblin"))
+
+	host.SetInput("café gob now")
+	host.InputSetCursor(len("café gob"))
+	engine.CallHook("input_changed", host.GetInput())
+
+	engine.HandleKeyBind("tab")
+	assertInput(t, host, "café goblin now")
+	assertCursor(t, host, len("café goblin"))
 }

--- a/lua/mock_host_input_test.go
+++ b/lua/mock_host_input_test.go
@@ -33,3 +33,22 @@ func TestMockSetInputUsesVerbatimAdmissionAndStickyReset(t *testing.T) {
 		t.Fatalf("cleared input mode = %s, want command", host.InputMode)
 	}
 }
+
+func TestMockHostInputCursorUsesByteBoundaries(t *testing.T) {
+	host := &MockHost{InputText: "café"}
+
+	host.InputSetCursor(4)
+	if got, want := host.InputGetCursor(), 3; got != want {
+		t.Fatalf("cursor inside UTF-8 sequence = %d, want %d", got, want)
+	}
+
+	host.InputSetCursor(6)
+	if got, want := host.InputGetCursor(), len("café"); got != want {
+		t.Fatalf("cursor beyond input = %d, want %d", got, want)
+	}
+
+	host.InputSetCursor(-1)
+	if got := host.InputGetCursor(); got != 0 {
+		t.Fatalf("negative cursor = %d, want 0", got)
+	}
+}

--- a/lua/mock_host_test.go
+++ b/lua/mock_host_test.go
@@ -357,13 +357,7 @@ func (m *MockHost) InputGetCursor() int {
 func (m *MockHost) InputSetCursor(pos int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if pos < 0 {
-		pos = 0
-	}
-	if pos > len(m.InputText) {
-		pos = len(m.InputText)
-	}
-	m.InputCursor = pos
+	m.InputCursor = input.ClampByteCursor(m.InputText, pos)
 }
 
 func (m *MockHost) OpenEditor(initial string) (string, bool) {

--- a/session/lua_ui.go
+++ b/session/lua_ui.go
@@ -1,8 +1,6 @@
 package session
 
 import (
-	"unicode/utf8"
-
 	"github.com/mmcdole/rune/input"
 	"github.com/mmcdole/rune/ui"
 )
@@ -56,7 +54,7 @@ func (s *Session) GetInput() string {
 func (s *Session) SetInput(text string) {
 	s.ui.SetInput(text)
 	s.currentInput = text
-	s.currentCursor = utf8.RuneCountInString(text)
+	s.currentCursor = len(text)
 }
 
 // SetInputSubmission implements lua.Host. History recall uses it to restore
@@ -65,7 +63,7 @@ func (s *Session) SetInput(text string) {
 func (s *Session) SetInputSubmission(submission input.Submission) {
 	s.ui.SetInputSubmission(submission)
 	s.currentInput = submission.Text
-	s.currentCursor = utf8.RuneCountInString(submission.Text)
+	s.currentCursor = len(submission.Text)
 }
 
 // InputGetCursor implements lua.Host.
@@ -73,19 +71,12 @@ func (s *Session) InputGetCursor() int {
 	return s.currentCursor
 }
 
-// InputSetCursor implements lua.Host.
-// The position is clamped to the current input's rune count here, so
-// the mirror Lua reads via rune.input.get_cursor() cannot drift from
-// what the input widget (which clamps independently) will display.
+// InputSetCursor implements lua.Host. Lua supplies a UTF-8 byte offset;
+// the input widget expects a rune offset.
 func (s *Session) InputSetCursor(pos int) {
-	if pos < 0 {
-		pos = 0
-	}
-	if max := utf8.RuneCountInString(s.currentInput); pos > max {
-		pos = max
-	}
+	pos = input.ClampByteCursor(s.currentInput, pos)
 	s.currentCursor = pos
-	s.ui.InputSetCursor(pos)
+	s.ui.InputSetCursor(input.ByteCursorToRune(s.currentInput, pos))
 }
 
 // OpenEditor implements lua.Host.

--- a/session/mocks_test.go
+++ b/session/mocks_test.go
@@ -116,6 +116,7 @@ type mockUI struct {
 	prompts     []string // every SetPrompt call, including clears
 	inputSet    []string
 	inputModes  []input.Submission
+	inputCursor []int
 	bindsPushed map[string]bool // last UpdateBinds payload
 	input       chan input.Submission
 	outbound    chan ui.UIEvent
@@ -196,7 +197,11 @@ func (m *mockUI) TogglePane(name string)                   {}
 func (m *mockUI) SetPaneVisible(name string, visible bool) {}
 func (m *mockUI) ClearPane(name string)                    {}
 
-func (m *mockUI) InputSetCursor(pos int)                   {}
+func (m *mockUI) InputSetCursor(pos int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.inputCursor = append(m.inputCursor, pos)
+}
 func (m *mockUI) OpenEditor(initial string) (string, bool) { return "", false }
 
 func (m *mockUI) PaneScrollUp(name string, lines int)   {}

--- a/session/session.go
+++ b/session/session.go
@@ -87,7 +87,7 @@ type Session struct {
 	config        Config
 	clientState   lua.ClientState
 	currentInput  string // Tracked so Lua can query via rune.input.get()
-	currentCursor int    // Tracked so Lua can query via rune.input.get_cursor()
+	currentCursor int    // Zero-based UTF-8 byte offset exposed to Lua
 }
 
 // New creates a new Session. It is passive - no goroutines start here.
@@ -427,10 +427,10 @@ func (s *Session) handleUIMessage(msg ui.UIEvent) {
 		s.handlePickerResult(m.CallbackID, m.Value, m.Accepted)
 	case ui.InputChangedMsg:
 		s.currentInput = m.Text
-		s.currentCursor = m.Cursor
+		s.currentCursor = input.RuneCursorToByte(m.Text, m.Cursor)
 		s.engine.CallHook("input_changed", m.Text)
 	case ui.CursorMovedMsg:
-		s.currentCursor = m.Cursor
+		s.currentCursor = input.RuneCursorToByte(s.currentInput, m.Cursor)
 		// No Lua hook - cursor-only changes don't need Lua processing
 	}
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mmcdole/rune/input"
 	"github.com/mmcdole/rune/lua"
 	runetext "github.com/mmcdole/rune/text"
+	"github.com/mmcdole/rune/ui"
 )
 
 // newTestSession boots a Session against mocks with the real embedded
@@ -225,7 +226,7 @@ func TestHistoryPreservesModeAndDedupesWholeSubmission(t *testing.T) {
 
 func TestSetInputSubmissionForwardsExplicitMode(t *testing.T) {
 	s, _, uiMock := newTestSession(t)
-	want := input.Verbatim("one line;still data")
+	want := input.Verbatim("café;still data")
 
 	s.SetInputSubmission(want)
 
@@ -235,8 +236,35 @@ func TestSetInputSubmissionForwardsExplicitMode(t *testing.T) {
 	if got := s.GetInput(); got != want.Text {
 		t.Fatalf("Session input mirror = %q, want %q", got, want.Text)
 	}
-	if got, wantCursor := s.InputGetCursor(), len([]rune(want.Text)); got != wantCursor {
+	if got, wantCursor := s.InputGetCursor(), len(want.Text); got != wantCursor {
 		t.Fatalf("Session cursor mirror = %d, want %d", got, wantCursor)
+	}
+}
+
+func TestInputCursorConvertsAtUIBoundary(t *testing.T) {
+	s, _, uiMock := newTestSession(t)
+
+	s.handleUIMessage(ui.InputChangedMsg{Text: "café gob", Cursor: 8})
+	if got, want := s.InputGetCursor(), len("café gob"); got != want {
+		t.Fatalf("cursor after input change = %d, want %d", got, want)
+	}
+
+	s.handleUIMessage(ui.CursorMovedMsg{Cursor: 4})
+	if got, want := s.InputGetCursor(), len("café"); got != want {
+		t.Fatalf("cursor after UI move = %d, want %d", got, want)
+	}
+
+	s.InputSetCursor(4)
+	if got, want := s.InputGetCursor(), 3; got != want {
+		t.Fatalf("cursor inside UTF-8 sequence = %d, want %d", got, want)
+	}
+	if got, want := uiMock.inputCursor[len(uiMock.inputCursor)-1], 3; got != want {
+		t.Fatalf("widget cursor = %d, want %d", got, want)
+	}
+
+	s.InputSetCursor(len("café"))
+	if got, want := uiMock.inputCursor[len(uiMock.inputCursor)-1], 4; got != want {
+		t.Fatalf("widget cursor after multibyte text = %d, want %d", got, want)
 	}
 }
 

--- a/ui/interface.go
+++ b/ui/interface.go
@@ -31,7 +31,7 @@ type UI interface {
 	SetPaneVisible(name string, visible bool)
 	ClearPane(name string)
 
-	// Input primitives for Lua
+	// Input primitives. Cursor positions are zero-based rune offsets.
 	InputSetCursor(pos int)
 	OpenEditor(initial string) (string, bool)
 

--- a/ui/messages.go
+++ b/ui/messages.go
@@ -90,8 +90,8 @@ type ScrollStateChangedMsg struct {
 
 func (ScrollStateChangedMsg) uiEvent() {}
 
-// InputChangedMsg notifies Session of input content changes.
-// Session tracks this so Lua can query current input via rune.input.get().
+// InputChangedMsg notifies Session of input content changes. Cursor is a
+// zero-based rune offset from the input widget.
 type InputChangedMsg struct {
 	Text   string
 	Cursor int
@@ -99,8 +99,8 @@ type InputChangedMsg struct {
 
 func (InputChangedMsg) uiEvent() {}
 
-// CursorMovedMsg notifies Session of cursor position changes (without text change).
-// This allows tracking cursor for Lua without triggering input_changed hooks.
+// CursorMovedMsg notifies Session of cursor position changes without a text
+// change. Cursor is a zero-based rune offset from the input widget.
 type CursorMovedMsg struct {
 	Cursor int
 }
@@ -150,7 +150,7 @@ func (PickerSelectMsg) uiEvent() {}
 
 // --- Input Primitive Messages (Session -> UI) ---
 
-// InputSetCursorMsg sets the cursor position.
+// InputSetCursorMsg sets the widget cursor to a zero-based rune offset.
 type InputSetCursorMsg int
 
 // --- Pane Scrolling Messages (Session -> UI) ---

--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -194,7 +194,7 @@ func (b *BubbleTeaUI) SetInputSubmission(submission input.Submission) {
 
 // --- Input Primitives for Lua ---
 
-// InputSetCursor sets the cursor position.
+// InputSetCursor sets the widget cursor to a zero-based rune offset.
 func (b *BubbleTeaUI) InputSetCursor(pos int) {
 	b.send(ui.InputSetCursorMsg(pos))
 }

--- a/website/src/content/docs/reference/api/input.md
+++ b/website/src/content/docs/reference/api/input.md
@@ -13,8 +13,8 @@ keys, the multiline composer, history navigation, and tab completion), see
 ```lua
 rune.input.get()                  -- current input text
 rune.input.set(text)              -- replace the input text
-rune.input.get_cursor()           -- cursor position (clamped to input length)
-rune.input.set_cursor(pos)        -- move the cursor
+rune.input.get_cursor()           -- zero-based UTF-8 byte offset
+rune.input.set_cursor(pos)        -- move to a UTF-8 byte offset
 rune.input.open_editor(initial?)  -- edit in $EDITOR; returns edited_text, ok
 rune.input.word_left()            -- move cursor to the previous word boundary
 rune.input.word_right()           -- move cursor to the next word boundary
@@ -25,6 +25,11 @@ rune.input.delete_word()          -- delete the word before the cursor
 them with cursor moves and are what the default `ctrl+w`,
 `alt+left`/`alt+right` binds call. Setting the input fires the
 `"input_changed"` [hook event](/reference/api/hooks/), same as typing.
+
+Cursor positions are zero-based UTF-8 byte offsets, using the same byte units
+as Lua 5.1 string operations. `set_cursor` clamps positions to the input and
+snaps an offset inside a multibyte sequence to the preceding UTF-8 code point
+boundary.
 
 Setting text containing a newline, tab, or terminal control byte activates the
 visible verbatim composer. Once active, replacing the draft with one non-empty


### PR DESCRIPTION
## Summary

- Define Lua input cursor positions as UTF-8 byte offsets.
- Convert byte and rune offsets at the UI boundary.
- Clamp invalid offsets and add multibyte regression tests.
- Document the cursor unit.

## Validation

- go test ./...
- go vet ./...
- Headless TUI: Ctrl+W on café brave world produced café brave

Closes #56