### PR TITLE
session: ignore server clear-screen and cursor sequences at display egress

### DIFF
--- a/session/lua_ui.go
+++ b/session/lua_ui.go
@@ -2,12 +2,15 @@ package session
 
 import (
 	"github.com/mmcdole/rune/input"
+	"github.com/mmcdole/rune/text"
 	"github.com/mmcdole/rune/ui"
 )
 
-// Print implements lua.Host.
-func (s *Session) Print(text string) {
-	s.ui.Print(text)
+// Print implements lua.Host. Scripts routinely re-print captured
+// server text, so display sanitization applies here too (issue #69);
+// rune.style output is SGR and passes through untouched.
+func (s *Session) Print(msg string) {
+	s.ui.Print(text.SanitizeDisplay(msg))
 }
 
 // PaneCreate implements lua.Host.
@@ -15,9 +18,10 @@ func (s *Session) PaneCreate(name string) {
 	s.ui.CreatePane(name)
 }
 
-// PaneWrite implements lua.Host.
-func (s *Session) PaneWrite(name, text string) {
-	s.ui.WritePane(name, text)
+// PaneWrite implements lua.Host. Sanitized like Print: pane content is
+// often trigger-captured server text.
+func (s *Session) PaneWrite(name, msg string) {
+	s.ui.WritePane(name, text.SanitizeDisplay(msg))
 }
 
 // PaneToggle implements lua.Host.

--- a/session/session.go
+++ b/session/session.go
@@ -209,7 +209,10 @@ func (s *Session) handleEvent(ev event.Event) {
 		payload := string(ev.Payload.(event.Line))
 		line := text.NewLine(payload)
 		if modified, show := s.engine.OnOutput(line); show {
-			s.ui.Print(modified)
+			// Display egress owns terminal safety: strip everything but
+			// SGR so server clear/cursor sequences cannot wipe UI chrome
+			// (issue #69). Lua hooks above saw the raw line.
+			s.ui.Print(text.SanitizeDisplay(modified))
 		}
 		// Server line ends the prompt overlay
 		s.lastPrompt = ""
@@ -225,7 +228,9 @@ func (s *Session) handleEvent(ev event.Event) {
 		// (handleSubmission).
 		payload := string(ev.Payload.(event.Line))
 		line := text.NewLine(payload)
-		modified := s.engine.OnPrompt(line)
+		// Sanitized before storing so the overlay and the later
+		// scrollback commit (handleSubmission) both stay chrome-safe.
+		modified := text.SanitizeDisplay(s.engine.OnPrompt(line))
 		s.lastPrompt = modified
 		s.ui.SetPrompt(modified)
 

--- a/test/e2e/scenarios/regressions/69-editor-clear-screen.json
+++ b/test/e2e/scenarios/regressions/69-editor-clear-screen.json
@@ -1,0 +1,35 @@
+{
+  "description": "Issue #69: Aardwolf's OLC editor sends terminal clear-screen and cursor-addressing sequences. Replaying those from inside a rendered scrollback row wipes UI chrome (separators, input line, bars), so Rune ignores them like CMUD/MUSHclient: no non-SGR escape sequence may reach any display surface. SGR color sequences must survive.",
+  "scenarios": [
+    {
+      "name": "clear-screen and cursor sequences are dropped from server lines, colors kept",
+      "issue": "https://github.com/mmcdole/rune/issues/69",
+      "steps": [
+        { "connect": true },
+        { "server_line": "\u001b[H\u001b[2J\u001b[3;1H\u001b[JE2E-EDITOR \u001b[31mred\u001b[0m\u001b[K kept\u001bc" },
+        { "expect_printed": "E2E-EDITOR", "note": "sync: the line reached the scrollback" },
+        { "expect_printed": "\u001b[31mred\u001b[0m", "note": "SGR color survives sanitization" },
+        { "expect_not_printed": "\u001b[2J", "note": "clear entire screen" },
+        { "expect_not_printed": "\u001b[H", "note": "cursor home" },
+        { "expect_not_printed": "\u001b[3;1H", "note": "cursor addressing" },
+        { "expect_not_printed": "\u001b[J", "note": "erase below" },
+        { "expect_not_printed": "\u001b[K", "note": "erase line" },
+        { "expect_not_printed": "\u001bc", "note": "full terminal reset" }
+      ]
+    },
+    {
+      "name": "editor clear arriving as an unterminated prompt block is ignored",
+      "issue": "https://github.com/mmcdole/rune/issues/69",
+      "steps": [
+        { "connect": true },
+        { "server_prompt": "\u001b[H\u001b[2JE2E-EDITOR-PROMPT> " },
+        { "expect_prompt": "E2E-EDITOR-PROMPT>", "note": "sync: prompt overlay updated" },
+        { "type": "look" },
+        { "expect_sent": "look", "note": "sync: submission processed, prompt committed to scrollback" },
+        { "expect_printed": "E2E-EDITOR-PROMPT>" },
+        { "expect_not_printed": "\u001b[2J", "note": "the committed prompt carries no clear sequence" },
+        { "expect_not_printed": "\u001b[H" }
+      ]
+    }
+  ]
+}

--- a/text/sanitize.go
+++ b/text/sanitize.go
@@ -1,0 +1,103 @@
+package text
+
+import "strings"
+
+// SanitizeDisplay makes server text safe for a row-based display: it
+// keeps printable text and SGR color sequences (CSI ... 'm' with plain
+// numeric parameters) and drops every other escape sequence and
+// terminal-active control character.
+//
+// MUD-side editors (e.g. Aardwolf's OLC editor) send clear-screen and
+// cursor-addressing sequences. Rune's scrollback is an append-only row
+// model, so replaying such a sequence from inside a rendered row would
+// wipe UI chrome (separators, input line, bars) instead of "clearing
+// the screen"; like CMUD and MUSHclient, Rune ignores them. Tabs, CR,
+// and LF pass through - later display stages own tab expansion and
+// line splitting.
+//
+// The state machine mirrors StripANSI (line.go), which owns the notes
+// on why each sequence class is parsed the way it is; this variant
+// re-emits SGR sequences instead of dropping them.
+func SanitizeDisplay(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+
+	state := stText
+	var params strings.Builder // parameter bytes of the CSI being scanned
+	sgr := false               // CSI still qualifies as plain SGR
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch state {
+		case stText:
+			switch {
+			case c == 0x1b:
+				state = stEsc
+			case c == '\t' || c == '\r' || c == '\n':
+				b.WriteByte(c)
+			case c < 0x20 || c == 0x7f:
+				// Terminal-active C0 control (BEL, BS, FF, ...): drop
+			default:
+				b.WriteByte(c)
+			}
+
+		case stEsc:
+			switch {
+			case c == '[':
+				state = stCSI
+				params.Reset()
+				sgr = true
+			case c == ']' || c == 'P' || c == 'X' || c == '^' || c == '_':
+				state = stString
+			case c == 0x1b:
+				// ESC ESC: restart sequence detection
+			case c >= 0x20 && c <= 0x2f:
+				// Intermediate byte: stay until the final byte arrives
+			default:
+				// Two-character escape (ESC c, ESC 7, ...): dropped
+				state = stText
+			}
+
+		case stCSI:
+			switch {
+			case c >= 0x40 && c <= 0x7e:
+				// Final byte. Only a plain SGR survives: private-mode
+				// markers, intermediates, and embedded controls all
+				// disqualify (e.g. "CSI > 4 m" is XTMODKEYS, not color).
+				if c == 'm' && sgr {
+					b.WriteString("\x1b[")
+					b.WriteString(params.String())
+					b.WriteByte('m')
+				}
+				state = stText
+			case c == 0x1b:
+				state = stEsc
+			case c >= '0' && c <= '9' || c == ';' || c == ':':
+				params.WriteByte(c)
+			default:
+				// Non-SGR parameter/intermediate byte, or an embedded
+				// C0 control: the sequence is not a color
+				sgr = false
+			}
+
+		case stString:
+			switch c {
+			case 0x07:
+				state = stText
+			case 0x1b:
+				state = stStringEsc
+			}
+
+		case stStringEsc:
+			switch c {
+			case '\\':
+				state = stText
+			case 0x1b:
+				// Still a candidate ST terminator
+			default:
+				state = stString
+			}
+		}
+	}
+
+	return b.String()
+}

--- a/text/sanitize_test.go
+++ b/text/sanitize_test.go
@@ -1,0 +1,68 @@
+package text
+
+import "testing"
+
+func TestSanitizeDisplay(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain text", "hello world", "hello world"},
+		{"sgr kept", "\x1b[31mred\x1b[0m text", "\x1b[31mred\x1b[0m text"},
+		{"multi-param sgr kept", "\x1b[1;32;40mbold green\x1b[0m", "\x1b[1;32;40mbold green\x1b[0m"},
+		{"empty sgr kept", "\x1b[mreset", "\x1b[mreset"},
+		{"colon sgr kept", "\x1b[38:2::255:0:0mtruecolor\x1b[0m", "\x1b[38:2::255:0:0mtruecolor\x1b[0m"},
+
+		// The Aardwolf editor-clear repertoire and friends.
+		{"clear screen", "\x1b[2Jtext", "text"},
+		{"cursor home", "\x1b[Htext", "text"},
+		{"home then clear", "\x1b[H\x1b[2Jtext", "text"},
+		{"erase below", "before\x1b[Jafter", "beforeafter"},
+		{"erase line", "before\x1b[Kafter", "beforeafter"},
+		{"cursor addressing", "\x1b[3;1Htext", "text"},
+		{"scrollback clear", "\x1b[3Jtext", "text"},
+		{"full reset", "text\x1bcmore", "textmore"},
+		{"cursor movement", "a\x1b[2Ab", "ab"},
+		{"private-mode csi", "\x1b[?25htext", "text"},
+
+		// Non-color sequences that end in 'm' must not slip through.
+		{"xtmodkeys not sgr", "\x1b[>4;1mtext", "text"},
+		{"private marker with m final", "\x1b[?4mtext", "text"},
+		{"intermediate with m final", "\x1b[0 mtext", "text"},
+
+		// String sequences and charset designations drop cleanly.
+		{"osc title bel", "\x1b]0;window title\x07visible", "visible"},
+		{"osc title st", "\x1b]0;window title\x1b\\visible", "visible"},
+		{"dcs string", "\x1bPsome payload\x1b\\visible", "visible"},
+		{"charset designation", "\x1b(Btext", "text"},
+		{"two-char escape", "\x1b7saved\x1b8", "saved"},
+
+		// C0 policy: structural whitespace passes, terminal-active drops.
+		{"tab kept", "a\tb", "a\tb"},
+		{"crlf kept", "a\r\nb", "a\r\nb"},
+		{"bel dropped", "ding\x07dong", "dingdong"},
+		{"backspace dropped", "ab\x08c", "abc"},
+		{"form feed dropped", "a\x0cb", "ab"},
+		{"del dropped", "a\x7fb", "ab"},
+		{"c0 inside csi dropped with sequence", "\x1b[31\x07mtext", "text"},
+
+		// Malformed input stays inert.
+		{"bare esc at end", "text\x1b", "text"},
+		{"unterminated csi at end", "text\x1b[31", "text"},
+		{"esc restarts esc", "\x1b\x1b[31mred", "\x1b[31mred"},
+		{"esc inside csi restarts", "\x1b[3\x1b[32mgreen", "\x1b[32mgreen"},
+		{"utf8 preserved", "\x1b[36m→ östlich\x1b[0m", "\x1b[36m→ östlich\x1b[0m"},
+		{"empty", "", ""},
+
+		{"editor burst", "\x1b[H\x1b[2J\x1b[3;1H\x1b[Jedit \x1b[31mred\x1b[0m\x1b[K done", "edit \x1b[31mred\x1b[0m done"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeDisplay(tc.in); got != tc.want {
+				t.Errorf("SanitizeDisplay(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -266,7 +266,7 @@ func (m *Model) syncBars(content map[string]ui.BarContent) {
 func (m *Model) handleServerOutput(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case ui.PrintLineMsg:
-		rows := splitRows(util.FilterClearSequences(string(msg)), m.width)
+		rows := splitRows(string(msg), m.width)
 		if m.flushScheduled {
 			// Inside a batch window: coalesce with the burst.
 			m.pendingRows = append(m.pendingRows, rows...)

--- a/ui/tui/util/ansi.go
+++ b/ui/tui/util/ansi.go
@@ -36,17 +36,6 @@ func WrapLine(line string, width int) []string {
 	return strings.Split(ansi.Wrap(line, width, ""), "\n")
 }
 
-// FilterClearSequences removes ANSI sequences that would clear the screen.
-// MUD clients typically ignore these to prevent server-side screen wipes.
-func FilterClearSequences(line string) string {
-	// Filter clear screen sequences
-	line = strings.ReplaceAll(line, "\x1b[2J", "")   // Clear entire screen
-	line = strings.ReplaceAll(line, "\x1b[H", "")    // Move cursor to home
-	line = strings.ReplaceAll(line, "\x1b[0;0H", "") // Move cursor to 0,0
-	line = strings.ReplaceAll(line, "\x1b[1;1H", "") // Move cursor to 1,1
-	return line
-}
-
 // tabStop is the classic terminal tab width.
 const tabStop = 8
 


### PR DESCRIPTION
Fixes #69.

Aardwolf's OLC editor sends a clear-screen when it opens. Rune's display path only filtered four exact byte strings (`FilterClearSequences`), and only on the line path — so variants like `ESC[J`/`ESC[K`, cursor addressing, and anything arriving as an unterminated prompt block leaked to the terminal and erased the separators around the input line and (temporarily) the status bar.

## Approach

Ignore the clear like CMUD/MUSHclient do (per the Discord discussion), rather than applying it to the append-only scrollback:

- **`text.SanitizeDisplay`**: allowlist sanitizer next to `StripANSI`, sharing its state-machine structure. Keeps plain text and plain SGR color sequences (`CSI ... m` with numeric params only — `CSI > 4 m` XTMODKEYS and friends don't qualify); drops all other escape sequences and terminal-active C0 controls. Tab/CR/LF pass through since later display stages own tab expansion and line splitting. Distinct from `StripANSI`, which removes *everything* including colors to produce the clean text triggers match against.
- **Applied at session display egress**, after Lua hooks so scripts still see the raw line: server line print, prompt overlay (sanitized before storing in `lastPrompt`, covering the later scrollback commit), `rune.print`, and pane writes — pane content is often trigger-captured server text. The echo path was already projected via `VisualizeTerminalControls`.
- **Removed `FilterClearSequences`** from the TUI.

## Testing

- New regression scenario `test/e2e/scenarios/regressions/69-editor-clear-screen.json` (written first, confirmed failing): editor-style burst on both the line path and the GA-terminated prompt path, asserting the escapes never reach any display surface while SGR color survives.
- Byte-exact table-driven tests for `SanitizeDisplay`.
- `go test -race` passes on e2e, session, text, and all ui packages.