### PR TITLE
lua: survive a clobbered rune._state table

### DIFF
--- a/lua/api_state.go
+++ b/lua/api_state.go
@@ -35,12 +35,12 @@ func (e *Engine) UpdateState(state ClientState) {
 		return
 	}
 
-	stateTable := e.L.GetField(e.runeTable, "_state")
-	if stateTable == glua.LNil {
+	// A user script can clobber rune._state; skip the push rather than
+	// panic. Scripts see stale state until /reload rebuilds the table.
+	t, ok := e.L.GetField(e.runeTable, "_state").(*glua.LTable)
+	if !ok {
 		return
 	}
-
-	t := stateTable.(*glua.LTable)
 	e.L.SetField(t, "connected", glua.LBool(state.Connected))
 	e.L.SetField(t, "address", glua.LString(state.Address))
 	e.L.SetField(t, "scroll_mode", glua.LString(state.ScrollMode))

--- a/lua/engine_test.go
+++ b/lua/engine_test.go
@@ -103,6 +103,48 @@ func TestBrokenHooksDegradesGracefully(t *testing.T) {
 	}
 }
 
+// TestClobberedStateTableDoesNotPanic verifies a user script that
+// overwrites rune._state cannot crash the client: UpdateState skips the
+// push instead of panicking the process on an unchecked type assertion.
+// State pushes ride connection, resize, and scroll events, so before
+// the checked lookup this was a delayed hard crash from one bad script
+// line.
+func TestClobberedStateTableDoesNotPanic(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	for _, sabotage := range []string{
+		"rune._state = 5",
+		`rune._state = "text"`,
+		"rune._state = nil",
+	} {
+		if err := engine.DoString("sabotage", sabotage); err != nil {
+			t.Fatalf("%s: %v", sabotage, err)
+		}
+		engine.UpdateState(ClientState{Connected: true, Address: "mud.example.com:4000", Width: 80, Height: 24})
+	}
+
+	// The VM survives and everything else keeps working.
+	if err := engine.DoString("after", `rune.send_raw("still alive")`); err != nil {
+		t.Fatalf("VM unusable after clobbered-state update: %v", err)
+	}
+	if sent := host.DrainNetworkCalls(); len(sent) != 1 || sent[0] != "still alive" {
+		t.Errorf("expected send after clobbered-state update, got %v", sent)
+	}
+
+	// Re-init (what /reload does) rebuilds the mirror and pushes land again.
+	if err := engine.Init(); err != nil {
+		t.Fatal(err)
+	}
+	engine.UpdateState(ClientState{Connected: true, Address: "mud.example.com:4000"})
+	if err := engine.DoString("check", `
+		assert(rune._state.connected == true, "state push lost after reload")
+		assert(rune._state.address == "mud.example.com:4000")
+	`); err != nil {
+		t.Error(err)
+	}
+}
+
 // TestBrokenHandlerIsIsolated verifies that a throwing output handler
 // is reported and skipped, while later handlers (including core trigger
 // processing) still run.


### PR DESCRIPTION
## Problem

`rune._state` is an ordinary field on the `rune` table, so any user script can overwrite it - one line like `rune._state = 5` in init.lua (a typo for `rune.state`) loads without complaint. `Engine.UpdateState` guarded against `nil` but then cast the value with an unchecked type assertion:

```go
t := stateTable.(*glua.LTable)
```

Any non-table value panics in Go, on the session goroutine, outside every protection that wraps Lua execution (pcall isolation, handler quarantine, the watchdog, degraded mode). An unrecovered Go panic terminates the whole process, so the client hard-crashes on the next state push - a connection event, window resize, or scroll change - long after the script line that caused it, which makes the cause hard for the user to connect to the effect.

## Fix

Replace the assertion with a checked lookup and skip the push when `rune._state` is no longer a table. The Lua-side mirror is already broken at that point, so skipping is honest: scripts read stale state until `/reload` rebuilds the table, and everything else keeps working. Degrade, never die - the same policy the rest of the client follows, and the same checked-lookup pattern `getRuneFunc` already uses for identical reasons.

## Tests

`TestClobberedStateTableDoesNotPanic` clobbers `rune._state` with a number, a string, and `nil`, drives `UpdateState` through each, and verifies the VM stays usable (a send still reaches the host) and that a re-init - what `/reload` does - restores the mirror so pushes land again. Against the previous code the test dies with the interface-conversion panic.

`go test ./...` passes.