### PR TITLE
network: escape IAC in outgoing line data

### DIFF
--- a/network/client.go
+++ b/network/client.go
@@ -545,6 +545,12 @@ func (c *TCPClient) writeLoop(cx *connection) {
 				// Clear prompt buffer before sending - in unterminated mode,
 				// the server will reprint the prompt after echoing our input
 				cx.output.InputSent()
+				// Line data is text: double IAC bytes so the server
+				// reads them as data, not commands. Raw messages are
+				// protocol frames and pass through untouched.
+				if bytes.IndexByte(data, CmdIAC) >= 0 {
+					data = EscapeIAC(data)
+				}
 				data = append(data, '\r', '\n')
 			}
 

--- a/network/client_test.go
+++ b/network/client_test.go
@@ -402,6 +402,28 @@ func TestGMCPSendRequiresNegotiation(t *testing.T) {
 
 // --- prompt emission ---
 
+// TestSendEscapesIAC verifies outgoing line data doubles IAC bytes so
+// the server reads them as data. Protocol frames stay untouched - the
+// negotiation loopback tests pin those byte-exact.
+func TestSendEscapesIAC(t *testing.T) {
+	done := make(chan struct{})
+	addr := telnetServer(t, func(t *testing.T, conn net.Conn) {
+		defer close(done)
+		expectBytes(t, conn, []byte{'a', 0xFF, 0xFF, 'b', '\r', '\n'}, "escaped line send")
+	})
+
+	c := connectLoopback(t, addr)
+	if err := c.Send("a\xffb"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server never saw the escaped bytes")
+	}
+}
+
 // TestUnterminatedPromptSurvivesPromptlessNegotiation pins the
 // prompt-mode policy: negotiating SGA or EOR is not evidence of prompt
 // termination (WILL is a promise, DO concerns our output), so a server


### PR DESCRIPTION
Fixes #78.

Rune wrote user text to the socket as-is. In telnet, a 0xFF byte in data must be doubled or the server reads it as the start of a command - eating it and the byte after it. Typing can't produce that byte (UTF-8 never contains 0xFF), but Lua scripts send raw bytes, and since the inbound decoding fix, server text containing Latin-1 "ÿ" can arrive in a trigger and be sent back out.

The fix is in the write loop: line messages (all user/script text) get IAC bytes doubled before the line ending is added, with a fast path that skips the copy when there is no 0xFF. Raw messages - negotiation replies, GMCP, NAWS - are untouched; they are already correctly framed, and the existing byte-exact loopback tests prove they stay that way.

One deliberate consequence: scripts can no longer inject raw telnet commands through `rune.send_raw`. That was undocumented and unused; `send_raw` means "skip alias processing", not "skip the protocol". Mudlet, MUSHclient, and Blightmud all escape outgoing text the same way.

`TestSendEscapesIAC` pins the wire bytes (`a ff ff b 0d 0a`); it fails without the fix. Full suite passes.