### PR TITLE
lua: share regex userdata methods instead of per-lookup closures

### DIFF
--- a/lua/api_regex.go
+++ b/lua/api_regex.go
@@ -8,46 +8,54 @@ import (
 
 const luaRegexTypeName = "Regex"
 
-// registerRegexType registers the Regex userdata type.
+// registerRegexType registers the Regex userdata type. Methods live in
+// a shared table (like line.go), so a lookup on the per-line match path
+// resolves a function instead of allocating a closure.
 func registerRegexType(L *glua.LState) {
 	mt := L.NewTypeMetatable(luaRegexTypeName)
-	L.SetField(mt, "__index", L.NewFunction(regexIndex))
+	L.SetField(mt, "__index", L.SetFuncs(L.NewTable(), regexMethods))
 }
 
-// regexIndex handles method calls on Regex userdata.
-func regexIndex(L *glua.LState) int {
-	ud := L.CheckUserData(1)
-	re, ok := ud.Value.(*regexp.Regexp)
-	if !ok {
-		L.ArgError(1, "regex expected")
-		return 0
+// checkRegex retrieves a *regexp.Regexp from userdata at stack position n.
+func checkRegex(L *glua.LState, n int) *regexp.Regexp {
+	ud := L.CheckUserData(n)
+	if re, ok := ud.Value.(*regexp.Regexp); ok {
+		return re
 	}
-	method := L.CheckString(2)
+	L.ArgError(n, "regex expected")
+	return nil
+}
 
-	switch method {
-	case "match":
-		L.Push(L.NewFunction(func(L *glua.LState) int {
-			// Method call re:match(text): self at position 1, text at position 2
-			text := L.CheckString(2)
-			matches := re.FindStringSubmatch(text)
-			if matches == nil {
-				L.Push(glua.LNil)
-				return 1
-			}
-			tbl := L.NewTable()
-			for i, m := range matches {
-				tbl.RawSetInt(i+1, glua.LString(m))
-			}
-			L.Push(tbl)
-			return 1
-		}))
-		return 1
-	case "pattern":
-		L.Push(glua.LString(re.String()))
+// regexMethods defines the methods available on Regex objects in Lua.
+var regexMethods = map[string]glua.LGFunction{
+	"match":   regexMatch,
+	"pattern": regexPattern,
+}
+
+// regexMatch returns the full match plus captures, or nil.
+// Usage: re:match(text)
+func regexMatch(L *glua.LState) int {
+	re := checkRegex(L, 1)
+	text := L.CheckString(2)
+	matches := re.FindStringSubmatch(text)
+	if matches == nil {
+		L.Push(glua.LNil)
 		return 1
 	}
+	tbl := L.NewTable()
+	for i, m := range matches {
+		tbl.RawSetInt(i+1, glua.LString(m))
+	}
+	L.Push(tbl)
+	return 1
+}
 
-	return 0
+// regexPattern returns the source pattern string.
+// Usage: re:pattern()
+func regexPattern(L *glua.LState) int {
+	re := checkRegex(L, 1)
+	L.Push(glua.LString(re.String()))
+	return 1
 }
 
 // registerRegexFuncs registers internal rune._regex.* primitives

--- a/lua/regex_test.go
+++ b/lua/regex_test.go
@@ -1,0 +1,29 @@
+package lua
+
+import "testing"
+
+// TestCompiledRegexObject pins the documented compiled-object contract:
+// re:match returns the full match at index 1 plus captures, or nil on
+// no match. The identity assertion proves method lookup resolves to a
+// shared function rather than manufacturing a fresh closure per call.
+func TestCompiledRegexObject(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	if err := engine.DoString("regex_object", `
+		local re = assert(rune.regex.compile("(\\w+) says (\\w+)"))
+
+		local m = re:match("Bob says hi")
+		assert(m[1] == "Bob says hi" and m[2] == "Bob" and m[3] == "hi",
+			"match: " .. table.concat(m, ","))
+		assert(re:match("nothing here") == nil, "non-match must be nil")
+		assert(re:pattern() == "(\\w+) says (\\w+)", "pattern: " .. re:pattern())
+
+		assert(re.match == re.match, "method lookup must return a shared function")
+
+		local ok, err = rune.regex.compile("(unclosed")
+		assert(ok == nil and err ~= nil, "bad pattern must return nil, err")
+	`); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Problem

The Regex userdata's `__index` metamethod was a function whose `"match"` branch pushed a freshly built closure on every lookup. Since `re:match(text)` desugars to `re["match"](re, text)`, every call allocated a function object, used it once, and left it for the GC. The cached-pattern path in `10_regex.lua` calls `entry.re:match(text)` internally, so every trigger and alias regex evaluation in the client paid this - once per line per pattern - on exactly the hot path the reference docs recommend compiled objects for. `line.go` in the same package already uses the correct idiom (shared method table registered once).

## Fix

Register `match` and `pattern` once in a shared method table (`L.SetFuncs`), mirroring `line.go`; methods fetch their receiver from argument 1 via a new `checkRegex` helper that mirrors `checkLine`. No allocation on lookup, and both userdata types in the package now follow one pattern.

One deliberate change: `pattern` moves from an undocumented property (`re.pattern`) to a method (`re:pattern()`), consistent with `re:match()` and `line:raw()`/`line:clean()`. The reference page documents only `re:match(text)`, and nothing in the core, tests, or demo used the property form.

## Tests

`TestCompiledRegexObject` pins the documented contract - full match at index 1 plus captures, `nil` on no match, `nil, err` from bad patterns - and asserts `re.match == re.match`: method lookup must return a shared function. That identity assertion fails against the closure-per-lookup code (verified by stash).

`go test ./...` passes.