### PR TITLE
Layout entries carry component options; separator takes char

### DIFF
--- a/lua/api_bar.go
+++ b/lua/api_bar.go
@@ -50,6 +50,8 @@ func (e *Engine) registerBarFuncs() {
 
 // parseLayoutArray converts a Lua array table to LayoutEntry slice.
 // Supports both strings ("name") and tables ({name="name", height=10}).
+// Any other string-valued key on a table entry is carried in Opts
+// without interpretation; the named widget owns its keys' meaning.
 func parseLayoutArray(L *glua.LState, tbl *glua.LTable) []ui.LayoutEntry {
 	var result []ui.LayoutEntry
 	tbl.ForEach(func(k, v glua.LValue) {
@@ -58,7 +60,7 @@ func parseLayoutArray(L *glua.LState, tbl *glua.LTable) []ui.LayoutEntry {
 			// Simple string: "component_name"
 			result = append(result, ui.LayoutEntry{Name: string(val)})
 		case *glua.LTable:
-			// Table: {name="component_name", height=10}
+			// Table: {name="component_name", height=10, ...opts}
 			entry := ui.LayoutEntry{}
 			if name := L.GetField(val, "name"); name != glua.LNil {
 				entry.Name = name.String()
@@ -68,6 +70,18 @@ func parseLayoutArray(L *glua.LState, tbl *glua.LTable) []ui.LayoutEntry {
 					entry.Height = int(h)
 				}
 			}
+			val.ForEach(func(ok, ov glua.LValue) {
+				key, isStr := ok.(glua.LString)
+				if !isStr || key == "name" || key == "height" {
+					return
+				}
+				if s, isStr := ov.(glua.LString); isStr {
+					if entry.Opts == nil {
+						entry.Opts = make(map[string]string)
+					}
+					entry.Opts[string(key)] = string(s)
+				}
+			})
 			if entry.Name != "" {
 				result = append(result, entry)
 			}

--- a/lua/layout_test.go
+++ b/lua/layout_test.go
@@ -1,0 +1,43 @@
+package lua
+
+import "testing"
+
+// rune.ui.layout carries unknown table-entry keys to Go as an opaque
+// option bag; name/height stay typed fields and never leak into it.
+func TestLayoutEntryOptsPassThrough(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	script := `
+		rune.ui.layout({
+			top    = { { name = "chat", height = 10 } },
+			bottom = { "input", { name = "separator", char = "=" }, "status" },
+		})
+	`
+	if err := engine.DoString("test", script); err != nil {
+		t.Fatalf("script failed: %v", err)
+	}
+
+	layout := engine.GetLayout()
+
+	if len(layout.Top) != 1 || len(layout.Bottom) != 3 {
+		t.Fatalf("got %d top / %d bottom entries, want 1/3: %+v", len(layout.Top), len(layout.Bottom), layout)
+	}
+
+	chat := layout.Top[0]
+	if chat.Name != "chat" || chat.Height != 10 || chat.Opts != nil {
+		t.Errorf("chat entry = %+v, want name/height typed and no opts", chat)
+	}
+
+	sep := layout.Bottom[1]
+	if sep.Name != "separator" || sep.Opts["char"] != "=" {
+		t.Errorf("separator entry = %+v, want opts char %q", sep, "=")
+	}
+	if _, leaked := sep.Opts["name"]; leaked {
+		t.Errorf("name leaked into opts: %+v", sep.Opts)
+	}
+
+	if plain := layout.Bottom[0]; plain.Name != "input" || plain.Opts != nil {
+		t.Errorf("string entry = %+v, want bare name", plain)
+	}
+}

--- a/ui/layout.go
+++ b/ui/layout.go
@@ -2,8 +2,9 @@ package ui
 
 // LayoutEntry represents a single component in a layout dock.
 type LayoutEntry struct {
-	Name   string // Component name (e.g., "input", "status", pane name)
-	Height int    // Explicit height in lines (0 = intrinsic/auto)
+	Name   string            // Component name (e.g., "input", "status", pane name)
+	Height int               // Explicit height in lines (0 = intrinsic/auto)
+	Opts   map[string]string // Component-specific options, passed through opaquely; only the named widget interprets its keys
 }
 
 // LayoutConfig declares which components go in each dock.

--- a/ui/tui/layout.go
+++ b/ui/tui/layout.go
@@ -45,6 +45,13 @@ func (m *Model) layoutDock(entries []ui.LayoutEntry) (string, int) {
 			continue
 		}
 
+		// Options are per-entry but the widget instance is shared, so
+		// pass the bag unconditionally: an entry without options must
+		// reset whatever a previous entry configured this render pass.
+		if c, ok := w.(widget.Configurable); ok {
+			c.SetOptions(entry.Opts)
+		}
+
 		// Width can affect intrinsic height (notably soft-wrapped composer
 		// text), so make the current width available before asking for it.
 		// Existing fixed-height widgets ignore the zero height.

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -338,6 +338,30 @@ func TestBarCannotClobberBuiltinWidget(t *testing.T) {
 	}
 }
 
+// TestLayoutEntryOptsReachWidget verifies layoutDock hands each
+// entry's option bag to Configurable widgets — and that a second
+// separator entry without options resets the shared instance instead
+// of inheriting the first entry's char.
+func TestLayoutEntryOptsReachWidget(t *testing.T) {
+	m := newTestModel(t)
+
+	// No "input" entry: the input widget draws its own default rule,
+	// which would mask a separator that failed to reset.
+	next, _ := m.Update(ui.UpdateLayoutMsg{
+		Top:    []ui.LayoutEntry{{Name: "separator", Opts: map[string]string{"char": "═"}}},
+		Bottom: []ui.LayoutEntry{{Name: "separator"}},
+	})
+	m = next.(*Model)
+
+	view := m.View()
+	if !strings.Contains(view, strings.Repeat("═", m.width)) {
+		t.Error("configured separator rule missing from view")
+	}
+	if !strings.Contains(view, strings.Repeat("─", m.width)) {
+		t.Error("option-less separator entry did not reset to the default rule")
+	}
+}
+
 // newInlinePickerModel builds a model with an inline picker open over a
 // command-style item list and the input seeded with text, returning the
 // outbound channel so tests can observe picker cancel messages.

--- a/ui/tui/style/styles.go
+++ b/ui/tui/style/styles.go
@@ -7,8 +7,12 @@ import (
 )
 
 // RenderBorder returns a horizontal border line with dim styling.
-func RenderBorder(width int) string {
-	return "\x1b[90m" + strings.Repeat("─", width) + "\x1b[0m"
+// An empty char draws the default rule.
+func RenderBorder(width int, char string) string {
+	if char == "" {
+		char = "─"
+	}
+	return "\x1b[90m" + strings.Repeat(char, width) + "\x1b[0m"
 }
 
 // Styles holds the lipgloss styles the widgets render with. Server

--- a/ui/tui/widget/input.go
+++ b/ui/tui/widget/input.go
@@ -110,7 +110,7 @@ func (i *Input) PreferredHeight() int {
 }
 
 func (i *Input) borderLine() string {
-	return style.RenderBorder(i.width)
+	return style.RenderBorder(i.width, "")
 }
 
 // Value returns the current input text.

--- a/ui/tui/widget/separator.go
+++ b/ui/tui/widget/separator.go
@@ -1,13 +1,21 @@
 package widget
 
-import "github.com/mmcdole/rune/ui/tui/style"
+import (
+	"github.com/mattn/go-runewidth"
 
-// Compile-time check that Separator implements Widget
-var _ Widget = (*Separator)(nil)
+	"github.com/mmcdole/rune/ui/tui/style"
+)
+
+// Compile-time checks that Separator implements Widget and Configurable
+var (
+	_ Widget       = (*Separator)(nil)
+	_ Configurable = (*Separator)(nil)
+)
 
 // Separator renders a horizontal line.
 type Separator struct {
 	width int
+	char  string
 }
 
 // NewSeparator creates a new separator widget.
@@ -15,9 +23,20 @@ func NewSeparator() *Separator {
 	return &Separator{}
 }
 
+// SetOptions implements Configurable. "char" sets the rule character;
+// anything but a single-cell value is dropped so the rule can never
+// break the width math.
+func (s *Separator) SetOptions(opts map[string]string) {
+	char := opts["char"]
+	if runewidth.StringWidth(char) != 1 {
+		char = ""
+	}
+	s.char = char
+}
+
 // View implements Widget.
 func (s *Separator) View() string {
-	return style.RenderBorder(s.width)
+	return style.RenderBorder(s.width, s.char)
 }
 
 // SetSize implements Widget.

--- a/ui/tui/widget/separator_test.go
+++ b/ui/tui/widget/separator_test.go
@@ -1,0 +1,52 @@
+package widget
+
+import "testing"
+
+// The separator's contract: the rule character comes from the "char"
+// option, and anything that isn't exactly one display cell falls back
+// to the default so the rule always spans the width it was given.
+func TestSeparatorCharOption(t *testing.T) {
+	cases := []struct {
+		name  string
+		opts  map[string]string
+		width int
+		want  string
+	}{
+		{"no options", nil, 5, "─────"},
+		{"double rule", map[string]string{"char": "═"}, 5, "═════"},
+		{"ascii equals", map[string]string{"char": "="}, 3, "==="},
+		{"unknown keys ignored", map[string]string{"color": "red"}, 3, "───"},
+		{"wide char falls back", map[string]string{"char": "全"}, 4, "────"},
+		{"multi-char falls back", map[string]string{"char": "=="}, 4, "────"},
+		{"empty char falls back", map[string]string{"char": ""}, 4, "────"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := NewSeparator()
+			s.SetOptions(tc.opts)
+			s.SetSize(tc.width, 1)
+			want := "\x1b[90m" + tc.want + "\x1b[0m"
+			if got := s.View(); got != want {
+				t.Errorf("View() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+// A later entry without options must reset a char set earlier in the
+// same render pass — the widget instance is shared across entries.
+func TestSeparatorOptionsResetBetweenEntries(t *testing.T) {
+	s := NewSeparator()
+	s.SetSize(3, 1)
+
+	s.SetOptions(map[string]string{"char": "═"})
+	if got, want := s.View(), "\x1b[90m═══\x1b[0m"; got != want {
+		t.Fatalf("configured View() = %q, want %q", got, want)
+	}
+
+	s.SetOptions(nil)
+	if got, want := s.View(), "\x1b[90m───\x1b[0m"; got != want {
+		t.Errorf("reset View() = %q, want %q", got, want)
+	}
+}

--- a/ui/tui/widget/widget.go
+++ b/ui/tui/widget/widget.go
@@ -6,3 +6,11 @@ type Widget interface {
 	PreferredHeight() int
 	View() string
 }
+
+// Configurable is an optional interface for widgets that accept
+// per-layout-entry options. The layout passes each entry's option bag
+// through untouched (nil when the entry has none); the widget alone
+// interprets its keys and must tolerate unknown ones.
+type Configurable interface {
+	SetOptions(opts map[string]string)
+}

--- a/website/src/content/docs/interface/layout.md
+++ b/website/src/content/docs/interface/layout.md
@@ -38,10 +38,10 @@ a separator rule, and the status bar below it.
   `"input"`, `"status"`, `"separator"`. A table entry
   (`{ name = ..., height = n }`) sets an explicit height in lines (a pane
   spends two of those on its header and bottom border).
-- A table entry can also carry component options: the separator takes
-  `char`, so `{ name = "separator", char = "═" }` draws a double rule.
-  Anything fancier than a repeated character is a one-line
-  [bar](/interface/bars/) away.
+- A table entry can also carry component options — extra string-valued
+  keys handed to the component it names (see
+  [Built-in components](#built-in-components)). Unknown keys are
+  ignored.
 - `rune.ui.layout` replaces the whole layout. Always include the bottom
   dock with `"input"`, because nothing re-adds the input line if you leave
   it out.
@@ -50,6 +50,20 @@ a separator rule, and the status bar below it.
   or writing to a pane is not enough — the layout decides what appears.
 - The default layout is `bottom = { "input", "status" }`. You only need
   `rune.ui.layout` to change it.
+
+## Built-in components
+
+- **`input`** — the [command line](/interface/input/) or multiline
+  composer. Its height is intrinsic; the layout only decides where it
+  sits. Always include it in the bottom dock.
+- **`status`** — the default status bar. Registering a bar named
+  `"status"` replaces it with your own renderer.
+- **`separator`** — a one-line horizontal rule. Its `char` option sets
+  the character the rule repeats: `{ name = "separator", char = "═" }`
+  draws a double rule. The character must occupy a single terminal
+  cell; anything else falls back to the default `─`. For anything
+  fancier than a repeated character — color, patterns, text — write a
+  [bar](/interface/bars/) instead.
 
 ## The pieces
 

--- a/website/src/content/docs/interface/layout.md
+++ b/website/src/content/docs/interface/layout.md
@@ -80,10 +80,13 @@ this in one short script.
 
 ## Reactive state
 
-Bars usually render from `rune.state`, a read-only table the client keeps
-current: `connected`, `address`, `scroll_mode`, `scroll_lines`, `width`,
-`height`. When your own state changes and a bar should reflect it now, call
-`rune.ui.refresh_bars()`.
+A bar renders from whatever state your script keeps — GMCP vitals, group
+flags, anything. Precompute in the event that changes the data, and call
+`rune.ui.refresh_bars()` when a bar should reflect it now rather than on
+the next tick. For client-side facts there is also
+[`rune.state`](/reference/api/state-lines/), a read-only table the client
+keeps current (`connected`, `address`, `scroll_mode`, `scroll_lines`,
+`width`, `height`) — it's what the built-in status bar renders from.
 
 **Related:** [rune.ui reference](/reference/api/ui/),
 [Bars](/interface/bars/),

--- a/website/src/content/docs/interface/layout.md
+++ b/website/src/content/docs/interface/layout.md
@@ -38,6 +38,10 @@ a separator rule, and the status bar below it.
   `"input"`, `"status"`, `"separator"`. A table entry
   (`{ name = ..., height = n }`) sets an explicit height in lines (a pane
   spends two of those on its header and bottom border).
+- A table entry can also carry component options: the separator takes
+  `char`, so `{ name = "separator", char = "═" }` draws a double rule.
+  Anything fancier than a repeated character is a one-line
+  [bar](/interface/bars/) away.
 - `rune.ui.layout` replaces the whole layout. Always include the bottom
   dock with `"input"`, because nothing re-adds the input line if you leave
   it out.

--- a/website/src/content/docs/interface/layout.md
+++ b/website/src/content/docs/interface/layout.md
@@ -78,15 +78,20 @@ a separator rule, and the status bar below it.
 The [quake console recipe](/cookbook/quake-console/) combines all of
 this in one short script.
 
-## Reactive state
+## Pull and push
 
-A bar renders from whatever state your script keeps — GMCP vitals, group
-flags, anything. Precompute in the event that changes the data, and call
-`rune.ui.refresh_bars()` when a bar should reflect it now rather than on
-the next tick. For client-side facts there is also
-[`rune.state`](/reference/api/state-lines/), a read-only table the client
-keeps current (`connected`, `address`, `scroll_mode`, `scroll_lines`,
-`width`, `height`) — it's what the built-in status bar renders from.
+Bars are pulled. Four times a second, rune calls each bar's render
+function and displays whatever it returns. The function reads state
+your script keeps, such as vitals stored by a GMCP handler. When that
+state changes and the bar should update before the next tick, call
+`rune.ui.refresh_bars()`.
+
+Panes are pushed. Nothing polls a pane; it shows the lines you append
+with `rune.pane.write()` as they arrive.
+
+Bars can also read [`rune.state`](/reference/api/state-lines/), a
+read-only table of client facts like the connection status and terminal
+size. The built-in status bar renders from it.
 
 **Related:** [rune.ui reference](/reference/api/ui/),
 [Bars](/interface/bars/),

--- a/website/src/content/docs/reference/api/ui.md
+++ b/website/src/content/docs/reference/api/ui.md
@@ -26,14 +26,10 @@ rune.ui.layout(config)
 
 - `config` (table) — `top` and/or `bottom` arrays of dock entries.
   Each entry is a string (the component name) or a table with options:
-  `{name = "tells", height = 8}`. Built-in components: `"input"` (the
-  command line), `"status"` (the default status bar), and
-  `"separator"` (a horizontal rule); anything else names a bar or pane.
-  Beyond `name` and `height`, string-valued keys are passed to the
-  named component, which ignores any it doesn't understand. The
-  separator accepts `char` — the character the rule repeats
-  (`{name = "separator", char = "═"}`); it must occupy a single
-  terminal cell, otherwise the default `─` is used.
+  `{name = "tells", height = 8}`. The name is a built-in component
+  (below), a bar, or a pane. Beyond `name` and `height`, string-valued
+  keys are passed to the named component as component options; a
+  component ignores keys it doesn't understand.
 
 ```lua
 -- The default layout
@@ -52,6 +48,17 @@ rune.ui.layout({
 A bar or pane renders only if a layout dock names it — see
 [Layout & UI](/interface/layout/).
 :::
+
+#### Built-in components
+
+- `"input"` — the command line or multiline composer. Height is
+  intrinsic; no options.
+- `"status"` — the default status bar, shown until a bar named
+  `"status"` replaces it. No options.
+- `"separator"` — a one-line horizontal rule. Options:
+  - `char` (string) — the character the rule repeats:
+    `{name = "separator", char = "═"}`. Must occupy a single terminal
+    cell; anything else falls back to the default `─`.
 
 ### rune.ui.bar
 

--- a/website/src/content/docs/reference/api/ui.md
+++ b/website/src/content/docs/reference/api/ui.md
@@ -29,6 +29,11 @@ rune.ui.layout(config)
   `{name = "tells", height = 8}`. Built-in components: `"input"` (the
   command line), `"status"` (the default status bar), and
   `"separator"` (a horizontal rule); anything else names a bar or pane.
+  Beyond `name` and `height`, string-valued keys are passed to the
+  named component, which ignores any it doesn't understand. The
+  separator accepts `char` — the character the rule repeats
+  (`{name = "separator", char = "═"}`); it must occupy a single
+  terminal cell, otherwise the default `─` is used.
 
 ```lua
 -- The default layout


### PR DESCRIPTION
Closes #85.

Layout table entries can now carry component-specific options beyond `name` and `height`:

```lua
rune.ui.layout({
    bottom = { "input", {name = "separator", char = "═"}, "status" }
})
```

The design deliberately keeps the shared layout plumbing ignorant of what any option means. `parseLayoutArray` copies string-valued keys other than `name`/`height` into an opaque `Opts map[string]string` on `LayoutEntry`; `layoutDock` hands the bag to any widget implementing the new optional `Configurable` interface. The string `"char"` appears in exactly one Go file: the separator widget, which validates the value to a single display cell (`runewidth`) and falls back to the default `─` otherwise, so the rule can never break width math. `name` and `height` stay typed fields because the layout algorithm itself consumes them; everything a component privately interprets rides in the bag, and future component options need no changes to the shared layer.

Because the separator is one shared widget instance, `layoutDock` passes the bag unconditionally — an entry without options resets whatever a previous entry configured in the same render pass. There's a model test pinning exactly that, plus table-driven widget tests for the char/fallback contract and a Lua-layer test that `char` survives the trip through `rune.ui.layout` without `name`/`height` leaking into the bag.

Anything richer than a repeated character (color, patterns, text in the rule) remains out of scope — that's expressible today as a custom bar renderer, and the docs point there.