### PR TITLE
network: refuse unimplemented negotiation directions

### DIFF
--- a/network/telnet.go
+++ b/network/telnet.go
@@ -586,8 +586,9 @@ func (p *Parser) processNegotiation(command, opt byte) []TelnetEvent {
 
 	case CmdDO:
 		if entry.Local && !entry.LocalState {
+			// DO enables our side only; the remote side needs the
+			// server's own WILL.
 			entry.LocalState = true
-			entry.RemoteState = true
 			p.Options.Set(opt, entry)
 			responses = append(responses, TelnetEvent{
 				Kind: TelnetEventDataSend,
@@ -784,9 +785,9 @@ func (o *OutputBuffer) Clear() {
 // options here only together with their implementation.
 func defaultCompatibility() CompatibilityTable {
 	t := NewCompatibilityTable()
-	t.Support(OptEcho)            // WILL/WONT ECHO toggles local echo (client.go)
+	t.SupportRemote(OptEcho)      // WILL/WONT ECHO toggles local echo (client.go); we never echo to the server
 	t.Support(OptSGA)             // Suppress Go Ahead: full-duplex handshake
-	t.Support(OptEOR)             // End of Record: servers mark prompts with IAC EOR
+	t.SupportRemote(OptEOR)       // End of Record: servers mark prompts; we never send them
 	t.SupportLocal(OptTTYPE)      // Terminal type + MTTS cycle (negotiate.go)
 	t.SupportLocal(OptNAWS)       // Window size reports (negotiate.go, client.go)
 	t.Support(OptCharset)         // UTF-8 charset negotiation (negotiate.go)

--- a/network/telnet_test.go
+++ b/network/telnet_test.go
@@ -611,8 +611,22 @@ func TestNegotiationDO(t *testing.T) {
 
 	// Check state
 	entry := parser.Options.Get(OptNAWS)
-	if !entry.LocalState || !entry.RemoteState {
-		t.Error("Both LocalState and RemoteState should be true after DO")
+	if !entry.LocalState {
+		t.Error("LocalState should be true after accepted DO")
+	}
+	if entry.RemoteState {
+		t.Error("RemoteState must stay false: the server never sent WILL")
+	}
+}
+
+// TestDefaultCompatibilityRefusesUnimplementedDirections verifies the
+// remote-only options: the server's WILL is accepted, but its DO is
+// refused - the client never echoes to the server or sends EOR marks.
+func TestDefaultCompatibilityRefusesUnimplementedDirections(t *testing.T) {
+	for _, opt := range []byte{OptEcho, OptEOR} {
+		parser := NewParser(DefaultCompatibility())
+		events := parser.Receive([]byte{CmdIAC, CmdDO, opt})
+		assertReply(t, events, []byte{CmdIAC, CmdWONT, opt}, "DO", opt)
 	}
 }
 


### PR DESCRIPTION
Fixes #80.

- ECHO and EOR are registered remote-only: the server's `WILL` is still accepted (echo suppression, prompt marks work as before), its `DO` is refused with `WONT` instead of promising behavior the client doesn't have.
- Accepting a `DO` no longer sets the option's remote state; that requires the server's own `WILL`. Wire replies are unchanged.

`TestNegotiationDO` now asserts remote state stays false, and a new test pins the `WONT` replies for `DO ECHO`/`DO EOR`. The identity-negotiation loopback test covers the client-answered options (TTYPE, NAWS, CHARSET, MNES) end to end. Full suite passes.