### PR TITLE
lua: one presentation convention for core output tags

### DIFF
--- a/lua/commands_test.go
+++ b/lua/commands_test.go
@@ -63,3 +63,25 @@ func TestListingCommandsShowRegistrations(t *testing.T) {
 		t.Errorf("listing commands leaked to the network: %v", sent)
 	}
 }
+
+// TestErrorTagIsRed pins the presentation convention (05_style.lua):
+// [Error] tags are red, tag only, message plain - checked on the two
+// highest-traffic paths, the default error handler and unknown
+// commands.
+func TestErrorTagIsRed(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	engine.CallHook("error", "something broke")
+	engine.OnInput("/nosuchcommand")
+
+	printed := strings.Join(host.DrainPrintCalls(), "\n")
+	for _, want := range []string{
+		"\x1b[31m[Error]\x1b[0m something broke",
+		"\x1b[31m[Error]\x1b[0m Unknown command: /nosuchcommand",
+	} {
+		if !strings.Contains(printed, want) {
+			t.Errorf("missing red-tagged error %q in:\n%s", want, printed)
+		}
+	}
+}

--- a/lua/core/05_style.lua
+++ b/lua/core/05_style.lua
@@ -4,6 +4,10 @@
 -- degraded-mode messages (see text package).
 --
 -- Usage: rune.echo(rune.style.red("[Error]") .. " something broke")
+--
+-- Tag conventions for core output: [Error] tags are red (tag only,
+-- message plain), [Usage] lines are plain, success/action tags
+-- ([World], [Log], [Loaded], ...) are green.
 
 local function wrap(code)
     local prefix = "\027[" .. code .. "m"

--- a/lua/core/55_commands.lua
+++ b/lua/core/55_commands.lua
@@ -172,7 +172,7 @@ rune.command.add("reconnect", function(args)
     if addr then
         rune.connect(addr)
     else
-        rune.echo("[Error] No previous connection")
+        rune.echo(red("[Error]") .. " No previous connection")
     end
 end, "Reconnect to last server")
 
@@ -184,9 +184,9 @@ rune.command.add("load", function(args)
     end
     local ok, err = rune.load(args)
     if ok then
-        rune.echo("[Loaded] " .. args)
+        rune.echo(green("[Loaded]") .. " " .. args)
     else
-        rune.echo("[Error] " .. tostring(err))
+        rune.echo(red("[Error]") .. " " .. tostring(err))
     end
 end, "Load a Lua script file")
 
@@ -210,10 +210,10 @@ rune.command.add("lua", function(args)
                 rune.echo(tostring(result))
             end
         else
-            rune.echo("[Error] " .. tostring(result))
+            rune.echo(red("[Error]") .. " " .. tostring(result))
         end
     else
-        rune.echo("[Error] " .. tostring(err))
+        rune.echo(red("[Error]") .. " " .. tostring(err))
     end
 end, "Execute Lua code")
 

--- a/lua/core/75_send.lua
+++ b/lua/core/75_send.lua
@@ -64,7 +64,7 @@ end
 -- INTERNAL: Recursive send implementation
 local function send_impl(input, depth)
     if depth > MAX_RECURSION_DEPTH then
-        rune.echo(rune.style.red("[Error] Alias loop detected (depth limit exceeded)"))
+        rune.echo(rune.style.red("[Error]") .. " Alias loop detected (depth limit exceeded)")
         return
     end
 
@@ -130,7 +130,7 @@ rune.hooks.on("input", function(input, context)
     local cmd, args = input:match("^/(%S+)%s*(.*)")
     if cmd then
         if not rune.command.dispatch(cmd, args) then
-            rune.echo("[Error] Unknown command: /" .. cmd)
+            rune.echo(rune.style.red("[Error]") .. " Unknown command: /" .. cmd)
         end
         return false
     end

--- a/lua/core/85_events.lua
+++ b/lua/core/85_events.lua
@@ -63,5 +63,5 @@ rune.hooks.on("loaded", function(path)
 end, { priority = 100 })
 
 rune.hooks.on("error", function(msg)
-    rune.echo("[Error] " .. msg)
+    rune.echo(rune.style.red("[Error]") .. " " .. msg)
 end, { priority = 100 })


### PR DESCRIPTION
Error tags were red in six core sites and plain in six others - and the plain ones included the default error handler, the highest-traffic error path in the client. One rule now applies everywhere, stated in 05_style.lua (the file that owns ANSI in the Lua core):

- `[Error]` tags are red - tag only, message plain
- `[Usage]` lines are plain (already true everywhere; now the written rule)
- success/action tags are green (`[Loaded]` joins `[World]`/`[Log]`/`[Group]`)

Changed sites: the default `error` handler (85_events), unknown commands and the alias-loop notice in 75_send (the latter was whole-line red), and `/reconnect`, `/load`, `/lua` in 55_commands.

`TestErrorTagIsRed` pins the convention on the default error handler and unknown-command paths. Full suite passes.