### PR TITLE
network: detect prompt mode from received GA/EOR, not negotiation

### DIFF
--- a/network/client.go
+++ b/network/client.go
@@ -62,9 +62,10 @@ type connection struct {
 	// Identity negotiation responder (TTYPE/MTTS, NAWS, CHARSET, MNES)
 	hs *handshake
 
-	// Telnet mode tracking - separate flags allow proper reversion
-	willEOR atomic.Bool // Server indicated WILL EOR
-	willSGA atomic.Bool // Server indicated WILL SGA (Suppress Go Ahead)
+	// Prompt-mode evidence: set once the first IAC GA or EOR arrives.
+	// Mode keys on received terminators, not negotiation state -
+	// options promise behavior, marks demonstrate it.
+	promptTerminated atomic.Bool
 
 	gmcpActive atomic.Bool // GMCP negotiated on this connection
 
@@ -188,7 +189,6 @@ func (c *TCPClient) Connect(ctx context.Context, address string) error {
 		done:      make(chan struct{}),
 	}
 	cx.localEcho.Store(true)
-	// willEOR and willSGA default to false (unterminated prompt mode)
 
 	// Set as current and start workers
 	c.current = cx
@@ -391,8 +391,9 @@ func (c *TCPClient) processIncoming(cx *connection, data []byte) bool {
 
 		case TelnetEventIAC:
 			if ev.Command == CmdGA || ev.Command == CmdEOR {
-				// GA/EOR commands indicate prompt termination for this message,
-				// but don't change the negotiated mode (that's done via WILL/WONT)
+				// A received mark is evidence the server terminates its
+				// prompts; the first one switches modes for good.
+				cx.markPromptTerminated()
 				if cx.output.HasNewData() {
 					prompt := cx.output.Prompt(true)
 					if prompt != "" {
@@ -573,7 +574,12 @@ func (cx *connection) shutdown() {
 	})
 }
 
-// applyNegotiation updates local state based on telnet negotiation events.
+// applyNegotiation updates local echo state from telnet negotiation.
+// EOR/SGA negotiation deliberately does not drive prompt mode: WILL is
+// a promise about future marks and DO concerns our own output, so a
+// server could negotiate either and still send unterminated prompts.
+// Only received GA/EOR marks switch modes (markPromptTerminated), the
+// way other MUD clients detect prompts.
 func (cx *connection) applyNegotiation(cmd, opt byte) {
 	switch opt {
 	case OptEcho:
@@ -585,36 +591,22 @@ func (cx *connection) applyNegotiation(cmd, opt byte) {
 			// Server won't echo or wants us to echo - enable local echo
 			cx.localEcho.Store(true)
 		}
-	case OptEOR:
-		switch cmd {
-		case CmdWILL, CmdDO:
-			cx.willEOR.Store(true)
-			cx.updateTelnetMode()
-		case CmdWONT, CmdDONT:
-			cx.willEOR.Store(false)
-			cx.updateTelnetMode()
-		}
-	case OptSGA:
-		switch cmd {
-		case CmdWILL, CmdDO:
-			cx.willSGA.Store(true)
-			cx.updateTelnetMode()
-		case CmdWONT, CmdDONT:
-			cx.willSGA.Store(false)
-			cx.updateTelnetMode()
-		}
 	}
 }
 
-// telnetMode returns the current telnet mode based on negotiation state.
+// markPromptTerminated records received GA/EOR evidence. From the
+// first mark on, the unterminated-prompt peek turns off and the output
+// buffer stops clearing on input; sticky for the connection.
+func (cx *connection) markPromptTerminated() {
+	if !cx.promptTerminated.Swap(true) {
+		cx.output.SetMode(TelnetModeTerminatedPrompt)
+	}
+}
+
+// telnetMode returns the current prompt-detection mode.
 func (cx *connection) telnetMode() TelnetMode {
-	if cx.willEOR.Load() || cx.willSGA.Load() {
+	if cx.promptTerminated.Load() {
 		return TelnetModeTerminatedPrompt
 	}
 	return TelnetModeUnterminated
-}
-
-// updateTelnetMode recalculates and applies the telnet mode to the output buffer.
-func (cx *connection) updateTelnetMode() {
-	cx.output.SetMode(cx.telnetMode())
 }

--- a/network/client_test.go
+++ b/network/client_test.go
@@ -402,6 +402,88 @@ func TestGMCPSendRequiresNegotiation(t *testing.T) {
 
 // --- prompt emission ---
 
+// TestUnterminatedPromptSurvivesPromptlessNegotiation pins the
+// prompt-mode policy: negotiating SGA or EOR is not evidence of prompt
+// termination (WILL is a promise, DO concerns our output), so a server
+// that negotiates either but never sends GA/EOR keeps its unterminated
+// prompts visible.
+func TestUnterminatedPromptSurvivesPromptlessNegotiation(t *testing.T) {
+	for _, neg := range []struct {
+		name  string
+		bytes []byte
+	}{
+		{"WILL SGA", []byte{CmdIAC, CmdWILL, OptSGA}},
+		{"DO EOR", []byte{CmdIAC, CmdDO, OptEOR}},
+	} {
+		t.Run(neg.name, func(t *testing.T) {
+			addr := telnetServer(t, func(t *testing.T, conn net.Conn) {
+				conn.Write(neg.bytes)
+				time.Sleep(50 * time.Millisecond)
+				conn.Write([]byte("Enter your name: "))
+
+				buf := make([]byte, 1)
+				conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+				conn.Read(buf)
+			})
+
+			c := connectLoopback(t, addr)
+			out := nextOutput(t, c, OutputPrompt, "unterminated prompt after "+neg.name)
+			if out.Payload != "Enter your name: " {
+				t.Fatalf("prompt = %q, want %q", out.Payload, "Enter your name: ")
+			}
+		})
+	}
+}
+
+// TestFirstGASwitchesOffUnterminatedPeek verifies the received-mark
+// switch: after the first GA-terminated prompt, a later partial line
+// is no longer peeked at read boundaries - it renders exactly once,
+// when its own GA arrives.
+func TestFirstGASwitchesOffUnterminatedPeek(t *testing.T) {
+	addr := telnetServer(t, func(t *testing.T, conn net.Conn) {
+		conn.Write(append([]byte("HP:100> "), CmdIAC, CmdGA))
+		time.Sleep(50 * time.Millisecond)
+		conn.Write([]byte("HP:90> ")) // partial, terminator still in flight
+		time.Sleep(50 * time.Millisecond)
+		conn.Write([]byte{CmdIAC, CmdGA})
+		conn.Write([]byte("marker\r\n"))
+
+		buf := make([]byte, 1)
+		conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+		conn.Read(buf)
+	})
+
+	c := connectLoopback(t, addr)
+	var prompts []string
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case out := <-c.Output():
+			switch out.Kind {
+			case OutputPrompt:
+				prompts = append(prompts, out.Payload)
+			case OutputLine:
+				if out.Payload == "marker" {
+					count := 0
+					for _, p := range prompts {
+						if p == "HP:90> " {
+							count++
+						}
+					}
+					if count != 1 {
+						t.Fatalf("second prompt emitted %d times, want exactly 1 (via GA); prompts=%q", count, prompts)
+					}
+					return
+				}
+			case OutputDisconnect:
+				t.Fatal("connection dropped while waiting for marker")
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for marker line")
+		}
+	}
+}
+
 // TestPromptEmittedOncePerGABatch pins the duplicate-prompt bug: a
 // line and a GA-terminated prompt arriving in one read must produce
 // exactly one prompt event. Before the fix, the unterminated-mode

--- a/network/telnet.go
+++ b/network/telnet.go
@@ -785,8 +785,8 @@ func (o *OutputBuffer) Clear() {
 func defaultCompatibility() CompatibilityTable {
 	t := NewCompatibilityTable()
 	t.Support(OptEcho)            // WILL/WONT ECHO toggles local echo (client.go)
-	t.Support(OptSGA)             // Suppress Go Ahead: prompt mode detection
-	t.Support(OptEOR)             // End of Record: prompt termination
+	t.Support(OptSGA)             // Suppress Go Ahead: full-duplex handshake
+	t.Support(OptEOR)             // End of Record: servers mark prompts with IAC EOR
 	t.SupportLocal(OptTTYPE)      // Terminal type + MTTS cycle (negotiate.go)
 	t.SupportLocal(OptNAWS)       // Window size reports (negotiate.go, client.go)
 	t.Support(OptCharset)         // UTF-8 charset negotiation (negotiate.go)


### PR DESCRIPTION
Fixes #76.

## Problem

Prompt-detection mode switched to terminated on any `WILL`/`DO` for EOR or SGA. Both readings cross the option directions: `DO EOR` asks the *client* to mark its records, and `WILL SGA` declares go-aheads *suppressed* - neither promises server-terminated prompts. A server that negotiates SGA (a routine full-duplex handshake) or probes with `DO EOR` while sending ordinary unterminated prompts made the login prompt silently invisible: the unterminated peek was disabled and no mark ever arrived to flush it.

## Fix

Mode now keys on evidence: the first received `IAC GA` or `IAC EOR` switches the connection to terminated mode, sticky until disconnect. Negotiation no longer drives prompt detection at all - `applyNegotiation` only tracks echo. This matches how TinTin++, Mudlet, and MUSHclient handle prompts: received marks drive display; negotiation at most invites the marks. EOR/SGA remain in the compatibility table so the options still negotiate.

Known tradeoff, deliberate: a server that sends exactly one stray GA and then never terminates again would strand later prompts - a far stranger server than the common ones the old behavior broke on. If one ever surfaces, the escape hatch is reverting to peeks when a partial line survives several reads unterminated.

## Tests

- `TestUnterminatedPromptSurvivesPromptlessNegotiation` (`WILL SGA` and `DO EOR` subtests): promptless negotiation must not hide unterminated prompts - both failed before this change.
- `TestFirstGASwitchesOffUnterminatedPeek`: after the first GA, a later partial line renders exactly once, via its own mark.
- Existing `TestPromptEmittedOncePerGABatch` and the prompt-fragmentation e2e regression still pass.

Note: only the network package is touched; the network suite passes. The full local suite currently has unrelated churn from concurrent work-in-progress in `session/` (separate effort in the same checkout), which does not interact with this diff.