### PR TITLE
lua: remove dead Host.Load and mock fossils

### DIFF
--- a/lua/host.go
+++ b/lua/host.go
@@ -60,7 +60,6 @@ type Host interface {
 	// System
 	Quit()
 	Reload()
-	Load(path string)
 	RefreshBars() // Force immediate bar refresh
 
 	// History

--- a/lua/mock_host_test.go
+++ b/lua/mock_host_test.go
@@ -23,7 +23,6 @@ type MockHost struct {
 	ConnectCalls    []string
 	DisconnectCalls int
 	ReloadCalls     int
-	LoadCalls       []string
 	PaneCalls       []struct{ Op, Name, Data string }
 	PickerCalls     []ui.ShowPickerMsg
 	ClipboardCalls  []string
@@ -138,12 +137,6 @@ func (m *MockHost) Reload() {
 	m.ReloadCalls++
 }
 
-func (m *MockHost) Load(path string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.LoadCalls = append(m.LoadCalls, path)
-}
-
 func (m *MockHost) RefreshBars() {
 	// No-op for tests
 }
@@ -176,12 +169,6 @@ func (m *MockHost) PaneClear(name string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PaneCalls = append(m.PaneCalls, struct{ Op, Name, Data string }{"clear", name, ""})
-}
-
-func (m *MockHost) GetClientState() ClientState {
-	return ClientState{
-		ScrollMode: "live",
-	}
 }
 
 func (m *MockHost) OnConfigChange() {

--- a/session/lua_system.go
+++ b/session/lua_system.go
@@ -35,21 +35,6 @@ func (s *Session) Reload() {
 	}
 }
 
-// Load implements lua.Host.
-func (s *Session) Load(path string) {
-	if path == "" {
-		s.ui.Print(text.Red("Load Failed: empty path"))
-		return
-	}
-
-	if err := s.engine.DoFile(path); err != nil {
-		s.ui.Print(text.Red(fmt.Sprintf("Load Failed (%s): %v", path, err)))
-		return
-	}
-
-	s.engine.CallHook("loaded", path)
-}
-
 // RefreshBars forces an immediate bar refresh.
 // Called from Lua when bar state changes and we don't want to wait for the ticker.
 func (s *Session) RefreshBars() {


### PR DESCRIPTION
Pure deletion, no behavior change.

- **`Host.Load` / `Session.Load` / `MockHost.Load` (+ `LoadCalls`)**: no caller anywhere. The real script-loading path is `rune._load` in api_core.go, which calls `Engine.DoFile` directly and fires the "loaded" hook itself - it never crosses the Host boundary. The dead path also disagreed with the live one on error reporting (printed vs `nil, err`), so leaving it around invited the wrong wiring later. `rune._load` remains the single canonical path, which it already was in practice.
- **`MockHost.GetClientState`**: implemented a method that no longer exists on the `Host` interface; compiled only because Go ignores extra methods.

Verification is the existing compile-time interface checks (`var _ lua.Host = (*Session)(nil)`, `var _ Host = (*MockHost)(nil)`) and the full suite - `go build ./...`, `go vet ./...`, and `go test ./...` all pass. Nothing observable changed, so there is nothing new to test.

29 deletions, 0 insertions.