### PR TITLE
Restructure the Layout & UI doc page

### DIFF
--- a/website/src/content/docs/interface/layout.md
+++ b/website/src/content/docs/interface/layout.md
@@ -5,8 +5,8 @@ description: The dock model, and how bars, panes, the input line, and the output
 
 Rune's screen is one main output viewport with docks above and below.
 Docks hold bars (single-line, script-rendered), panes (multi-line output
-buffers), and the built-in components `input`, `status`, and `separator`.
-You declare the arrangement once:
+buffers), and the built-ins `input` and `separator`. You declare the
+arrangement once:
 
 ```lua
 rune.ui.layout({
@@ -32,66 +32,51 @@ a separator rule, and the status bar below it.
 └─────────────────────────────┘
 ```
 
+## What a dock can hold
+
+**[Bars](/interface/bars/)** are single-line displays rendered by your
+script. Bars are pulled: four times a second, rune calls the bar's
+render function with the current width and shows what it returns. Call
+`rune.ui.refresh_bars()` when a bar should update sooner than the next
+tick. A renderer usually reads state your script keeps, such as vitals
+stored by a GMCP handler, and can also read
+[`rune.state`](/reference/api/state-lines/) for client facts like the
+connection status. The default status bar is simply a bar named
+`status` that the core scripts register; register your own renderer
+under that name to replace it.
+
+**[Panes](/interface/panes/)** are multi-line buffers that show their
+most recent lines. Panes are pushed: nothing polls them. A pane shows
+the lines your script appends with `rune.pane.write()` as they arrive,
+from a trigger, for example.
+
+**`input`** is the built-in [command line](/interface/input/). Its
+height is intrinsic, so the layout only decides where it sits.
+
+**`separator`** is a built-in one-line horizontal rule. Its `char`
+option sets the character the rule repeats:
+`{ name = "separator", char = "═" }` draws a double rule. The character
+must fit in a single terminal cell; anything else falls back to the
+default `─`. For a rule with color, patterns, or text, write a bar
+instead.
+
 ## Rules of the layout table
 
-- Entries are component names: a bar name, a pane name, or the built-ins
-  `"input"`, `"status"`, `"separator"`. A table entry
-  (`{ name = ..., height = n }`) sets an explicit height in lines (a pane
-  spends two of those on its header and bottom border).
-- A table entry can also carry component options — extra string-valued
-  keys handed to the component it names (see
-  [Built-in components](#built-in-components)). Unknown keys are
-  ignored.
-- `rune.ui.layout` replaces the whole layout. Always include the bottom
-  dock with `"input"`, because nothing re-adds the input line if you leave
-  it out.
-- Unknown names are skipped; hidden panes and empty bars take no space.
-- A bar or pane renders only if a dock names it. Registering a renderer
-  or writing to a pane is not enough — the layout decides what appears.
+- A table entry (`{ name = ..., height = n }`) sets an explicit height
+  in lines (a pane spends two of those on its header and bottom
+  border). Any other string-valued key is an option for the named
+  component, like the separator's `char`; unknown keys are ignored.
+- `rune.ui.layout` replaces the whole layout. Always include `"input"`
+  in a dock, because nothing re-adds it if you leave it out.
+- A component appears only if a dock names it. Registering a bar or
+  writing to a pane is not enough; the layout decides what shows.
+  Unknown names are skipped, and hidden panes and empty bars take no
+  space.
 - The default layout is `bottom = { "input", "status" }`. You only need
   `rune.ui.layout` to change it.
 
-## Built-in components
-
-- **`input`** — the [command line](/interface/input/) or multiline
-  composer. Its height is intrinsic; the layout only decides where it
-  sits. Always include it in the bottom dock.
-- **`status`** — the default status bar. Registering a bar named
-  `"status"` replaces it with your own renderer.
-- **`separator`** — a one-line horizontal rule. Its `char` option sets
-  the character the rule repeats: `{ name = "separator", char = "═" }`
-  draws a double rule. The character must occupy a single terminal
-  cell; anything else falls back to the default `─`. For anything
-  fancier than a repeated character — color, patterns, text — write a
-  [bar](/interface/bars/) instead.
-
-## The pieces
-
-- **[Bars](/interface/bars/)**: you write a render function, and rune
-  calls it with the current width every 250ms. The built-in status bar is
-  one of these.
-- **[Panes](/interface/panes/)**: named buffers that show their most
-  recent lines. Write to them from triggers; toggle them from binds.
-- **[Pickers](/interface/pickers/)**: fuzzy overlays for commands,
-  worlds, and anything your scripts want to offer.
-
-The [quake console recipe](/cookbook/quake-console/) combines all of
-this in one short script.
-
-## Pull and push
-
-Bars are pulled. Four times a second, rune calls each bar's render
-function and displays whatever it returns. The function reads state
-your script keeps, such as vitals stored by a GMCP handler. When that
-state changes and the bar should update before the next tick, call
-`rune.ui.refresh_bars()`.
-
-Panes are pushed. Nothing polls a pane; it shows the lines you append
-with `rune.pane.write()` as they arrive.
-
-Bars can also read [`rune.state`](/reference/api/state-lines/), a
-read-only table of client facts like the connection status and terminal
-size. The built-in status bar renders from it.
+The [quake console recipe](/cookbook/quake-console/) combines bars,
+panes, and layout in one short script.
 
 **Related:** [rune.ui reference](/reference/api/ui/),
 [Bars](/interface/bars/),


### PR DESCRIPTION
Follow-up to #86. The layout page had accreted three overlapping component sections ("Rules of the layout table" enumerating them, "Built-in components", "The pieces") plus a "Pull and push" section re-describing bars and panes, with the status bar appearing in two of them.

Restructured around the two questions a script author actually has:

- **What a dock can hold** — bars, panes, `input`, `separator`, each introduced exactly once, with its data-flow model stated inline (bars are pulled on the 250ms tick, `refresh_bars()` to update sooner; panes are pushed via `pane.write()`). The status bar is folded into the bars entry since it is one; the separator entry keeps the `char` option docs.
- **Rules of the layout table** — height, component options, whole-layout replacement, name-gated rendering, the default.

Pickers moved to the related links: they're overlays, not dock components, so listing them among the dock pieces was misleading.