### PR TITLE
tui: pin scrolled viewport when the ring buffer evicts its anchor

### DIFF
--- a/ui/tui/widget/viewport.go
+++ b/ui/tui/widget/viewport.go
@@ -135,7 +135,14 @@ func (v *Viewport) View() string {
 		return v.cachedView
 	}
 
+	// Defensive: whatever happened to the offset, the frame must never
+	// grow taller than the assigned height. An offset beyond Count()
+	// would make endIdx negative and the padding loop below emit more
+	// than contentHeight rows.
 	totalLines := v.buffer.Count()
+	if v.offset > totalLines {
+		v.offset = totalLines
+	}
 	endIdx := totalLines - v.offset
 	if endIdx > totalLines {
 		endIdx = totalLines
@@ -195,8 +202,26 @@ func (v *Viewport) OnNewRows(count int) {
 	case ModeScrolled:
 		v.offset += count
 		v.newLines += count
+		// Once the ring buffer is full, appends evict the oldest rows
+		// and Count() stops growing - the rows this offset was anchored
+		// on may be gone. Pin to the oldest surviving window (like
+		// Pane.clampOffset) instead of letting the offset drift past
+		// the buffer and inflate the rendered frame.
+		if max := v.maxOffset(); v.offset > max {
+			v.offset = max
+		}
 		v.cacheValid = false
 	}
+}
+
+// maxOffset is the largest scroll offset that still fills the window
+// with buffered rows; 0 when the buffer fits the viewport.
+func (v *Viewport) maxOffset() int {
+	max := v.buffer.Count() - v.height
+	if max < 0 {
+		max = 0
+	}
+	return max
 }
 
 // SetPrompt sets the server prompt.
@@ -209,14 +234,9 @@ func (v *Viewport) SetPrompt(text string) {
 
 // PageUp scrolls up one page.
 func (v *Viewport) PageUp() {
-	maxOffset := v.buffer.Count() - v.height
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
-
 	v.offset += v.height - 1
-	if v.offset > maxOffset {
-		v.offset = maxOffset
+	if max := v.maxOffset(); v.offset > max {
+		v.offset = max
 	}
 
 	if v.offset > 0 {
@@ -238,14 +258,9 @@ func (v *Viewport) PageDown() {
 
 // ScrollUp scrolls up by N lines (toward older content).
 func (v *Viewport) ScrollUp(lines int) {
-	maxOffset := v.buffer.Count() - v.height
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
-
 	v.offset += lines
-	if v.offset > maxOffset {
-		v.offset = maxOffset
+	if max := v.maxOffset(); v.offset > max {
+		v.offset = max
 	}
 
 	if v.offset > 0 {
@@ -275,11 +290,7 @@ func (v *Viewport) GotoBottom() {
 
 // GotoTop scrolls to the oldest line.
 func (v *Viewport) GotoTop() {
-	maxOffset := v.buffer.Count() - v.height
-	if maxOffset < 0 {
-		maxOffset = 0
-	}
-	v.offset = maxOffset
+	v.offset = v.maxOffset()
 	if v.offset > 0 {
 		v.mode = ModeScrolled
 	}

--- a/ui/tui/widget/viewport_test.go
+++ b/ui/tui/widget/viewport_test.go
@@ -182,6 +182,65 @@ func TestViewportEmptyBufferRendersBlankRows(t *testing.T) {
 	}
 }
 
+// A viewport left scrolled while the full ring buffer evicts its anchor
+// rows must pin to the oldest surviving window and keep its exact
+// geometry. The offset used to grow past the buffer unclamped, and View
+// then emitted more rows than its assigned height, corrupting the frame
+// (issue #60).
+func TestViewportScrolledSurvivesRingBufferEviction(t *testing.T) {
+	buf := NewScrollbackBuffer(8)
+	v := NewViewport(buf)
+	v.SetSize(40, 3)
+	for i := 1; i <= 8; i++ {
+		buf.Append(fmt.Sprintf("line %d", i))
+		v.OnNewRows(1)
+	}
+
+	v.GotoTop() // anchored on lines 1-3
+	if v.Mode() != ModeScrolled {
+		t.Fatal("expected scrolled mode after GotoTop")
+	}
+
+	// Push far past the anchor: lines 1-32 are evicted, 33-40 survive.
+	for i := 9; i <= 40; i++ {
+		buf.Append(fmt.Sprintf("line %d", i))
+		v.OnNewRows(1)
+	}
+
+	rows := viewRows(v)
+	if len(rows) != 3 {
+		t.Fatalf("View emitted %d rows, want exactly the assigned 3: %q", len(rows), rows)
+	}
+	want := []string{"line 33", "line 34", "line 35"}
+	for i, w := range want {
+		if rows[i] != w {
+			t.Errorf("row %d = %q, want %q (view should pin to the oldest surviving rows)", i, rows[i], w)
+		}
+	}
+	if v.Mode() != ModeScrolled {
+		t.Error("eviction must not silently return the viewport to live mode")
+	}
+
+	v.GotoBottom()
+	rows = viewRows(v)
+	if rows[len(rows)-1] != "line 40" {
+		t.Errorf("GotoBottom after eviction should land on the newest line, got %q", rows)
+	}
+}
+
+// View must never emit more rows than its height, whatever state the
+// offset is in - the frame-geometry backstop behind the OnNewRows clamp.
+func TestViewportViewNeverExceedsHeight(t *testing.T) {
+	v, _ := newTestViewport(40, 3, "a", "b", "c", "d", "e")
+	v.mode = ModeScrolled
+	v.offset = 999
+
+	rows := viewRows(v)
+	if len(rows) != 3 {
+		t.Fatalf("View emitted %d rows with a corrupt offset, want 3: %q", len(rows), rows)
+	}
+}
+
 func TestScrollbackBufferWrapsAtCapacity(t *testing.T) {
 	buf := NewScrollbackBuffer(3)
 	for i := 1; i <= 5; i++ {


### PR DESCRIPTION
Fixes #60.

## Problem

While the viewport is scrolled back, `OnNewRows` increments the scroll offset for every appended row so the view stays anchored on the same history. The offset was never clamped. Once the 100,000-row scrollback ring buffer wraps, `Count()` stops growing while the offset keeps climbing:

- past `Count()-height`, blank rows bleed in at the top of the scrolled view;
- past `Count()`, `View()` computes a negative visible count and emits more rows than its assigned height, pushing bars, the input line, and docked panes off position. The frame stays garbled until the user scrolls back to live.

Reachable by staying scrolled back while the server produces enough output to wrap the buffer.

## Fix

- `OnNewRows` clamps the offset to the oldest surviving full window (`Count()-height`). When eviction reaches the anchor, the view pins to the top of surviving history and stays in scroll mode - the same behavior `Pane.clampOffset` already gives panes when trimming removes their anchor. End/PageDown still returns to live.
- `View()` additionally clamps the offset to `Count()` as a geometry backstop, so no offset state can make the frame taller than the assigned height.
- The clamp that `ScrollUp`/`PageUp`/`GotoTop` each duplicated is now a shared `maxOffset` helper used by all four sites.

## User-visible behavior after the fix

Nothing changes while the anchor rows still exist. When they are evicted, the view pins to the oldest surviving rows (the text slides up as history is consumed) instead of degrading into blank padding and then a corrupted frame. Frame geometry is now invariant: the viewport always renders exactly its assigned height.

## Tests

- `TestViewportScrolledSurvivesRingBufferEviction`: small-capacity (8-row) buffer, scrolled to top, appends far past eviction; asserts exact row count, pinning to the oldest surviving rows, scroll mode retained, and a clean return to live. Fails on the previous code with 32 blank rows emitted for a height-3 viewport.
- `TestViewportViewNeverExceedsHeight`: pins the `View()` backstop directly with a corrupt offset. Fails on the previous code with 997 rows emitted.

`go test ./...` and `go test -race ./ui/tui/...` pass.