### PR TITLE
tui: give Home/End to the input cursor; scroll on Ctrl+Home/Ctrl+End

### DIFF
--- a/lua/core/95_ui.lua
+++ b/lua/core/95_ui.lua
@@ -66,8 +66,10 @@ end
 
 rune.bind("pageup", function() rune.pane.scroll_up("main", 20) end)
 rune.bind("pagedown", function() rune.pane.scroll_down("main", 20) end)
-rune.bind("home", function() rune.pane.scroll_to_top("main") end)
-rune.bind("end", function() rune.pane.scroll_to_bottom("main") end)
+-- Bare Home/End are deliberately unbound: they fall through to the
+-- input widget as cursor-to-start/end, matching the composer's keymap.
+rune.bind("ctrl+home", function() rune.pane.scroll_to_top("main") end)
+rune.bind("ctrl+end", function() rune.pane.scroll_to_bottom("main") end)
 
 -- ============================================================
 -- STATUS BAR

--- a/ui/tui/input_mode_test.go
+++ b/ui/tui/input_mode_test.go
@@ -587,3 +587,22 @@ func TestInlineTabReportsCompletedInput(t *testing.T) {
 		t.Fatalf("expected input %q after completion, got %q", "/connect ", got)
 	}
 }
+
+// TestReboundHomeOverridesInputCursor pins the override path the docs
+// promise: a user bind on "home" wins over the widget's cursor
+// movement even while a draft is in progress (non-printable bound keys
+// are never gated on empty input).
+func TestReboundHomeOverridesInputCursor(t *testing.T) {
+	h := newControllerHarness()
+	h.bound["home"] = true
+
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("look")})
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyHome})
+
+	if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("home") {
+		t.Fatalf("expected one home bind dispatch, got %v", binds)
+	}
+	if pos := h.ctl.input.Position(); pos != len("look") {
+		t.Fatalf("bound home moved the cursor to %d, want untouched at %d", pos, len("look"))
+	}
+}

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -422,9 +422,9 @@ func (m *Model) handleScrollKey(keyType tea.KeyType) bool {
 		m.viewport.PageUp()
 	case tea.KeyPgDown:
 		m.viewport.PageDown()
-	case tea.KeyHome:
+	case tea.KeyCtrlHome:
 		m.viewport.GotoTop()
-	case tea.KeyEnd:
+	case tea.KeyCtrlEnd:
 		m.viewport.GotoBottom()
 	default:
 		return false

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -521,3 +521,48 @@ func TestPrintedTabsAreExpanded(t *testing.T) {
 		t.Errorf("prompt = %q, want tab expanded", got)
 	}
 }
+
+// TestHomeEndEditInputWhileCtrlVariantsScroll pins the default key
+// split: with no binds registered, bare Home/End fall through to the
+// input widget as cursor movement, while Ctrl+Home/Ctrl+End hit the Go
+// scroll fallback (the path that keeps degraded mode navigable).
+func TestHomeEndEditInputWhileCtrlVariantsScroll(t *testing.T) {
+	m := newTestModel(t)
+
+	typed := "say hello"
+	next, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(typed)})
+	m = next.(*Model)
+
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyHome})
+	m = next.(*Model)
+	if m.viewport.Mode() != widget.ModeLive {
+		t.Fatal("Home scrolled the viewport instead of reaching the input")
+	}
+	if pos := m.inputCtl.input.Position(); pos != 0 {
+		t.Fatalf("Home left cursor at %d, want 0", pos)
+	}
+
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	m = next.(*Model)
+	if m.viewport.Mode() != widget.ModeLive {
+		t.Fatal("End scrolled the viewport instead of reaching the input")
+	}
+	if pos := m.inputCtl.input.Position(); pos != len(typed) {
+		t.Fatalf("End left cursor at %d, want %d", pos, len(typed))
+	}
+
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlHome})
+	m = next.(*Model)
+	if m.viewport.Mode() == widget.ModeLive {
+		t.Fatal("Ctrl+Home did not scroll the viewport to the top")
+	}
+
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlEnd})
+	m = next.(*Model)
+	if m.viewport.Mode() != widget.ModeLive {
+		t.Fatal("Ctrl+End did not return the viewport to live")
+	}
+	if got := m.inputCtl.input.Value(); got != typed {
+		t.Fatalf("input draft = %q, want %q", got, typed)
+	}
+}

--- a/website/src/content/docs/interface/input.md
+++ b/website/src/content/docs/interface/input.md
@@ -19,6 +19,7 @@ separators, `#N` repeats, and `/commands` all work here.
 | `Escape` | Clear the input line |
 | `Ctrl+W`, `Alt+Backspace` | Delete the word before the cursor |
 | `Alt+Left`/`Alt+Right`, `Ctrl+Left`/`Ctrl+Right` | Move the cursor by word |
+| `Home`/`End` | Move the cursor to the start/end of the line |
 | `Ctrl+C` | Clear the input line; pressed twice on an empty line, quit |
 
 (Most terminals send `Ctrl+Backspace` as `Ctrl+H`, so it can't be bound
@@ -102,8 +103,9 @@ inserts a tab instead.
 
 ## Scrolling and the mouse
 
-`PageUp`/`PageDown` scroll the output viewport; `Home`/`End` jump to the top and
-bottom. The mouse wheel scrolls too. While you're off the bottom, the status
+`PageUp`/`PageDown` scroll the output viewport; `Ctrl+Home`/`Ctrl+End` jump to
+the top and bottom (`Home`/`End` stay on the input line — rebind them if you
+prefer they scroll). The mouse wheel scrolls too. While you're off the bottom, the status
 bar shows `SCROLL (n new)` so you know what's piling up, and it returns to
 `LIVE` when you catch up. Composer mode uses those keyboard navigation keys
 for the draft; the mouse wheel still scrolls output.

--- a/website/src/content/docs/interface/panes.md
+++ b/website/src/content/docs/interface/panes.md
@@ -31,7 +31,7 @@ soft-wrap, and re-fit when the terminal resizes.
 ## Scrolling
 
 Every pane scrolls its own buffer; the special name `"main"` is the
-output viewport (that's what the default PageUp/PageDown/Home/End
+output viewport (that's what the default PageUp/PageDown/Ctrl+Home/Ctrl+End
 binds target). Aim a pane with binds of your own:
 
 ```lua

--- a/website/src/content/docs/reference/api/bind.md
+++ b/website/src/content/docs/reference/api/bind.md
@@ -72,7 +72,15 @@ All defaults are registered by the Lua core and are rebindable:
 | `tab` / `shift+tab` | Completion cycling |
 | `ctrl+e` | Edit input in `$EDITOR` |
 | `pageup` / `pagedown` | Scroll output viewport |
-| `home` / `end` | Jump to top/bottom of output |
+| `ctrl+home` / `ctrl+end` | Jump to top/bottom of output |
+
+Bare `home` / `end` are deliberately not bound: they move the input
+cursor to the start or end of the line, the same keymap the composer
+uses. Binding them replaces that cursor movement with your callback —
+`rune.bind("end", function() rune.pane.scroll_to_bottom("main") end)`
+puts the scroll jump back on `end`, useful when your terminal cannot
+send distinct `ctrl+home` / `ctrl+end` (tmux without `xterm-keys`,
+macOS Terminal.app).
 
 The table describes normal input. In the verbatim composer, `tab` inserts a
 literal tab, navigation keys edit or scroll the draft, and `ctrl+u` deletes to

--- a/website/src/content/docs/reference/api/pane.md
+++ b/website/src/content/docs/reference/api/pane.md
@@ -32,7 +32,7 @@ width soft-wrap at render time, so they re-fit on resize.
 
 The `scroll_*` functions work on any pane by name. The special name
 `"main"` is the output viewport — that's what the default
-PageUp/PageDown/Home/End binds target:
+PageUp/PageDown/Ctrl+Home/Ctrl+End binds target:
 
 ```lua
 rune.pane.scroll_up("main", 20)     -- the output viewport


### PR DESCRIPTION
## Summary

Resolves the request for Home/End to work in the input bar instead of scrolling the output pane.

- Bare **Home/End** are no longer bound; they fall through to the input widget as cursor-to-start/end — the same keymap the verbatim composer already uses, and the convention of Mudlet/zMUD, editors, and readline.
- **Ctrl+Home/Ctrl+End** take over jump-to-top/bottom of scrollback (new default binds in `95_ui.lua`; the Go degraded-mode fallback in `handleScrollKey` follows).
- **PageUp/PageDown** are unchanged and remain the universal scroll keys for terminals that cannot send distinct ctrl-modified Home/End.

The input-bar half needed no new code: `bubbles/textinput` natively handles Home/End once nothing intercepts them, so the cursor movement is synchronous (no session round trip), rune-indexed, and still works in degraded mode.

## Compatibility

- Rebinding `home`/`end` in `init.lua` restores the old behavior (two lines, documented in the bind reference) — relevant for tmux without `xterm-keys` and macOS Terminal.app, which don't deliver distinct ctrl variants.
- A user bind on `home`/`end` still wins over the widget, so the override path is unchanged.

## Testing

- `TestHomeEndEditInputWhileCtrlVariantsScroll` (model level): Home/End move the cursor and leave the viewport live; Ctrl+Home/Ctrl+End drive the Go scroll fallback.
- `TestReboundHomeOverridesInputCursor` (controller level): a user bind on `home` dispatches even mid-draft.
- `go build ./cmd/rune/` and `go test ./...` pass.

## Docs

Updated the default keymap table (`reference/api/bind.md`) with the rebind recipe and terminal caveat, the normal-input key table and scrolling section (`interface/input.md`), and the two pane-scrolling references (`interface/panes.md`, `reference/api/pane.md`).

## Out of scope (follow-ups discussed)

- Snap-to-live on input submit — would make jump-to-bottom largely unnecessary as a key; worth doing since Ctrl+End is the least reliable key in the scheme.
- The Ctrl+A/Ctrl+E asymmetry (Ctrl+E opens $EDITOR rather than cursor-to-end) — separable, touches an advertised binding.