### PR TITLE
lua: make completion-cache eviction O(1)

### DIFF
--- a/lua/core/90_input.lua
+++ b/lua/core/90_input.lua
@@ -302,9 +302,12 @@ local MAX_WORDS = 5000
 local MIN_WORD_LEN = 3
 
 -- Data structures for word cache
-local cache = {}        -- lower -> {word=original, order=int}
-local order_list = {}   -- array of lowercase words (insertion order for eviction)
-local prefix_idx = {}   -- 2-char -> set of lowercase words
+local cache = {}      -- lower -> {word=original, order=int}
+-- Fixed-size ring of lowercase words in insertion order: the slot a
+-- new word claims holds the eviction victim, so eviction is O(1).
+local ring = {}
+local ring_pos = 0    -- last written slot (1..MAX_WORDS)
+local prefix_idx = {} -- 2-char -> set of lowercase words
 local order_counter = 0
 
 local function cache_add(word)
@@ -318,28 +321,25 @@ local function cache_add(word)
         -- Update existing entry (bump recency)
         entry.word = word
         entry.order = order_counter
-    else
-        -- New word
-        cache[lower] = { word = word, order = order_counter }
-        order_list[#order_list + 1] = lower
+        return
+    end
 
-        -- Add to prefix index
-        if #lower >= 2 then
-            local key = lower:sub(1, 2)
-            prefix_idx[key] = prefix_idx[key] or {}
-            prefix_idx[key][lower] = true
-        end
-
-        -- Evict oldest if over capacity
-        if #order_list > MAX_WORDS then
-            local oldest = table.remove(order_list, 1)
-            local old_key = oldest:sub(1, 2)
-            if prefix_idx[old_key] then
-                prefix_idx[old_key][oldest] = nil
-            end
-            cache[oldest] = nil
+    -- New word: claim the next ring slot, evicting its occupant.
+    ring_pos = ring_pos % MAX_WORDS + 1
+    local evicted = ring[ring_pos]
+    if evicted then
+        cache[evicted] = nil
+        local bucket = prefix_idx[evicted:sub(1, 2)]
+        if bucket then
+            bucket[evicted] = nil
         end
     end
+    ring[ring_pos] = lower
+
+    cache[lower] = { word = word, order = order_counter }
+    local key = lower:sub(1, 2)
+    prefix_idx[key] = prefix_idx[key] or {}
+    prefix_idx[key][lower] = true
 end
 
 local function cache_find(prefix)
@@ -511,7 +511,8 @@ end
 
 function rune.completion.clear_cache()
     cache = {}
-    order_list = {}
+    ring = {}
+    ring_pos = 0
     prefix_idx = {}
     order_counter = 0
 end

--- a/lua/input_test.go
+++ b/lua/input_test.go
@@ -6,6 +6,8 @@ package lua
 // UI would emit them.
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mmcdole/rune/input"
@@ -388,6 +390,46 @@ func TestTabCompletionIgnoresShortPrefixAndInput(t *testing.T) {
 	typeInput(engine, host, "bra")
 	engine.HandleKeyBind("tab")
 	assertInput(t, host, "brandish ")
+}
+
+// The word cache caps at 5,000 entries (MAX_WORDS in 90_input.lua) and
+// evicts in insertion order: past the cap the oldest words stop
+// completing while newer ones still do. Pins the contract, not the
+// data structure.
+func TestTabCompletionCacheEvictsOldestBeyondCap(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	// Ten distinct "old" words, then verify they complete.
+	var old strings.Builder
+	for i := 1; i <= 10; i++ {
+		fmt.Fprintf(&old, "oldword%02d ", i)
+	}
+	engine.OnOutput(text.NewLine(old.String()))
+
+	typeInput(engine, host, "oldwor")
+	engine.HandleKeyBind("tab")
+	assertInput(t, host, "oldword10 ") // most recent match first
+
+	// 5,000 distinct filler words: exactly enough to evict the ten
+	// oldest entries and nothing else.
+	for line := 0; line < 50; line++ {
+		var b strings.Builder
+		for j := 1; j <= 100; j++ {
+			fmt.Fprintf(&b, "fill%04d ", line*100+j)
+		}
+		engine.OnOutput(text.NewLine(b.String()))
+	}
+
+	// The old words are gone: Tab is a no-op.
+	typeInput(engine, host, "oldwor")
+	engine.HandleKeyBind("tab")
+	assertInput(t, host, "oldwor")
+
+	// Surviving filler words still complete, newest match first.
+	typeInput(engine, host, "fill49")
+	engine.HandleKeyBind("tab")
+	assertInput(t, host, "fill4999 ")
 }
 
 func TestCompletionMidLineInsertsWithoutTrailingSpace(t *testing.T) {


### PR DESCRIPTION
## Problem

The tab-completion word cache (90_input.lua) caps at 5,000 words and tracked insertion order in a plain array, evicting with:

```lua
local oldest = table.remove(order_list, 1)
```

Front-removal shifts every remaining entry down one slot - a 5,000-element copy. Word tokenizing runs on the output hook for every server line, so once the cache fills (a few hours of normal play), every new distinct token the server produces pays that shift, on the path between socket and screen. Repeated words only bump recency and skip it, but MUD output is a steady stream of fresh tokens.

This was never user-visible lag (the shift happens inside gopher-lua's Go implementation of table.remove), so this is hot-path hygiene rather than a rescue: removing an accidental O(n) from a per-line code path.

## Fix

Replace the order array with a fixed-size ring and a write position. A new word claims the next slot (wrapping at 5,000); whatever word held that slot is the eviction victim, found in O(1). Semantics are unchanged: same cap, same insertion-order eviction (recency bumps never reordered the old array either), and `rune.completion.clear_cache()` resets the ring.

## Tests

`TestTabCompletionCacheEvictsOldestBeyondCap` is the first coverage this path has had. It seeds ten old words, proves they complete, overflows the cap with exactly 5,000 fillers, then asserts the old words no longer complete while recent fillers still do (newest match first). The test is deliberately implementation-agnostic - verified to pass against the old `table.remove` structure as well, so it pins the eviction contract rather than the data structure.

`go test ./...` passes.