### PR TITLE
lua: harden DoFile's package.path handling

### DIFF
--- a/lua/engine.go
+++ b/lua/engine.go
@@ -232,18 +232,17 @@ func (e *Engine) DoFile(path string) error {
 	if err != nil {
 		return err
 	}
-	dir := filepath.Dir(absPath)
+	// A user script can clobber the package global; skip the path
+	// prefix rather than panic (require is already broken then). The
+	// deferred restore keeps the prefix scoped to this load even if a
+	// panic escapes the guarded call.
+	if pkg, ok := e.L.GetGlobal("package").(*glua.LTable); ok {
+		oldPath := e.L.GetField(pkg, "path").String()
+		e.L.SetField(pkg, "path", glua.LString(filepath.Dir(absPath)+"/?.lua;"+oldPath))
+		defer e.L.SetField(pkg, "path", glua.LString(oldPath))
+	}
 
-	pkg := e.L.GetGlobal("package").(*glua.LTable)
-	oldPath := e.L.GetField(pkg, "path").String()
-	newPath := dir + "/?.lua;" + oldPath
-	e.L.SetField(pkg, "path", glua.LString(newPath))
-
-	err = e.guard(func() error { return e.L.DoFile(absPath) })
-
-	e.L.SetField(pkg, "path", glua.LString(oldPath))
-
-	return err
+	return e.guard(func() error { return e.L.DoFile(absPath) })
 }
 
 // OnInput handles traditional command input. It remains as a convenience for

--- a/lua/engine_test.go
+++ b/lua/engine_test.go
@@ -2,6 +2,8 @@ package lua
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -100,6 +102,42 @@ func TestBrokenHooksDegradesGracefully(t *testing.T) {
 	}
 	if warnings != 1 {
 		t.Errorf("expected exactly one degraded-mode warning, got %d", warnings)
+	}
+}
+
+// TestDoFileSurvivesClobberedPackageAndRestoresPath verifies DoFile's
+// two package.path invariants: a script that clobbers the package
+// global cannot panic the process on the next file load, and a
+// successful load leaves package.path exactly as it found it.
+func TestDoFileSurvivesClobberedPackageAndRestoresPath(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	script := filepath.Join(t.TempDir(), "loaded.lua")
+	if err := os.WriteFile(script, []byte(`rune.send_raw("file ran")`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Normal path: package.path is restored byte-identically.
+	if err := engine.DoString("snap", `path_before = package.path`); err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.DoFile(script); err != nil {
+		t.Fatalf("DoFile: %v", err)
+	}
+	if err := engine.DoString("check", `assert(package.path == path_before, "package.path not restored")`); err != nil {
+		t.Error(err)
+	}
+
+	// Clobbered package global: the load still runs instead of panicking.
+	if err := engine.DoString("sabotage", `package = 5`); err != nil {
+		t.Fatal(err)
+	}
+	if err := engine.DoFile(script); err != nil {
+		t.Fatalf("DoFile with clobbered package: %v", err)
+	}
+	if sent := host.DrainNetworkCalls(); len(sent) != 2 {
+		t.Errorf("expected the file to run both times, sent %v", sent)
 	}
 }
 


### PR DESCRIPTION
## Problem

Two weaknesses on adjacent lines in `Engine.DoFile`:

1. The `package.path` restore was a plain statement after the guarded call. No panic currently escapes that call, but nothing enforces it - a Go-level panic through the VM would skip the restore and leave the script's directory prefixed onto `package.path` for the life of the session, silently changing where every later `require` searches first.
2. `e.L.GetGlobal("package").(*glua.LTable)` is an unchecked assertion on a script-writable global - the same crash class fixed for `rune._state` in #62. `package = 5` in a user script made the next `/load`, `rune.load`, or `rune._load` panic in Go and terminate the process.

## Fix

```go
if pkg, ok := e.L.GetGlobal("package").(*glua.LTable); ok {
    oldPath := e.L.GetField(pkg, "path").String()
    e.L.SetField(pkg, "path", glua.LString(filepath.Dir(absPath)+"/?.lua;"+oldPath))
    defer e.L.SetField(pkg, "path", glua.LString(oldPath))
}
return e.guard(func() error { return e.L.DoFile(absPath) })
```

Checked assertion: with `package` clobbered, the path prefix is skipped (local `require`s are already broken at that point - `require` itself is gone) but the file still loads. Deferred restore: the prefix is scoped to the load however it exits. This closes the residual explicitly left open in #62.

## Tests

`TestDoFileSurvivesClobberedPackageAndRestoresPath` pins both invariants: after a successful load `package.path` is byte-identical to before, and a load after `package = 5` executes the file without panicking. The clobbered-package half dies with the interface-conversion panic against the previous code (verified by stash); the restore half passes both ways and pins the contract.

`go test ./...` passes.