### PR TITLE
network: make NEW-ENVIRON ESC quoting a uniform lexical rule

### DIFF
--- a/network/negotiate.go
+++ b/network/negotiate.go
@@ -235,10 +235,10 @@ func (h *handshake) environReplyLocked(data []byte) [][]byte {
 
 	appendVar := func(kind byte, name string) {
 		payload = append(payload, kind)
-		payload = append(payload, []byte(name)...)
+		payload = append(payload, environEscape(name)...)
 		if value, ok := h.environValueLocked(name); ok {
 			payload = append(payload, environVALUE)
-			payload = append(payload, []byte(value)...)
+			payload = append(payload, environEscape(value)...)
 		}
 	}
 
@@ -261,6 +261,21 @@ type environName struct {
 	name string
 }
 
+// environEscape ESC-quotes the VAR/VALUE/ESC/USERVAR bytes so they
+// ride as data (RFC 1572). Our own names and values are ASCII; only
+// echoed request names can carry quoted markers.
+func environEscape(s string) []byte {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case environVAR, environVALUE, environESC, environUSERVAR:
+			out = append(out, environESC)
+		}
+		out = append(out, s[i])
+	}
+	return out
+}
+
 // parseEnvironNames decodes the VAR/USERVAR name list of a SEND
 // request, honoring ESC-quoted bytes.
 func parseEnvironNames(data []byte) []environName {
@@ -280,9 +295,15 @@ func parseEnvironNames(data []byte) []environName {
 			flush()
 			current = &environName{kind: data[i]}
 		case environESC:
-			if current != nil && i+1 < len(data) {
+			// ESC quotes the next byte unconditionally - a lexical
+			// rule, like telnet's IAC IAC. A quoted byte outside any
+			// name has nowhere to attach and is discarded (RFC 1572
+			// leaves that case undefined).
+			if i+1 < len(data) {
 				i++
-				current.name += string(data[i])
+				if current != nil {
+					current.name += string(data[i])
+				}
 			}
 		default:
 			if current != nil {

--- a/network/negotiate_test.go
+++ b/network/negotiate_test.go
@@ -208,6 +208,74 @@ func TestEnvironSendSpecificVariables(t *testing.T) {
 	}
 }
 
+// TestEnvironEscapeQuoting pins the ESC policy: ESC quotes the next
+// byte unconditionally, as a lexical rule. Inside a name the quoted
+// marker byte becomes data; before any VAR/USERVAR the quoted byte has
+// no name to attach to and is discarded; a trailing ESC quotes nothing.
+func TestEnvironEscapeQuoting(t *testing.T) {
+	cases := []struct {
+		name string
+		data []byte
+		want []environName
+	}{
+		{
+			"quoted marker inside a name",
+			[]byte{environVAR, 'A', environESC, environUSERVAR, 'B'},
+			[]environName{{kind: environVAR, name: "A\x03B"}},
+		},
+		{
+			"leading ESC discards its quoted marker",
+			[]byte{environESC, environVAR, 'X'},
+			nil, // quoted VAR is data with no name to join; bare X is ignored
+		},
+		{
+			"trailing ESC quotes nothing",
+			[]byte{environVAR, 'A', environESC},
+			[]environName{{kind: environVAR, name: "A"}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := parseEnvironNames(c.data)
+			if len(got) != len(c.want) {
+				t.Fatalf("parsed %+v, want %+v", got, c.want)
+			}
+			for i := range c.want {
+				if got[i] != c.want[i] {
+					t.Errorf("name %d = %+v, want %+v", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestEnvironGarbageRequestGetsSendAll verifies a SEND whose name list
+// dissolves entirely into quoted garbage is treated as an empty SEND:
+// the reply is the full identity set, which is public by design.
+func TestEnvironGarbageRequestGetsSendAll(t *testing.T) {
+	all := newHandshake(false, 80, 24).onSubnegotiation(OptNewEnviron, []byte{environSEND})
+	got := newHandshake(false, 80, 24).onSubnegotiation(OptNewEnviron,
+		[]byte{environSEND, environESC, environVAR, 'X'})
+	if len(all) != 1 || len(got) != 1 || !bytes.Equal(got[0], all[0]) {
+		t.Fatalf("garbage SEND reply:\n got %v\nwant the send-all reply %v", got, all)
+	}
+}
+
+// TestEnvironReplyRequotesEchoedNames verifies an unknown requested
+// name carrying a quoted marker byte is echoed with the byte re-quoted,
+// so the reply stays inside the RFC 1572 grammar.
+func TestEnvironReplyRequotesEchoedNames(t *testing.T) {
+	h := newHandshake(false, 80, 24)
+	request := []byte{environSEND, environVAR, 'B', environESC, environVAR, 'G'}
+
+	frames := h.onSubnegotiation(OptNewEnviron, request)
+	want := subnegFrame(OptNewEnviron,
+		[]byte{environIS, environVAR, 'B', environESC, environVAR, 'G'})
+	if len(frames) != 1 || !bytes.Equal(frames[0], want) {
+		t.Fatalf("requoted echo:\n got %v\nwant %v", frames, want)
+	}
+}
+
 // TestGMCPSplit verifies package/payload separation.
 func TestGMCPSplit(t *testing.T) {
 	cases := []struct {


### PR DESCRIPTION
## Problem

`parseEnvironNames` honored RFC 1572's ESC quoting only while a name was being built. An ESC appearing before any `VAR`/`USERVAR` was skipped *without consuming the byte it quotes*, so the quoted marker byte was then parsed as a real marker. The RFC's grammar never places ESC at the top level, so it defines no recovery - this is a policy choice, not a spec violation.

## Policy chosen

ESC quotes the next byte unconditionally - the same lexical model as telnet's own `IAC IAC` (fixed for the data stream in 1c8a7d4). A quoted byte with no open name to attach to is discarded. One consequence, deliberate and pinned by test: a request whose name list dissolves entirely into quoted garbage parses as an empty SEND and gets the send-all reply. That set is our public identity variables, volunteered wholesale to any empty SEND already - nothing to protect. Lenient parsing also matches the codebase's telnet doctrine throughout (charset TTABLE skipping, GMCP JSON repair, direction-loose negotiation).

## Reply-side completion

With quoting parsed correctly, names containing literal marker bytes become representable - and the reply builder was echoing them raw, producing replies outside the RFC grammar. `environEscape` now re-quotes `VAR`/`VALUE`/`ESC`/`USERVAR` bytes in echoed names and values. Our own names and values are ASCII, so all existing byte-exact reply tests are unchanged.

## Tests

- `TestEnvironEscapeQuoting`: quoted marker inside a name becomes data; leading ESC discards its quoted marker; trailing ESC quotes nothing.
- `TestEnvironGarbageRequestGetsSendAll`: all-garbage SEND replies identically to an empty SEND.
- `TestEnvironReplyRequotesEchoedNames`: byte-exact re-quoted echo of an unknown name carrying a marker byte.

The quoting and re-quoting tests fail against the previous code (verified by stash). `go test ./...` passes.