### PR TITLE
ui: add chronological scrollback search

### DIFF
--- a/lua/api_state.go
+++ b/lua/api_state.go
@@ -2,12 +2,13 @@ package lua
 
 // ClientState holds the current client state for Lua access.
 type ClientState struct {
-	Connected   bool
-	Address     string
-	ScrollMode  string // "live" or "scrolled"
-	ScrollLines int    // Lines behind live (when scrolled)
-	Width       int    // Terminal width
-	Height      int    // Terminal height
+	Connected    bool
+	Address      string
+	ScrollMode   string // "live" or "scrolled"
+	ScrollLines  int    // Lines behind live (when scrolled)
+	SearchActive bool   // scrollback-search navigator is trapping input
+	Width        int    // Terminal width
+	Height       int    // Terminal height
 }
 
 // registerStateFuncs creates the rune._state table that Go pushes
@@ -16,12 +17,13 @@ type ClientState struct {
 func (e *Engine) registerStateFuncs() {
 	// Initialize with defaults
 	e.vm.RegisterModule("rune._state", nil, map[string]any{
-		"connected":    false,
-		"address":      "",
-		"scroll_mode":  "live",
-		"scroll_lines": 0,
-		"width":        0,
-		"height":       0,
+		"connected":     false,
+		"address":       "",
+		"scroll_mode":   "live",
+		"scroll_lines":  0,
+		"search_active": false,
+		"width":         0,
+		"height":        0,
 	})
 }
 
@@ -32,6 +34,7 @@ func (e *Engine) UpdateState(state ClientState) {
 	e.vm.SetModuleField("rune._state", "address", state.Address)
 	e.vm.SetModuleField("rune._state", "scroll_mode", state.ScrollMode)
 	e.vm.SetModuleField("rune._state", "scroll_lines", state.ScrollLines)
+	e.vm.SetModuleField("rune._state", "search_active", state.SearchActive)
 	e.vm.SetModuleField("rune._state", "width", state.Width)
 	e.vm.SetModuleField("rune._state", "height", state.Height)
 }

--- a/lua/api_ui.go
+++ b/lua/api_ui.go
@@ -1,6 +1,9 @@
 package lua
 
-import "github.com/mmcdole/rune/script"
+import (
+	"github.com/mmcdole/rune/script"
+	"github.com/mmcdole/rune/ui"
+)
 
 // registerUIFuncs registers all UI-related API functions
 func (e *Engine) registerUIFuncs() {
@@ -23,6 +26,19 @@ func (e *Engine) registerUIInternalFuncs() {
 		// system clipboard (OSC 52).
 		"set_clipboard": func(c *script.Call) error {
 			e.host.ClipboardSet(c.Str(1))
+			return nil
+		},
+
+		// rune._ui.search_show(opts): open the scrollback-search
+		// overlay. opts = { query = "..." } (optional; empty keeps the
+		// previous search's query). Fire-and-forget - unlike the picker
+		// there is no callback: the search is self-contained in the UI.
+		"search_show": func(c *script.Call) error {
+			query := ""
+			if c.NArgs() >= 1 && c.Arg(1).Kind() == script.KindTable {
+				query = c.Arg(1).Table().Field("query").Str()
+			}
+			e.host.ShowSearch(ui.ShowSearchMsg{Query: query})
 			return nil
 		},
 	}, nil)

--- a/lua/core/00_init.lua
+++ b/lua/core/00_init.lua
@@ -164,7 +164,7 @@ end
 -- Client state (read-only view)
 -- Go pushes updates into rune._state; rune.state is a read-only proxy
 -- so scripts cannot corrupt Go-owned state. Fields: connected,
--- address, scroll_mode, scroll_lines, width, height.
+-- address, scroll_mode, scroll_lines, search_active, width, height.
 rune.state = setmetatable({}, {
     __index = function(_, key)
         return rune._state[key]
@@ -259,6 +259,13 @@ rune.ui.picker = {}
 -- }
 function rune.ui.picker.show(opts)
     rune._ui.picker_show(opts)
+end
+
+-- Open the scrollback-search overlay (also bound to Ctrl+F and /find).
+-- opts = { query = "thief" }  -- optional; omitted or empty reopens
+--                             -- with the previous search's query
+function rune.ui.search(opts)
+    rune._ui.search_show(opts or {})
 end
 
 -- Startup

--- a/lua/core/55_commands.lua
+++ b/lua/core/55_commands.lua
@@ -404,6 +404,12 @@ rune.command.add("echo", function(args)
     rune.echo(args)
 end, "Print text locally")
 
+-- /find [pattern] - Search the scrollback. With no pattern the overlay
+-- reopens with the previous query (find-next lives in the overlay).
+rune.command.add("find", function(args)
+    rune.ui.search({ query = args })
+end, "Search scrollback")
+
 -- /version - Client version
 rune.command.add("version", function(args)
     rune.echo("Rune " .. rune.version .. " (lua: " .. rune.engine .. ")")

--- a/lua/core/95_ui.lua
+++ b/lua/core/95_ui.lua
@@ -147,7 +147,9 @@ rune.ui.bar("status", function(width)
 
     -- Right side: scroll mode indicator
     local right
-    if state.scroll_mode == "scrolled" then
+    if state.search_active then
+        right = yellow("SEARCH")
+    elseif state.scroll_mode == "scrolled" then
         right = yellow("SCROLL") .. " " .. dim("(" .. state.scroll_lines .. " new)")
     else
         right = dim("LIVE")
@@ -187,6 +189,13 @@ rune.bind("ctrl+t", function()
             rune.input.set(val)
         end
     })
+end)
+
+-- Scrollback Search (Ctrl+F)
+-- Reopening preserves the last query; typing replaces it. The overlay
+-- itself owns stepping (Up/Down), commit (Enter), and cancel (Esc).
+rune.bind("ctrl+f", function()
+    rune.ui.search()
 end)
 
 -- Slash Command Picker (Inline Mode)

--- a/lua/host.go
+++ b/lua/host.go
@@ -34,6 +34,7 @@ type Host interface {
 	PaneSetVisible(name string, visible bool)
 	PaneClear(name string)
 	ShowPicker(opts ui.ShowPickerMsg)
+	ShowSearch(opts ui.ShowSearchMsg)
 	ClipboardSet(text string)
 	GetInput() string
 	SetInput(text string)

--- a/lua/mock_host_test.go
+++ b/lua/mock_host_test.go
@@ -25,6 +25,7 @@ type MockHost struct {
 	ReloadCalls     int
 	PaneCalls       []struct{ Op, Name, Data string }
 	PickerCalls     []ui.ShowPickerMsg
+	SearchCalls     []ui.ShowSearchMsg
 	ClipboardCalls  []string
 	ScheduledTimers []struct {
 		ID       int
@@ -179,6 +180,12 @@ func (m *MockHost) ShowPicker(opts ui.ShowPickerMsg) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.PickerCalls = append(m.PickerCalls, opts)
+}
+
+func (m *MockHost) ShowSearch(opts ui.ShowSearchMsg) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.SearchCalls = append(m.SearchCalls, opts)
 }
 
 func (m *MockHost) ClipboardSet(text string) {

--- a/lua/search_test.go
+++ b/lua/search_test.go
@@ -1,0 +1,75 @@
+package lua
+
+import "testing"
+
+// TestSearchEntryPoints verifies the Lua policy layer around scrollback
+// search: the public wrapper, the Ctrl+F bind, and /find all reach the
+// host's ShowSearch with the right query. The search itself (scanning,
+// stepping, highlight) is UI-side and tested in ui/tui.
+func TestSearchEntryPoints(t *testing.T) {
+	cases := []struct {
+		name  string
+		run   func(e *Engine) error
+		query string // expected ShowSearchMsg.Query
+	}{
+		{
+			name:  "rune.ui.search with query",
+			run:   func(e *Engine) error { return e.DoString("t", `rune.ui.search({ query = "thief" })`) },
+			query: "thief",
+		},
+		{
+			name:  "rune.ui.search without opts keeps last query",
+			run:   func(e *Engine) error { return e.DoString("t", `rune.ui.search()`) },
+			query: "",
+		},
+		{
+			name:  "ctrl+f bind opens search",
+			run:   func(e *Engine) error { return e.DoString("t", `rune.binds._dispatch("ctrl+f")`) },
+			query: "",
+		},
+		{
+			name:  "/find with pattern",
+			run:   func(e *Engine) error { e.OnInput("/find the guard"); return nil },
+			query: "the guard",
+		},
+		{
+			name:  "/find bare reopens with last query",
+			run:   func(e *Engine) error { e.OnInput("/find"); return nil },
+			query: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, host, cleanup := setupTest(t)
+			defer cleanup()
+
+			if err := tc.run(engine); err != nil {
+				t.Fatalf("entry point failed: %v", err)
+			}
+			if len(host.SearchCalls) != 1 {
+				t.Fatalf("expected 1 ShowSearch call, got %d", len(host.SearchCalls))
+			}
+			if got := host.SearchCalls[0].Query; got != tc.query {
+				t.Errorf("Query = %q, want %q", got, tc.query)
+			}
+		})
+	}
+}
+
+// TestFindCommandListed verifies /find appears in the command registry,
+// which feeds both /help and the inline slash picker.
+func TestFindCommandListed(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	err := engine.DoString("find_listed", `
+		for _, c in ipairs(rune.command.list()) do
+			if c.name == "find" then return end
+		end
+		error("/find missing from the command registry")
+	`)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/session/lua_ui.go
+++ b/session/lua_ui.go
@@ -49,6 +49,11 @@ func (s *Session) ShowPicker(opts ui.ShowPickerMsg) {
 	s.ui.ShowPicker(opts)
 }
 
+// ShowSearch implements lua.Host.
+func (s *Session) ShowSearch(opts ui.ShowSearchMsg) {
+	s.ui.ShowSearch(opts)
+}
+
 // GetInput implements lua.Host.
 func (s *Session) GetInput() string {
 	return s.currentInput

--- a/session/mocks_test.go
+++ b/session/mocks_test.go
@@ -190,6 +190,7 @@ func (m *mockUI) pushedBinds() map[string]bool {
 }
 
 func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg)         {}
+func (m *mockUI) ShowSearch(opts ui.ShowSearchMsg)         {}
 func (m *mockUI) SetClipboard(text string)                 {}
 func (m *mockUI) CreatePane(name string)                   {}
 func (m *mockUI) WritePane(name, text string)              {}

--- a/session/session.go
+++ b/session/session.go
@@ -424,6 +424,10 @@ func (s *Session) handleUIMessage(msg ui.UIEvent) {
 		s.clientState.ScrollLines = m.NewLines
 		s.engine.UpdateState(s.clientState)
 		s.pushBarUpdates()
+	case ui.SearchStateChangedMsg:
+		s.clientState.SearchActive = bool(m)
+		s.engine.UpdateState(s.clientState)
+		s.pushBarUpdates()
 	case ui.PickerSelectMsg:
 		s.handlePickerResult(m.CallbackID, m.Value, m.Accepted)
 	case ui.InputChangedMsg:

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -266,6 +266,24 @@ func TestInputCursorConvertsAtUIBoundary(t *testing.T) {
 	}
 }
 
+func TestSearchStateIsIndependentFromScrollState(t *testing.T) {
+	s, _, _ := newTestSession(t)
+	s.clientState.ScrollMode = "live"
+
+	s.handleUIMessage(ui.SearchStateChangedMsg(true))
+	if !s.clientState.SearchActive {
+		t.Fatal("search-active UI event did not update client state")
+	}
+	if s.clientState.ScrollMode != "live" {
+		t.Fatalf("search changed scroll mode to %q", s.clientState.ScrollMode)
+	}
+
+	s.handleUIMessage(ui.SearchStateChangedMsg(false))
+	if s.clientState.SearchActive {
+		t.Fatal("search-close UI event left client state active")
+	}
+}
+
 func TestSendFailureReportedNotFatal(t *testing.T) {
 	s, net, uiMock := newTestSession(t)
 	net.connected = false // sends fail

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -209,6 +209,7 @@ func (m *mockUI) UpdateBars(content map[string]ui.BarContent) {}
 func (m *mockUI) UpdateBinds(keys map[string]bool)            {}
 func (m *mockUI) UpdateLayout(top, bottom []ui.LayoutEntry)   {}
 func (m *mockUI) ShowPicker(opts ui.ShowPickerMsg)            {}
+func (m *mockUI) ShowSearch(opts ui.ShowSearchMsg)            {}
 func (m *mockUI) SetClipboard(text string)                    {}
 func (m *mockUI) CreatePane(name string)                      {}
 func (m *mockUI) WritePane(name, text string)                 {}

--- a/ui/interface.go
+++ b/ui/interface.go
@@ -24,6 +24,7 @@ type UI interface {
 
 	// Components
 	ShowPicker(opts ShowPickerMsg)
+	ShowSearch(opts ShowSearchMsg)
 	SetClipboard(text string)
 	CreatePane(name string)
 	WritePane(name, text string)

--- a/ui/messages.go
+++ b/ui/messages.go
@@ -90,6 +90,14 @@ type ScrollStateChangedMsg struct {
 
 func (ScrollStateChangedMsg) uiEvent() {}
 
+// SearchStateChangedMsg reports whether the modal scrollback-search
+// navigator is active. Search interaction and viewport scroll position are
+// independent state dimensions, so this is deliberately not another
+// ScrollStateChangedMsg.Mode value.
+type SearchStateChangedMsg bool
+
+func (SearchStateChangedMsg) uiEvent() {}
+
 // InputChangedMsg notifies Session of input content changes. Cursor is a
 // zero-based rune offset from the input widget.
 type InputChangedMsg struct {
@@ -122,6 +130,17 @@ type ShowPickerMsg struct {
 	// a space - for pickers over single-token items (slash commands) where
 	// a space means the user has committed and is typing arguments.
 	DismissOnSpace bool
+}
+
+// --- Search Messages (Session -> UI) ---
+
+// ShowSearchMsg requests the UI to open the scrollback-search overlay.
+// Sent from Session when Lua calls rune.ui.search(). Fire-and-forget:
+// unlike the picker there is no callback to settle - the search is
+// self-contained in the UI, and its only session-visible outcome is
+// the viewport position, reported through ScrollStateChangedMsg.
+type ShowSearchMsg struct {
+	Query string // initial query; empty keeps the previous search's query
 }
 
 // SetClipboardMsg asks the terminal to set the system clipboard

--- a/ui/tui/input_mode.go
+++ b/ui/tui/input_mode.go
@@ -19,7 +19,18 @@ const (
 	ModeCompose                       // Lossless structured-text input
 	ModePickerModal                   // Modal picker traps all keys
 	ModePickerInline                  // Inline picker filters based on input
+	ModeSearch                        // Scrollback-search overlay traps all keys
 )
+
+// searchEffects is the viewport half of scrollback search, implemented
+// by Model. The controller owns the mode state machine; the viewport
+// snapshot, centering, and highlight stay with the widget owner.
+type searchEffects interface {
+	OpenSearch() widget.SearchScope              // snapshot viewport and choose the search origin
+	PreviewSearch(m widget.SearchMatch, ok bool) // center+highlight the match, or restore when none
+	CommitSearch()                               // keep the accepted match and its highlight
+	CancelSearch()                               // restore the viewport and prior highlight
+}
 
 // inputController owns the input-mode state machine: the current mode,
 // the active picker's Lua callback, and the invariant that every path
@@ -42,6 +53,7 @@ type inputController struct {
 	submit  func(input.Submission) bool // transfer an immutable draft to the session
 	isBound func(key string) bool       // key has a Lua bind
 	scroll  func(tea.KeyType) bool      // Go scroll-key fallback; true if handled
+	search  searchEffects               // viewport side of scrollback search
 }
 
 func newInputController(
@@ -50,6 +62,7 @@ func newInputController(
 	submit func(input.Submission) bool,
 	isBound func(string) bool,
 	scroll func(tea.KeyType) bool,
+	search searchEffects,
 ) *inputController {
 	return &inputController{
 		input:   input,
@@ -57,6 +70,7 @@ func newInputController(
 		submit:  submit,
 		isBound: isBound,
 		scroll:  scroll,
+		search:  search,
 	}
 }
 
@@ -74,7 +88,7 @@ func (c *inputController) HandleKey(msg tea.KeyMsg) {
 	// dispatch so even a one-character paste can never fire a printable
 	// hotkey, and so structured text never passes through textinput's
 	// newline/tab sanitizer.
-	if msg.Paste && c.mode != ModePickerModal {
+	if msg.Paste && c.mode != ModePickerModal && c.mode != ModeSearch {
 		c.handlePaste(msg)
 		return
 	}
@@ -89,6 +103,10 @@ func (c *inputController) HandleKey(msg tea.KeyMsg) {
 	case tea.KeyCtrlC, tea.KeyEsc:
 		if c.mode == ModePickerModal || c.mode == ModePickerInline {
 			c.closePicker(false, "")
+			return
+		}
+		if c.mode == ModeSearch {
+			c.closeSearch(false)
 			return
 		}
 		if c.mode == ModeCompose && msg.Type == tea.KeyEsc {
@@ -106,6 +124,8 @@ func (c *inputController) HandleKey(msg tea.KeyMsg) {
 		c.handleModalKey(msg)
 	case ModePickerInline:
 		c.handleInlineKey(msg)
+	case ModeSearch:
+		c.handleSearchKey(msg)
 	default:
 		c.handleNormalKey(msg)
 	}
@@ -120,6 +140,11 @@ func (c *inputController) ShowPicker(opts ui.ShowPickerMsg) {
 	if c.input.IsComposing() {
 		c.notify(ui.PickerSelectMsg{CallbackID: opts.CallbackID, Accepted: false})
 		return
+	}
+	// Picker and search overlays are mutually exclusive; the newcomer
+	// wins, the open search settles as cancelled.
+	if c.mode == ModeSearch {
+		c.closeSearch(false)
 	}
 	if opts.Inline {
 		c.mode = ModePickerInline
@@ -136,6 +161,9 @@ func (c *inputController) ShowPicker(opts ui.ShowPickerMsg) {
 // keep its filter in sync, and close the picker (cancelling its
 // callback) when the input is cleared.
 func (c *inputController) SetText(text string) {
+	if c.mode == ModeSearch {
+		c.closeSearch(false)
+	}
 	c.historyRecall = false
 	wasPicker := c.mode == ModePickerInline || c.mode == ModePickerModal
 	wasInline := c.mode == ModePickerInline
@@ -163,6 +191,9 @@ func (c *inputController) SetText(text string) {
 // Unlike SetText, an explicit command entry exits sticky compose mode, while
 // verbatim is forced even for one safe, non-empty physical line.
 func (c *inputController) SetSubmission(submission input.Submission) {
+	if c.mode == ModeSearch {
+		c.closeSearch(false)
+	}
 	wasPicker := c.mode == ModePickerInline || c.mode == ModePickerModal
 	c.historyRecall = submission.Mode == input.ModeVerbatim
 
@@ -427,6 +458,102 @@ func (c *inputController) syncInlineFilter() {
 		return
 	}
 	c.input.UpdatePickerFilter()
+}
+
+// ShowSearch opens the scrollback-search overlay. Unlike the picker
+// there is no callback to settle, so refusing while a structured draft
+// is active is a plain no-op. An open picker settles first: overlays
+// are mutually exclusive and the newcomer wins.
+func (c *inputController) ShowSearch(opts ui.ShowSearchMsg) {
+	if c.input.IsComposing() {
+		return
+	}
+	if c.mode == ModePickerModal || c.mode == ModePickerInline {
+		c.closePicker(false, "")
+	}
+	if c.mode != ModeSearch {
+		c.mode = ModeSearch
+		scope := c.search.OpenSearch()
+		c.input.ShowSearch(opts.Query, scope)
+	} else {
+		c.input.ReopenSearch(opts.Query)
+	}
+	c.previewSearch()
+}
+
+// handleSearchKey traps all keys while the search overlay is open,
+// like the modal picker: bound keys do not dispatch to Lua.
+func (c *inputController) handleSearchKey(msg tea.KeyMsg) {
+	switch msg.Type {
+	case tea.KeyUp:
+		c.selectOlderSearch()
+
+	case tea.KeyDown:
+		c.selectNewerSearch()
+
+	case tea.KeyEnter:
+		c.closeSearch(true)
+
+	case tea.KeyRunes:
+		if msg.Alt {
+			return
+		}
+		c.input.SearchTypeRunes(msg.Runes)
+		c.previewSearch()
+
+	case tea.KeySpace:
+		c.input.SearchTypeRunes([]rune{' '})
+		c.previewSearch()
+
+	case tea.KeyBackspace:
+		c.input.SearchBackspace()
+		c.previewSearch()
+	}
+}
+
+// selectOlderSearch and selectNewerSearch are the semantic navigation seam
+// shared by keyboard and mouse input. Device handlers do not need to forge a
+// different device's event or re-enter the full key dispatcher.
+func (c *inputController) selectOlderSearch() bool {
+	if c.mode != ModeSearch {
+		return false
+	}
+	c.input.SearchSelectOlder()
+	c.previewSearch()
+	return true
+}
+
+func (c *inputController) selectNewerSearch() bool {
+	if c.mode != ModeSearch {
+		return false
+	}
+	c.input.SearchSelectNewer()
+	c.previewSearch()
+	return true
+}
+
+// previewSearch centers the viewport on the current selection (live
+// preview); with no match it restores the pre-search position so a
+// query edit that empties the result set snaps back.
+func (c *inputController) previewSearch() {
+	m, ok := c.input.SearchSelected()
+	c.search.PreviewSearch(m, ok)
+}
+
+// closeSearch is the single exit path from search mode: resets the
+// mode, hides the overlay, and settles the viewport exactly once -
+// committed (stay at the match) or cancelled (restore the snapshot).
+// The final ScrollStateChangedMsg emitted by the effects is search's
+// analog of the picker's settle message: it keeps the session's
+// rune.state scroll view fresh.
+func (c *inputController) closeSearch(accepted bool) {
+	c.mode = ModeNormal
+	c.input.HideSearch()
+	if accepted {
+		c.search.CommitSearch()
+	} else {
+		c.search.CancelSearch()
+	}
 }
 
 // closePicker is the single exit path from either picker mode: resets

--- a/ui/tui/input_mode_test.go
+++ b/ui/tui/input_mode_test.go
@@ -13,6 +13,26 @@ import (
 	"github.com/mmcdole/rune/ui/tui/widget"
 )
 
+// recordingSearchEffects records searchEffects calls so tests can
+// assert the settle-exactly-once invariant.
+type recordingSearchEffects struct {
+	opens    int
+	scope    widget.SearchScope
+	previews []bool // ok flag of each PreviewSearch call
+	commits  int
+	cancels  int
+}
+
+func (r *recordingSearchEffects) OpenSearch() widget.SearchScope {
+	r.opens++
+	return r.scope
+}
+func (r *recordingSearchEffects) PreviewSearch(_ widget.SearchMatch, ok bool) {
+	r.previews = append(r.previews, ok)
+}
+func (r *recordingSearchEffects) CommitSearch() { r.commits++ }
+func (r *recordingSearchEffects) CancelSearch() { r.cancels++ }
+
 // controllerHarness drives an inputController directly, recording
 // outbound events and submitted lines.
 type controllerHarness struct {
@@ -21,14 +41,19 @@ type controllerHarness struct {
 	submitted []input.Submission
 	bound     map[string]bool
 	accept    bool
+	fx        *recordingSearchEffects
+	buf       *widget.ScrollbackBuffer
 }
 
 func newControllerHarness() *controllerHarness {
 	h := &controllerHarness{
 		bound:  make(map[string]bool),
 		accept: true,
+		fx:     &recordingSearchEffects{},
+		buf:    widget.NewScrollbackBuffer(100),
 	}
-	draftInput := widget.NewInput(style.DefaultStyles())
+	styles := style.DefaultStyles()
+	draftInput := widget.NewInput(styles, widget.NewSearch(h.buf, styles))
 	h.ctl = newInputController(
 		draftInput,
 		func(ev ui.UIEvent) { h.events = append(h.events, ev) },
@@ -38,6 +63,7 @@ func newControllerHarness() *controllerHarness {
 		},
 		func(key string) bool { return h.bound[key] },
 		func(tea.KeyType) bool { return false },
+		h.fx,
 	)
 	return h
 }
@@ -604,5 +630,158 @@ func TestReboundHomeOverridesInputCursor(t *testing.T) {
 	}
 	if pos := h.ctl.input.Position(); pos != len("look") {
 		t.Fatalf("bound home moved the cursor to %d, want untouched at %d", pos, len("look"))
+	}
+}
+
+// TestSearchSettledOnEveryExit mirrors the picker invariant for search:
+// every path out of ModeSearch resets the mode and settles the
+// viewport exactly once - one CommitSearch or one CancelSearch.
+func TestSearchSettledOnEveryExit(t *testing.T) {
+	cases := []struct {
+		name    string
+		exit    func(h *controllerHarness)
+		commits int
+		cancels int
+	}{
+		{
+			name:    "escape cancels",
+			exit:    func(h *controllerHarness) { h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyEsc}) },
+			cancels: 1,
+		},
+		{
+			name:    "ctrl+c cancels",
+			exit:    func(h *controllerHarness) { h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyCtrlC}) },
+			cancels: 1,
+		},
+		{
+			name:    "enter commits",
+			exit:    func(h *controllerHarness) { h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyEnter}) },
+			commits: 1,
+		},
+		{
+			name:    "SetText cancels once",
+			exit:    func(h *controllerHarness) { h.ctl.SetText("go north") },
+			cancels: 1,
+		},
+		{
+			name: "opening a picker cancels the search",
+			exit: func(h *controllerHarness) {
+				h.ctl.ShowPicker(ui.ShowPickerMsg{Items: pickerTestItems, CallbackID: "cb"})
+			},
+			cancels: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newControllerHarness()
+			h.buf.Append("a thief passes")
+			h.ctl.ShowSearch(ui.ShowSearchMsg{Query: "thief"})
+			if h.ctl.mode != ModeSearch {
+				t.Fatalf("expected ModeSearch after ShowSearch, got %v", h.ctl.mode)
+			}
+			if h.fx.opens != 1 {
+				t.Fatalf("expected one OpenSearch, got %d", h.fx.opens)
+			}
+
+			tc.exit(h)
+
+			if h.fx.commits != tc.commits || h.fx.cancels != tc.cancels {
+				t.Fatalf("commits/cancels = %d/%d, want %d/%d",
+					h.fx.commits, h.fx.cancels, tc.commits, tc.cancels)
+			}
+			if tc.name == "opening a picker cancels the search" {
+				if h.ctl.mode != ModePickerModal {
+					t.Fatalf("expected ModePickerModal after picker-over-search, got %v", h.ctl.mode)
+				}
+			} else if h.ctl.mode != ModeNormal {
+				t.Fatalf("expected ModeNormal after exit, got %v", h.ctl.mode)
+			}
+		})
+	}
+}
+
+// TestSearchOpensWithPreviewAndSteps verifies opening previews the
+// newest match and Up/Down re-preview as the selection steps.
+func TestSearchOpensWithPreviewAndSteps(t *testing.T) {
+	h := newControllerHarness()
+	h.buf.Append("thief one")
+	h.buf.Append("quiet row")
+	h.buf.Append("thief two")
+
+	h.ctl.ShowSearch(ui.ShowSearchMsg{Query: "thief"})
+	if len(h.fx.previews) != 1 || !h.fx.previews[0] {
+		t.Fatalf("open should preview the newest match, previews = %v", h.fx.previews)
+	}
+
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyDown})
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyUp})
+	if len(h.fx.previews) != 3 {
+		t.Fatalf("selection moves should re-preview, previews = %v", h.fx.previews)
+	}
+
+	// Editing the query re-previews; a query with no matches previews
+	// ok=false (restores the snapshot).
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("zzz")})
+	last := h.fx.previews[len(h.fx.previews)-1]
+	if last {
+		t.Fatal("no-match query must preview ok=false")
+	}
+}
+
+// TestSearchTrapsBoundKeys verifies ModeSearch behaves like the modal
+// picker: bound keys edit the query instead of dispatching to Lua.
+func TestSearchTrapsBoundKeys(t *testing.T) {
+	h := newControllerHarness()
+	h.buf.Append("j marks the spot")
+	h.bound["j"] = true
+	h.bound["ctrl+t"] = true
+
+	h.ctl.ShowSearch(ui.ShowSearchMsg{})
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	h.ctl.HandleKey(tea.KeyMsg{Type: tea.KeyCtrlT})
+
+	if binds := h.executeBinds(); len(binds) != 0 {
+		t.Fatalf("search mode must not dispatch binds, got %v", binds)
+	}
+	if h.ctl.mode != ModeSearch {
+		t.Fatalf("unhandled chords must not exit search mode, got %v", h.ctl.mode)
+	}
+}
+
+// TestSearchIgnoredWhileComposing verifies ShowSearch over a structured
+// draft is a no-op: no mode change, no effects.
+func TestSearchIgnoredWhileComposing(t *testing.T) {
+	h := newControllerHarness()
+	h.ctl.SetText("line one\nline two")
+	if h.ctl.mode != ModeCompose {
+		t.Fatalf("expected ModeCompose, got %v", h.ctl.mode)
+	}
+
+	h.ctl.ShowSearch(ui.ShowSearchMsg{Query: "thief"})
+
+	if h.ctl.mode != ModeCompose {
+		t.Fatalf("search must not open over a composer, got %v", h.ctl.mode)
+	}
+	if h.fx.opens != 0 || len(h.fx.previews) != 0 {
+		t.Fatal("refused ShowSearch must produce zero effects")
+	}
+}
+
+// TestSearchOverPickerSettlesPickerFirst verifies the picker's callback
+// settles exactly once (cancelled) when search opens over it.
+func TestSearchOverPickerSettlesPickerFirst(t *testing.T) {
+	h := newControllerHarness()
+	h.buf.Append("a thief passes")
+	h.ctl.ShowPicker(ui.ShowPickerMsg{Items: pickerTestItems, CallbackID: "cb"})
+
+	h.ctl.ShowSearch(ui.ShowSearchMsg{Query: "thief"})
+
+	selects := h.pickerSelects()
+	if len(selects) != 1 || selects[0].Accepted {
+		t.Fatalf("picker must settle cancelled exactly once, got %v", selects)
+	}
+	if h.ctl.mode != ModeSearch {
+		t.Fatalf("expected ModeSearch, got %v", h.ctl.mode)
 	}
 }

--- a/ui/tui/layout.go
+++ b/ui/tui/layout.go
@@ -32,46 +32,85 @@ func (m *Model) getWidget(name string) widget.Widget {
 	return nil
 }
 
-// layoutDock sizes and renders one dock's widgets in a single pass,
-// returning the joined view and the dock's total height. A widget with
-// PreferredHeight 0 (hidden bar, collapsed pane) is skipped entirely.
+// sizeDockEntry applies one layout entry and returns its widget and final
+// height. Measurement and rendering share this path so intrinsic-height
+// policy cannot drift between an Update-time reflow and the next View.
+func (m *Model) sizeDockEntry(entry ui.LayoutEntry) (widget.Widget, int, bool) {
+	w := m.getWidget(entry.Name)
+	if w == nil {
+		return nil, 0, false
+	}
+
+	// Options are per-entry but the widget instance is shared, so pass the
+	// bag unconditionally: an entry without options must reset whatever a
+	// previous entry configured in the same layout pass.
+	if c, ok := w.(widget.Configurable); ok {
+		c.SetOptions(entry.Opts)
+	}
+
+	// Width can affect intrinsic height (notably soft-wrapped composer text),
+	// so make the current width available before asking for it. Existing
+	// fixed-height widgets ignore the zero height.
+	w.SetSize(m.width, 0)
+	preferred := w.PreferredHeight()
+	if preferred == 0 {
+		return nil, 0, false
+	}
+
+	h := entry.Height
+	if h == 0 {
+		h = preferred
+	}
+	w.SetSize(m.width, h)
+	return w, h, true
+}
+
+// layoutDock sizes and renders one dock's widgets, returning the joined
+// view and total height. A zero-height widget is skipped entirely.
 func (m *Model) layoutDock(entries []ui.LayoutEntry) (string, int) {
 	var parts []string
 	totalHeight := 0
-
 	for _, entry := range entries {
-		w := m.getWidget(entry.Name)
-		if w == nil {
+		w, h, ok := m.sizeDockEntry(entry)
+		if !ok {
 			continue
 		}
-
-		// Options are per-entry but the widget instance is shared, so
-		// pass the bag unconditionally: an entry without options must
-		// reset whatever a previous entry configured this render pass.
-		if c, ok := w.(widget.Configurable); ok {
-			c.SetOptions(entry.Opts)
-		}
-
-		// Width can affect intrinsic height (notably soft-wrapped composer
-		// text), so make the current width available before asking for it.
-		// Existing fixed-height widgets ignore the zero height.
-		w.SetSize(m.width, 0)
-		preferred := w.PreferredHeight()
-		if preferred == 0 {
-			continue
-		}
-
-		h := entry.Height
-		if h == 0 {
-			h = preferred
-		}
-
-		w.SetSize(m.width, h)
 		parts = append(parts, w.View())
 		totalHeight += h
 	}
-
 	return strings.Join(parts, "\n"), totalHeight
+}
+
+// dockHeight measures a dock without rendering it. Search uses this during
+// Update so viewport positioning sees the same final geometry as View.
+func (m *Model) dockHeight(entries []ui.LayoutEntry) int {
+	totalHeight := 0
+	for _, entry := range entries {
+		_, h, ok := m.sizeDockEntry(entry)
+		if ok {
+			totalHeight += h
+		}
+	}
+	return totalHeight
+}
+
+func (m *Model) setViewportSize(topHeight, bottomHeight int) {
+	viewportHeight := m.height - topHeight - bottomHeight
+	if viewportHeight < 1 {
+		viewportHeight = 1
+	}
+	m.viewport.SetSize(m.width, viewportHeight)
+}
+
+// syncViewportSize makes layout geometry current outside View. Callers that
+// anchor content inside the viewport can then position it against the same
+// dimensions the next render will use.
+func (m *Model) syncViewportSize() {
+	if !m.initialized {
+		return
+	}
+	cfg := m.getLayout()
+	m.setViewportSize(m.dockHeight(cfg.Top), m.dockHeight(cfg.Bottom))
 }
 
 // View implements tea.Model.
@@ -86,13 +125,9 @@ func (m *Model) View() string {
 	topView, topHeight := m.layoutDock(cfg.Top)
 	bottomView, bottomHeight := m.layoutDock(cfg.Bottom)
 
-	viewportHeight := m.height - topHeight - bottomHeight
-	if viewportHeight < 1 {
-		viewportHeight = 1
-	}
 	// The viewport spans the full terminal width; splitRows wraps
 	// appended rows to the same m.width.
-	m.viewport.SetSize(m.width, viewportHeight)
+	m.setViewportSize(topHeight, bottomHeight)
 
 	var parts []string
 	if topView != "" {

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -43,8 +43,11 @@ type Model struct {
 	input      *widget.Input
 	panes      *widget.PaneManager
 
-	// Input-mode state machine (normal / modal picker / inline picker)
+	// Input-mode state machine (normal / modal picker / inline picker / search)
 	inputCtl *inputController
+
+	// Viewport geometry and focus for the active/committed search result.
+	searchView searchViewState
 
 	// Push-based state from Session
 	boundKeys  map[string]bool
@@ -73,8 +76,9 @@ type Model struct {
 func NewModel(inputChan chan<- input.Submission, outbound chan<- ui.UIEvent) *Model {
 	styles := style.DefaultStyles()
 	scrollback := widget.NewScrollbackBuffer(100000)
-	viewport := widget.NewViewport(scrollback)
-	input := widget.NewInput(styles)
+	viewport := widget.NewViewport(scrollback, styles)
+	search := widget.NewSearch(scrollback, styles)
+	input := widget.NewInput(styles, search)
 	panes := widget.NewPaneManager(styles)
 
 	m := &Model{
@@ -86,7 +90,7 @@ func NewModel(inputChan chan<- input.Submission, outbound chan<- ui.UIEvent) *Mo
 		outbound:   outbound,
 		widgets:    make(map[string]widget.Widget),
 	}
-	m.inputCtl = newInputController(input, m.sendOutbound, m.sendLine, m.isBound, m.handleScrollKey)
+	m.inputCtl = newInputController(input, m.sendOutbound, m.sendLine, m.isBound, m.handleScrollKey, m)
 
 	// Register static widgets
 	m.widgets["input"] = input
@@ -131,6 +135,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ui.ShowPickerMsg:
 		m.inputCtl.ShowPicker(msg)
 		return m, nil
+	case ui.ShowSearchMsg:
+		m.inputCtl.ShowSearch(msg)
+		return m, nil
 	case ui.SetInputMsg:
 		m.inputCtl.SetText(string(msg))
 		return m, nil
@@ -155,32 +162,32 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// ignored rather than auto-created.
 	case ui.PaneScrollUpMsg:
 		if msg.Name == "main" {
-			m.viewport.ScrollUp(msg.Lines)
-			m.updateScrollState()
+			m.navigateMainViewport(func() {
+				m.viewport.ScrollUp(msg.Lines)
+			})
 		} else if m.panes.Exists(msg.Name) {
 			m.panes.Get(msg.Name).ScrollUp(msg.Lines)
 		}
 		return m, nil
 	case ui.PaneScrollDownMsg:
 		if msg.Name == "main" {
-			m.viewport.ScrollDown(msg.Lines)
-			m.updateScrollState()
+			m.navigateMainViewport(func() {
+				m.viewport.ScrollDown(msg.Lines)
+			})
 		} else if m.panes.Exists(msg.Name) {
 			m.panes.Get(msg.Name).ScrollDown(msg.Lines)
 		}
 		return m, nil
 	case ui.PaneScrollToTopMsg:
 		if msg.Name == "main" {
-			m.viewport.GotoTop()
-			m.updateScrollState()
+			m.navigateMainViewport(m.viewport.GotoTop)
 		} else if m.panes.Exists(msg.Name) {
 			m.panes.Get(msg.Name).ScrollToTop()
 		}
 		return m, nil
 	case ui.PaneScrollToBottomMsg:
 		if msg.Name == "main" {
-			m.viewport.GotoBottom()
-			m.updateScrollState()
+			m.navigateMainViewport(m.viewport.GotoBottom)
 		} else if m.panes.Exists(msg.Name) {
 			m.panes.Get(msg.Name).ScrollToBottom()
 		}
@@ -194,7 +201,12 @@ func (m *Model) handleWindowSize(msg tea.WindowSizeMsg) (tea.Model, tea.Cmd) {
 	m.width = msg.Width
 	m.height = msg.Height
 	m.initialized = true
+	m.syncViewportSize()
+	scrollStateChanged := m.recenterSearchFocus()
 	m.sendOutbound(ui.WindowSizeChangedMsg{Width: msg.Width, Height: msg.Height})
+	if scrollStateChanged {
+		m.updateScrollState()
+	}
 	return m, nil
 }
 
@@ -222,14 +234,23 @@ func (m *Model) flushPending() {
 }
 
 func (m *Model) handleConfigUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
+	layoutChanged := false
 	switch msg := msg.(type) {
 	case ui.UpdateBindsMsg:
 		m.boundKeys = msg
 	case ui.UpdateBarsMsg:
 		m.syncBars(msg)
+		layoutChanged = true
 	case ui.UpdateLayoutMsg:
 		m.luaLayout.Top = msg.Top
 		m.luaLayout.Bottom = msg.Bottom
+		layoutChanged = true
+	}
+	if layoutChanged {
+		m.syncViewportSize()
+		if m.recenterSearchFocus() {
+			m.updateScrollState()
+		}
 	}
 	return m, nil
 }
@@ -321,11 +342,19 @@ func (m *Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 	}
 	switch msg.Button {
 	case tea.MouseButtonWheelUp:
-		m.viewport.ScrollUp(wheelScrollLines)
-		m.updateScrollState()
+		if m.inputCtl.selectOlderSearch() {
+			return m, nil
+		}
+		m.navigateMainViewport(func() {
+			m.viewport.ScrollUp(wheelScrollLines)
+		})
 	case tea.MouseButtonWheelDown:
-		m.viewport.ScrollDown(wheelScrollLines)
-		m.updateScrollState()
+		if m.inputCtl.selectNewerSearch() {
+			return m, nil
+		}
+		m.navigateMainViewport(func() {
+			m.viewport.ScrollDown(wheelScrollLines)
+		})
 	}
 	return m, nil
 }
@@ -414,21 +443,29 @@ func (m *Model) updateScrollState() {
 	m.sendOutbound(ui.ScrollStateChangedMsg{Mode: modeStr, NewLines: newLines})
 }
 
+// navigateMainViewport is the single path for deliberate user/script
+// navigation of the main output surface. Search previews position the
+// viewport directly so their committed marker remains intact.
+func (m *Model) navigateMainViewport(move func()) {
+	m.clearCommittedSearchFocus()
+	move()
+	m.updateScrollState()
+}
+
 // handleScrollKey handles viewport scrolling keys.
 // Returns true if the key was handled.
 func (m *Model) handleScrollKey(keyType tea.KeyType) bool {
 	switch keyType {
 	case tea.KeyPgUp:
-		m.viewport.PageUp()
+		m.navigateMainViewport(m.viewport.PageUp)
 	case tea.KeyPgDown:
-		m.viewport.PageDown()
+		m.navigateMainViewport(m.viewport.PageDown)
 	case tea.KeyCtrlHome:
-		m.viewport.GotoTop()
+		m.navigateMainViewport(m.viewport.GotoTop)
 	case tea.KeyCtrlEnd:
-		m.viewport.GotoBottom()
+		m.navigateMainViewport(m.viewport.GotoBottom)
 	default:
 		return false
 	}
-	m.updateScrollState()
 	return true
 }

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -6,9 +6,12 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/mmcdole/rune/input"
+	runetext "github.com/mmcdole/rune/text"
 	"github.com/mmcdole/rune/ui"
 	"github.com/mmcdole/rune/ui/tui/widget"
+	"github.com/muesli/termenv"
 )
 
 // newTestModel builds a model with a sized window and enough
@@ -589,4 +592,201 @@ func TestHomeEndEditInputWhileCtrlVariantsScroll(t *testing.T) {
 	if got := m.inputCtl.input.Value(); got != typed {
 		t.Fatalf("input draft = %q, want %q", got, typed)
 	}
+}
+
+// Search changes the input widget's intrinsic height as its result list
+// grows and collapses. The viewport must be sized for that final geometry
+// before centering, or the selected source row can land just outside the
+// visible window even though it is selected in the overlay.
+func TestSearchFocusUsesFinalLayoutGeometry(t *testing.T) {
+	profile := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	t.Cleanup(func() { lipgloss.SetColorProfile(profile) })
+
+	inputChan := make(chan input.Submission, 16)
+	outbound := make(chan ui.UIEvent, 64)
+	m := NewModel(inputChan, outbound)
+
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 24})
+	m = next.(*Model)
+	next, _ = m.Update(ui.UpdateBarsMsg{"status": {Left: "status"}})
+	m = next.(*Model)
+
+	for i := 0; i < 9; i++ {
+		next, _ = m.Update(ui.EchoLineMsg(fmt.Sprintf("match %d thief", i)))
+		m = next.(*Model)
+	}
+	next, _ = m.Update(ui.EchoLineMsg("SELECTED thief"))
+	m = next.(*Model)
+	for i := 0; i < 20; i++ {
+		next, _ = m.Update(ui.EchoLineMsg(fmt.Sprintf("quiet %d", i)))
+		m = next.(*Model)
+	}
+
+	// Establish the normal layout, then the shorter no-match navigator. Typing
+	// the query expands it to its five-result maximum in one update.
+	m.View()
+	next, _ = m.Update(ui.ShowSearchMsg{})
+	m = next.(*Model)
+	m.View()
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("thief")})
+	m = next.(*Model)
+	m.View()
+
+	assertViewportRowCentered(t, m.viewport.View(), "SELECTED thief")
+
+	// Enter removes the overlay and expands the viewport. The accepted row
+	// must be centered again using that post-close height.
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = next.(*Model)
+	m.View()
+	assertViewportRowCentered(t, m.viewport.View(), "SELECTED thief")
+	if m.searchView.focus == nil {
+		t.Fatal("accepted search should retain its active-result marker")
+	}
+	committedSeq := m.searchView.focus.Seq
+	assertViewportRowHighlighted(t, m.viewport.View(), "SELECTED thief")
+
+	// A replacement search may preview another row, but cancelling it restores
+	// the previously committed focus from the grouped search lifecycle state.
+	next, _ = m.Update(ui.ShowSearchMsg{})
+	m = next.(*Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyUp})
+	m = next.(*Model)
+	if m.searchView.focus == nil || m.searchView.focus.Seq == committedSeq {
+		t.Fatal("replacement search did not preview an older result")
+	}
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	m = next.(*Model)
+	if m.searchView.focus == nil || m.searchView.focus.Seq != committedSeq {
+		t.Fatal("cancelled replacement search did not restore committed focus")
+	}
+	assertViewportRowHighlighted(t, m.viewport.View(), "SELECTED thief")
+
+	// Deliberate viewport navigation retires the accepted marker.
+	next, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp})
+	m = next.(*Model)
+	if m.searchView.focus != nil {
+		t.Fatal("manual scrolling should clear the accepted search marker")
+	}
+}
+
+func TestSearchReportsInteractionStateSeparatelyFromScrollState(t *testing.T) {
+	inputChan := make(chan input.Submission, 4)
+	outbound := make(chan ui.UIEvent, 32)
+	m := NewModel(inputChan, outbound)
+	m.initialized = true
+	m.width = 80
+	m.height = 24
+
+	next, _ := m.Update(ui.ShowSearchMsg{})
+	m = next.(*Model)
+	next, _ = m.Update(tea.KeyMsg{Type: tea.KeyEsc})
+	_ = next.(*Model)
+
+	var states []bool
+	for len(outbound) > 0 {
+		if state, ok := (<-outbound).(ui.SearchStateChangedMsg); ok {
+			states = append(states, bool(state))
+		}
+	}
+	if len(states) != 2 || !states[0] || states[1] {
+		t.Fatalf("search active states = %v, want [true false]", states)
+	}
+}
+
+func TestManualViewportEntryPointsClearCommittedSearchFocus(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.Msg
+	}{
+		{
+			name: "fallback scroll key",
+			msg:  tea.KeyMsg{Type: tea.KeyPgUp},
+		},
+		{
+			name: "mouse wheel",
+			msg:  tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp},
+		},
+		{
+			name: "Lua main-pane navigation",
+			msg:  ui.PaneScrollUpMsg{Name: "main", Lines: 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModel(t)
+			focus := widget.SearchMatch{Seq: m.scrollback.Seq(50)}
+			m.searchView.focus = &focus
+			m.viewport.SetHighlight(focus.Seq, focus.Ranges)
+
+			next, _ := m.Update(tt.msg)
+			m = next.(*Model)
+			if m.searchView.focus != nil {
+				t.Fatal("manual viewport navigation retained committed search focus")
+			}
+		})
+	}
+}
+
+func TestMouseWheelNavigatesActiveSearchMatches(t *testing.T) {
+	m := newBareModel(t)
+	for _, line := range []string{"thief oldest", "quiet", "thief middle", "quiet", "thief newest"} {
+		m.appendMessage(line)
+	}
+
+	m.inputCtl.ShowSearch(ui.ShowSearchMsg{Query: "thief"})
+	newest, ok := m.input.SearchSelected()
+	if !ok || newest.Stripped != "thief newest" {
+		t.Fatalf("initial selection = (%q, %v), want newest match", newest.Stripped, ok)
+	}
+
+	next, _ := m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelUp})
+	m = next.(*Model)
+	middle, ok := m.input.SearchSelected()
+	if !ok || middle.Stripped != "thief middle" {
+		t.Fatalf("wheel up selection = (%q, %v), want older middle match", middle.Stripped, ok)
+	}
+	if !m.input.SearchActive() || m.searchView.focus == nil || m.searchView.focus.Seq != middle.Seq {
+		t.Fatal("wheel navigation must keep search active and preview the selected match")
+	}
+
+	next, _ = m.Update(tea.MouseMsg{Action: tea.MouseActionPress, Button: tea.MouseButtonWheelDown})
+	m = next.(*Model)
+	selected, ok := m.input.SearchSelected()
+	if !ok || selected.Seq != newest.Seq {
+		t.Fatalf("wheel down selection = (%q, %v), want newer match", selected.Stripped, ok)
+	}
+}
+
+func assertViewportRowCentered(t *testing.T, view, want string) {
+	t.Helper()
+	rows := strings.Split(view, "\n")
+	for i, row := range rows {
+		if runetext.StripANSI(row) != want {
+			continue
+		}
+		center := (len(rows) - 1) / 2
+		if i < center-1 || i > center+1 {
+			t.Fatalf("row %q rendered at viewport row %d of %d, want it centered near %d\n%s",
+				want, i, len(rows), center, runetext.StripANSI(view))
+		}
+		return
+	}
+	t.Fatalf("row %q is outside the viewport:\n%s", want, runetext.StripANSI(view))
+}
+
+func assertViewportRowHighlighted(t *testing.T, view, want string) {
+	t.Helper()
+	for _, row := range strings.Split(view, "\n") {
+		if runetext.StripANSI(row) != want {
+			continue
+		}
+		if !strings.Contains(row, "\x1b[") {
+			t.Fatalf("row %q is visible but not highlighted:\n%s", want, runetext.StripANSI(view))
+		}
+		return
+	}
+	t.Fatalf("row %q is outside the viewport:\n%s", want, runetext.StripANSI(view))
 }

--- a/ui/tui/search.go
+++ b/ui/tui/search.go
@@ -1,0 +1,111 @@
+package tui
+
+import (
+	"github.com/mmcdole/rune/ui"
+	"github.com/mmcdole/rune/ui/tui/widget"
+)
+
+// searchViewState is Model's viewport-side state for one search lifecycle.
+// Search itself owns query/results; the controller owns interaction mode.
+type searchViewState struct {
+	snapshot   widget.ScrollPos
+	focus      *widget.SearchMatch
+	priorFocus *widget.SearchMatch
+}
+
+// Model implements searchEffects: the viewport half of scrollback
+// search. The controller drives the mode; these methods move the
+// viewport. Every position change reports the resulting scroll state
+// so the session's rune.state view cannot go stale - the settle
+// message of a search is its final ScrollStateChangedMsg.
+
+// OpenSearch snapshots the viewport and committed highlight for cancel, then
+// returns the temporal origin the Search widget should scan around.
+func (m *Model) OpenSearch() widget.SearchScope {
+	m.searchView.snapshot = m.viewport.SaveScroll()
+	m.searchView.priorFocus = m.searchView.focus
+	m.sendOutbound(ui.SearchStateChangedMsg(true))
+
+	scope := widget.SearchScope{}
+	if m.scrollback.Count() > 0 {
+		scope.OriginSeq = m.searchView.snapshot.BottomSeq
+		scope.OriginSet = true
+	}
+	if m.searchView.focus != nil {
+		scope.ResumeSeq = m.searchView.focus.Seq
+		scope.ResumeSet = true
+	}
+	return scope
+}
+
+// recenterSearchFocus reapplies the active preview after layout geometry
+// changes. Search owns the anchor; layout owns only viewport dimensions.
+// The return value reports whether session-visible scroll state changed.
+func (m *Model) recenterSearchFocus() bool {
+	if !m.input.SearchActive() || m.searchView.focus == nil {
+		return false
+	}
+	beforeMode := m.viewport.Mode()
+	beforeLines := m.viewport.NewLineCount()
+	m.viewport.CenterOn(m.searchView.focus.Seq)
+	return beforeMode != m.viewport.Mode() || beforeLines != m.viewport.NewLineCount()
+}
+
+// PreviewSearch centers and highlights the selected match; with no
+// match it returns the viewport to the pre-search position.
+func (m *Model) PreviewSearch(match widget.SearchMatch, ok bool) {
+	if ok {
+		m.searchView.focus = &match
+		m.syncViewportSize()
+		m.recenterSearchFocus()
+		m.viewport.SetHighlight(match.Seq, match.Ranges)
+	} else {
+		m.searchView.focus = nil
+		m.syncViewportSize()
+		m.viewport.ClearHighlight()
+		m.viewport.RestoreScroll(m.searchView.snapshot)
+	}
+	m.updateScrollState()
+}
+
+// CommitSearch keeps the accepted match centered and highlighted after the
+// navigator closes. Manual viewport navigation clears the marker.
+func (m *Model) CommitSearch() {
+	m.syncViewportSize()
+	if m.searchView.focus != nil {
+		m.viewport.CenterOn(m.searchView.focus.Seq)
+		m.viewport.SetHighlight(m.searchView.focus.Seq, m.searchView.focus.Ranges)
+	} else {
+		m.viewport.ClearHighlight()
+	}
+	m.searchView.priorFocus = nil
+	m.sendOutbound(ui.SearchStateChangedMsg(false))
+	m.updateScrollState()
+}
+
+// CancelSearch restores both the position and any committed highlight that
+// existed when the navigator opened.
+func (m *Model) CancelSearch() {
+	m.syncViewportSize()
+	m.viewport.RestoreScroll(m.searchView.snapshot)
+	if m.searchView.priorFocus != nil {
+		m.searchView.focus = m.searchView.priorFocus
+		m.viewport.SetHighlight(m.searchView.focus.Seq, m.searchView.focus.Ranges)
+	} else {
+		m.searchView.focus = nil
+		m.viewport.ClearHighlight()
+	}
+	m.searchView.priorFocus = nil
+	m.sendOutbound(ui.SearchStateChangedMsg(false))
+	m.updateScrollState()
+}
+
+// clearCommittedSearchFocus retires the accepted marker before deliberate
+// viewport navigation. An active search still owns its preview marker.
+func (m *Model) clearCommittedSearchFocus() {
+	if m.input.SearchActive() || m.searchView.focus == nil {
+		return
+	}
+	m.searchView.focus = nil
+	m.viewport.ClearHighlight()
+}

--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -177,6 +177,11 @@ func (b *BubbleTeaUI) ShowPicker(opts ui.ShowPickerMsg) {
 	b.send(opts)
 }
 
+// ShowSearch opens the scrollback-search overlay.
+func (b *BubbleTeaUI) ShowSearch(opts ui.ShowSearchMsg) {
+	b.send(opts)
+}
+
 // SetClipboard asks the terminal to set the system clipboard.
 func (b *BubbleTeaUI) SetClipboard(text string) {
 	b.send(ui.SetClipboardMsg(text))

--- a/ui/tui/util/highlight.go
+++ b/ui/tui/util/highlight.go
@@ -1,0 +1,48 @@
+package util
+
+import (
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mmcdole/rune/text"
+)
+
+// ColRange is a half-open range of visible columns within a row.
+type ColRange struct {
+	Start, End int
+}
+
+// HighlightRange re-styles the visible columns [startCol, endCol) of an
+// SGR-bearing row: the ambient style is reset before the highlighted
+// text and restored after it. render receives the stripped match text.
+//
+// ansi.Cut with a left edge > 0 re-emits the SGR sequences seen before
+// the cut point, so the suffix restores the row's ambient style without
+// a hand-rolled SGR state machine. (CutWc in the pinned x/ansi
+// truncates the right edge twice; stay on the grapheme-based Cut.)
+// Columns must be measured with ansi.StringWidth, the same method Cut
+// slices by, or wide runes misalign the splice.
+func HighlightRange(row string, startCol, endCol int, render func(string) string) string {
+	width := ansi.StringWidth(row)
+	if startCol < 0 {
+		startCol = 0
+	}
+	if endCol > width {
+		endCol = width
+	}
+	if startCol >= endCol {
+		return row
+	}
+	prefix := ansi.Cut(row, 0, startCol)
+	mid := text.StripANSI(ansi.Cut(row, startCol, endCol))
+	suffix := ansi.Cut(row, endCol, width)
+	return prefix + "\x1b[0m" + render(mid) + suffix
+}
+
+// HighlightRanges applies HighlightRange to each of several sorted,
+// non-overlapping ranges, splicing rightmost-first so earlier column
+// offsets stay valid as the string grows.
+func HighlightRanges(row string, ranges []ColRange, render func(string) string) string {
+	for i := len(ranges) - 1; i >= 0; i-- {
+		row = HighlightRange(row, ranges[i].Start, ranges[i].End, render)
+	}
+	return row
+}

--- a/ui/tui/util/highlight_test.go
+++ b/ui/tui/util/highlight_test.go
@@ -1,0 +1,142 @@
+package util
+
+import "testing"
+
+// tag makes expectations readable: the "style" wraps the match in
+// visible markers instead of escape codes.
+func tag(s string) string {
+	return "<H>" + s + "</H>"
+}
+
+func TestHighlightRange(t *testing.T) {
+	tests := []struct {
+		name       string
+		row        string
+		start, end int
+		want       string
+	}{
+		{
+			name:  "plain ascii",
+			row:   "the thief runs",
+			start: 4, end: 9,
+			want: "the \x1b[0m<H>thief</H> runs",
+		},
+		{
+			name:  "match at column zero",
+			row:   "thief!",
+			start: 0, end: 5,
+			want: "\x1b[0m<H>thief</H>!",
+		},
+		{
+			name:  "match at end of row",
+			row:   "a thief",
+			start: 2, end: 7,
+			want: "a \x1b[0m<H>thief</H>",
+		},
+		{
+			// The suffix must re-emit the ambient red so text after the
+			// match keeps its original color. ansi.Truncate also carries
+			// every later escape into the prefix (the row's trailing
+			// reset here) - a harmless doubled reset, encoded exactly.
+			name:  "match inside ambient sgr span",
+			row:   "\x1b[31mred thief red\x1b[0m",
+			start: 4, end: 9,
+			want: "\x1b[31mred \x1b[0m\x1b[0m<H>thief</H>\x1b[31m red\x1b[0m",
+		},
+		{
+			// The match's own styling is stripped for render; the suffix
+			// replays the escapes seen so far (net reset), so " here"
+			// stays unstyled as in the original.
+			name:  "styled match text",
+			row:   "a \x1b[32mthief\x1b[0m here",
+			start: 2, end: 7,
+			want: "a \x1b[32m\x1b[0m\x1b[0m<H>thief</H>\x1b[32m\x1b[0m here",
+		},
+		{
+			// Wide runes before the match: columns, not bytes or runes.
+			name:  "wide runes before match",
+			row:   "日本 thief",
+			start: 5, end: 10,
+			want: "日本 \x1b[0m<H>thief</H>",
+		},
+		{
+			name:  "range clamped past row width",
+			row:   "short",
+			start: 2, end: 99,
+			want: "sh\x1b[0m<H>ort</H>",
+		},
+		{
+			name:  "empty range is a no-op",
+			row:   "unchanged",
+			start: 3, end: 3,
+			want: "unchanged",
+		},
+		{
+			name:  "inverted range is a no-op",
+			row:   "unchanged",
+			start: 5, end: 2,
+			want: "unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HighlightRange(tt.row, tt.start, tt.end, tag)
+			if got != tt.want {
+				t.Errorf("HighlightRange(%q, %d, %d)\n got %q\nwant %q",
+					tt.row, tt.start, tt.end, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHighlightRanges(t *testing.T) {
+	tests := []struct {
+		name   string
+		row    string
+		ranges []ColRange
+		want   string
+	}{
+		{
+			// The doubled reset before the first match is the rightmost
+			// splice's injected reset carried into the second splice's
+			// prefix by ansi.Truncate.
+			name:   "two occurrences in one row",
+			row:    "The thief robbed another thief.",
+			ranges: []ColRange{{4, 9}, {25, 30}},
+			want:   "The \x1b[0m\x1b[0m<H>thief</H> robbed another \x1b[0m<H>thief</H>.",
+		},
+		{
+			// Matches at the exact row edges: ansi.Cut drops the escapes
+			// outside the cut (the leading 31m and trailing reset). Safe
+			// because the real render (lipgloss) always ends in its own
+			// reset; the text between matches keeps its ambient red.
+			name:   "two occurrences inside ambient sgr span",
+			row:    "\x1b[31mthief and thief\x1b[0m",
+			ranges: []ColRange{{0, 5}, {10, 15}},
+			want:   "\x1b[0m<H>thief</H>\x1b[31m and \x1b[0m\x1b[0m<H>thief</H>",
+		},
+		{
+			name:   "adjacent ranges",
+			row:    "aabb",
+			ranges: []ColRange{{0, 2}, {2, 4}},
+			want:   "\x1b[0m<H>aa</H>\x1b[0m<H>bb</H>",
+		},
+		{
+			name:   "no ranges is a no-op",
+			row:    "unchanged",
+			ranges: nil,
+			want:   "unchanged",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := HighlightRanges(tt.row, tt.ranges, tag)
+			if got != tt.want {
+				t.Errorf("HighlightRanges(%q, %v)\n got %q\nwant %q",
+					tt.row, tt.ranges, got, tt.want)
+			}
+		})
+	}
+}

--- a/ui/tui/widget/composer_test.go
+++ b/ui/tui/widget/composer_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func newComposerInput(width int) *Input {
-	in := NewInput(style.DefaultStyles())
+	styles := style.DefaultStyles()
+	in := NewInput(styles, NewSearch(NewScrollbackBuffer(100), styles))
 	in.SetSize(width, 0)
 	return in
 }

--- a/ui/tui/widget/input.go
+++ b/ui/tui/widget/input.go
@@ -20,17 +20,24 @@ type Input struct {
 	textinput textinput.Model
 	composer  *Composer
 	picker    *Picker
+	search    *Search
 	styles    style.Styles
 
 	// State
 	pickerActive   bool
+	searchActive   bool
 	discardPending bool
 	width          int
 	height         int
 }
 
-// NewInput creates a new input widget.
-func NewInput(styles style.Styles) *Input {
+// NewInput creates the input dock with its scrollback-search child. Search is
+// required because the dock delegates its entire surface to that child while
+// search mode is active.
+func NewInput(styles style.Styles, search *Search) *Input {
+	if search == nil {
+		panic("widget.NewInput requires a search widget")
+	}
 	ti := textinput.New()
 	ti.Placeholder = ""
 	ti.Prompt = "> "
@@ -44,6 +51,7 @@ func NewInput(styles style.Styles) *Input {
 			MaxVisible: 10,
 			EmptyText:  "No matches",
 		}, styles),
+		search: search,
 		styles: styles,
 	}
 }
@@ -67,9 +75,16 @@ func (i *Input) UpdateTextInput(msg tea.Msg) tea.Cmd {
 
 // View implements Widget.
 func (i *Input) View() string {
+	// Search is a modal navigator, not an inline completion surface. It
+	// replaces the command field while active so the terminal never shows
+	// two apparent cursors competing for keyboard focus.
+	if i.searchActive {
+		return i.search.View()
+	}
+
 	var parts []string
 
-	// Picker overlay (if active)
+	// Picker overlay (picker and search modes are mutually exclusive).
 	if i.pickerActive {
 		parts = append(parts, i.picker.View())
 	}
@@ -93,10 +108,15 @@ func (i *Input) SetSize(width, height int) {
 	i.height = height
 	i.textinput.Width = width - 2 // Account for prompt
 	i.picker.SetWidth(width)
+	i.search.SetWidth(width)
 }
 
 // PreferredHeight implements Widget.
 func (i *Input) PreferredHeight() int {
+	if i.searchActive {
+		return i.search.PreferredHeight()
+	}
+
 	h := 3 // normal: top border + input + bottom border
 	if i.composer != nil {
 		layout := buildComposerLayout(i.composer.text, i.composer.cursor, i.width)
@@ -446,4 +466,55 @@ func (i *Input) PickerQuery() string {
 // input mode and cancel the Lua callback.
 func (i *Input) UpdatePickerFilter() {
 	i.picker.Filter(i.textinput.Value())
+}
+
+// Search access
+
+// ShowSearch opens the search overlay. An empty query keeps the
+// previous search's query (the widget persists across open/close).
+func (i *Input) ShowSearch(query string, scope SearchScope) {
+	i.search.Open(query, scope)
+	i.searchActive = true
+}
+
+// ReopenSearch updates an already-active navigator without changing its
+// frozen scrollback scope.
+func (i *Input) ReopenSearch(query string) {
+	i.search.Reopen(query)
+}
+
+// HideSearch closes the search overlay. Query and match state persist
+// in the widget for the next ShowSearch.
+func (i *Input) HideSearch() {
+	i.searchActive = false
+}
+
+// SearchActive reports whether the search overlay is showing.
+func (i *Input) SearchActive() bool {
+	return i.searchActive
+}
+
+// SearchTypeRunes appends typed runes to the search query.
+func (i *Input) SearchTypeRunes(rs []rune) {
+	i.search.TypeRunes(rs)
+}
+
+// SearchBackspace deletes the last rune of the search query.
+func (i *Input) SearchBackspace() {
+	i.search.Backspace()
+}
+
+// SearchSelectOlder moves the search selection toward earlier output.
+func (i *Input) SearchSelectOlder() {
+	i.search.SelectOlder()
+}
+
+// SearchSelectNewer moves the search selection toward the live tail.
+func (i *Input) SearchSelectNewer() {
+	i.search.SelectNewer()
+}
+
+// SearchSelected returns the currently selected search match.
+func (i *Input) SearchSelected() (SearchMatch, bool) {
+	return i.search.Selected()
 }

--- a/ui/tui/widget/input_widget_test.go
+++ b/ui/tui/widget/input_widget_test.go
@@ -9,7 +9,8 @@ import (
 )
 
 func newTestInput(width int) *Input {
-	in := NewInput(style.DefaultStyles())
+	styles := style.DefaultStyles()
+	in := NewInput(styles, NewSearch(NewScrollbackBuffer(100), styles))
 	in.SetSize(width, 0)
 	return in
 }
@@ -107,5 +108,31 @@ func TestInputInlinePickerSeedsFilterFromInput(t *testing.T) {
 	view := in.View()
 	if !strings.Contains(view, "reload") {
 		t.Errorf("re-filtered view should keep matches, got %q", view)
+	}
+}
+
+func TestInputSearchReplacesInactiveCommandField(t *testing.T) {
+	buf := newTestBuffer("a thief passes")
+	styles := style.DefaultStyles()
+	search := NewSearch(buf, styles)
+	in := NewInput(styles, search)
+	in.SetSize(60, 0)
+	in.SetValue("COMMAND-DRAFT")
+	in.ShowSearch("thief", SearchScope{})
+
+	view := in.View()
+	if !strings.Contains(view, "Search:") || !strings.Contains(view, "a thief passes") {
+		t.Fatalf("search navigator missing from input view:\n%s", view)
+	}
+	if strings.Contains(view, "COMMAND-DRAFT") {
+		t.Fatalf("inactive command field remained visible during search:\n%s", view)
+	}
+	if got, want := in.PreferredHeight(), search.PreferredHeight(); got != want {
+		t.Fatalf("PreferredHeight = %d, want search-only height %d", got, want)
+	}
+
+	in.HideSearch()
+	if view := in.View(); !strings.Contains(view, "COMMAND-DRAFT") {
+		t.Fatalf("command draft did not return after search closed:\n%s", view)
 	}
 }

--- a/ui/tui/widget/search.go
+++ b/ui/tui/widget/search.go
@@ -1,0 +1,581 @@
+package widget
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/mmcdole/rune/text"
+	"github.com/mmcdole/rune/ui/tui/style"
+	"github.com/mmcdole/rune/ui/tui/util"
+)
+
+// searchPageSize bounds the matches materialized on either side of the
+// active search anchor. Reaching a loaded edge scans another page, so a
+// common query cannot make typing allocate matches for the full 100k-row
+// buffer and the cap never makes older history unreachable.
+const searchPageSize = 250
+
+// searchMaxVisible is the maximum number of match rows shown at once.
+const searchMaxVisible = 5
+
+// RowMatcher reports all non-overlapping occurrences in a stripped row
+// as byte-offset pairs, left to right; empty means no match. Regex
+// support later is another constructor producing this same signature.
+type RowMatcher func(stripped string) [][2]int
+
+// SearchMatch is one matching scrollback row. The result unit is the
+// row: every occurrence in it is carried (and highlighted), but
+// navigation steps rows, since stepping between occurrences of the
+// same row would re-center the same text.
+type SearchMatch struct {
+	Seq      uint64          // absolute row sequence number
+	Ranges   []util.ColRange // occurrences as visible columns (viewport splice)
+	ByteRuns [][2]int        // occurrences as byte offsets into Stripped (list render)
+	Stripped string          // ANSI-stripped row text
+}
+
+// substringMatcher builds the v1 matcher: case-insensitive plain
+// substring. ASCII queries scan the row bytes directly (no allocation,
+// offsets stay valid); non-ASCII queries fall back to a rune-wise
+// simple-fold walk.
+func substringMatcher(query string) RowMatcher {
+	if query == "" {
+		return func(string) [][2]int { return nil }
+	}
+	if isASCII(query) {
+		lower := strings.ToLower(query)
+		return func(stripped string) [][2]int {
+			return asciiFoldRanges(stripped, lower)
+		}
+	}
+	return func(stripped string) [][2]int {
+		return foldRanges(stripped, query)
+	}
+}
+
+func isASCII(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] >= utf8.RuneSelf {
+			return false
+		}
+	}
+	return true
+}
+
+// asciiFoldRanges finds non-overlapping occurrences of an
+// already-lowercased ASCII query, case-insensitively on ASCII letters.
+func asciiFoldRanges(s, lowerQuery string) [][2]int {
+	var ranges [][2]int
+	n := len(lowerQuery)
+	for i := 0; i+n <= len(s); {
+		if asciiFoldPrefix(s[i:], lowerQuery) {
+			ranges = append(ranges, [2]int{i, i + n})
+			i += n
+		} else {
+			i++
+		}
+	}
+	return ranges
+}
+
+func asciiFoldPrefix(s, lowerQuery string) bool {
+	for j := 0; j < len(lowerQuery); j++ {
+		c := s[j]
+		if 'A' <= c && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		if c != lowerQuery[j] {
+			return false
+		}
+	}
+	return true
+}
+
+// foldRanges finds non-overlapping occurrences of query under Unicode
+// simple case-folding, walking rune by rune.
+func foldRanges(s, query string) [][2]int {
+	var ranges [][2]int
+	for i := 0; i < len(s); {
+		if n, ok := foldPrefix(s[i:], query); ok {
+			ranges = append(ranges, [2]int{i, i + n})
+			i += n
+		} else {
+			_, sz := utf8.DecodeRuneInString(s[i:])
+			i += sz
+		}
+	}
+	return ranges
+}
+
+// foldPrefix reports whether s begins with query under simple case
+// folding, returning the byte length of the matched prefix in s.
+func foldPrefix(s, query string) (int, bool) {
+	i := 0
+	for _, qr := range query {
+		if i >= len(s) {
+			return 0, false
+		}
+		sr, sz := utf8.DecodeRuneInString(s[i:])
+		if !foldEq(sr, qr) {
+			return 0, false
+		}
+		i += sz
+	}
+	return i, true
+}
+
+// foldEq reports whether two runes are equal under Unicode simple
+// case folding.
+func foldEq(a, b rune) bool {
+	if a == b {
+		return true
+	}
+	for r := unicode.SimpleFold(a); r != a; r = unicode.SimpleFold(r) {
+		if r == b {
+			return true
+		}
+	}
+	return false
+}
+
+func matchBufferRow(buf *ScrollbackBuffer, index int, match RowMatcher) (SearchMatch, bool) {
+	row := buf.At(index)
+	stripped := row
+	if strings.IndexByte(row, 0x1b) >= 0 {
+		stripped = text.StripANSI(row)
+	}
+	runs := match(stripped)
+	if len(runs) == 0 {
+		return SearchMatch{}, false
+	}
+
+	m := SearchMatch{Seq: buf.Seq(index), ByteRuns: runs, Stripped: stripped}
+	for _, r := range runs {
+		// Columns measured the same way the viewport splice cuts
+		// (ansi.StringWidth), so wide runes stay aligned.
+		start := ansi.StringWidth(stripped[:r[0]])
+		end := start + ansi.StringWidth(stripped[r[0]:r[1]])
+		m.Ranges = append(m.Ranges, util.ColRange{Start: start, End: end})
+	}
+	return m, true
+}
+
+func indexAtOrBefore(buf *ScrollbackBuffer, seq uint64) int {
+	if buf.Count() == 0 || seq < buf.Seq(0) {
+		return -1
+	}
+	newest := buf.Count() - 1
+	if seq >= buf.Seq(newest) {
+		return newest
+	}
+	index, ok := buf.IndexOf(seq)
+	if !ok {
+		return -1
+	}
+	return index
+}
+
+// scanOlder collects the nearest matches at-or-older-than throughSeq and
+// returns them in chronological order. more reports a confirmed additional
+// match beyond the returned page, not merely unscanned buffer rows.
+func scanOlder(buf *ScrollbackBuffer, match RowMatcher, throughSeq uint64, limit int) (matches []SearchMatch, more bool) {
+	for i := indexAtOrBefore(buf, throughSeq); i >= 0; i-- {
+		m, ok := matchBufferRow(buf, i, match)
+		if !ok {
+			continue
+		}
+		if len(matches) == limit {
+			more = true
+			break
+		}
+		matches = append(matches, m)
+	}
+	// The scan walks backward for speed; the navigator renders the page in
+	// the same oldest-to-newest order as the scrollback itself.
+	for left, right := 0, len(matches)-1; left < right; left, right = left+1, right-1 {
+		matches[left], matches[right] = matches[right], matches[left]
+	}
+	return matches, more
+}
+
+// scanNewer collects the nearest matches strictly newer than afterSeq,
+// stopping at the frozen search-session tail.
+func scanNewer(buf *ScrollbackBuffer, match RowMatcher, afterSeq, throughSeq uint64, limit int) (matches []SearchMatch, more bool) {
+	end := indexAtOrBefore(buf, throughSeq)
+	if end < 0 {
+		return nil, false
+	}
+	start := 0
+	if afterSeq >= buf.Seq(0) {
+		index := indexAtOrBefore(buf, afterSeq)
+		if index < 0 {
+			return nil, false
+		}
+		start = index + 1
+	}
+	for i := start; i <= end; i++ {
+		m, ok := matchBufferRow(buf, i, match)
+		if !ok {
+			continue
+		}
+		if len(matches) == limit {
+			return matches, true
+		}
+		matches = append(matches, m)
+	}
+	return matches, false
+}
+
+// SearchScope fixes the temporal frame for one search session. OriginSeq is
+// the viewport position from which a new query starts; ResumeSeq optionally
+// identifies the previously committed result when reopening a preserved
+// query.
+type SearchScope struct {
+	OriginSeq uint64
+	OriginSet bool
+	ResumeSeq uint64
+	ResumeSet bool
+}
+
+// Search is the scrollback-search navigator: a query line plus a small
+// chronological window of matching rows. It owns query, match paging, and
+// selection state; Model owns the resulting viewport position.
+type Search struct {
+	buf        *ScrollbackBuffer
+	styles     style.Styles
+	query      string
+	pristine   bool // reopened with a preserved query: first typed rune replaces it
+	matches    []SearchMatch
+	selected   int // index into chronological matches
+	scrollOff  int
+	olderMore  bool
+	newerMore  bool
+	originSeq  uint64
+	originSet  bool
+	frozenTail uint64
+	frozenSet  bool
+	notice     string
+	width      int
+}
+
+// NewSearch creates a search overlay over the given buffer.
+func NewSearch(buf *ScrollbackBuffer, styles style.Styles) *Search {
+	return &Search{buf: buf, styles: styles}
+}
+
+// Open (re)opens the overlay over a frozen scrollback snapshot. An empty
+// query keeps the previous one; either way the first typed rune starts a
+// fresh query.
+func (s *Search) Open(query string, scope SearchScope) {
+	preservingQuery := query == ""
+	if query != "" {
+		s.query = query
+	}
+	if s.buf.Count() > 0 {
+		s.frozenTail = s.buf.Seq(s.buf.Count() - 1)
+		s.frozenSet = true
+	} else {
+		s.frozenSet = false
+	}
+	if scope.OriginSet {
+		s.originSeq = scope.OriginSeq
+		s.originSet = true
+	} else if s.frozenSet {
+		s.originSeq = s.frozenTail
+		s.originSet = true
+	} else {
+		s.originSet = false
+	}
+	s.pristine = true
+	anchor, anchorSet := s.originSeq, s.originSet
+	if preservingQuery && scope.ResumeSet {
+		anchor, anchorSet = scope.ResumeSeq, true
+	}
+	s.rescan(anchor, anchorSet)
+}
+
+// Reopen updates an already-visible navigator without replacing its cancel
+// snapshot or admitting rows appended after the session opened.
+func (s *Search) Reopen(query string) {
+	preservingQuery := query == ""
+	if query != "" {
+		s.query = query
+	}
+	s.pristine = true
+	anchor, anchorSet := s.originSeq, s.originSet
+	if preservingQuery {
+		if selected, ok := s.Selected(); ok {
+			anchor, anchorSet = selected.Seq, true
+		}
+	}
+	s.rescan(anchor, anchorSet)
+}
+
+// Query returns the current query.
+func (s *Search) Query() string {
+	return s.query
+}
+
+// TypeRunes appends typed runes to the query, replacing a preserved
+// query on the first edit after Open.
+func (s *Search) TypeRunes(rs []rune) {
+	selected, selectedSet := s.Selected()
+	if s.pristine {
+		s.query = ""
+		s.pristine = false
+		selectedSet = false
+	}
+	s.query += string(rs)
+	if selectedSet {
+		s.rescan(selected.Seq, true)
+	} else {
+		s.rescan(s.originSeq, s.originSet)
+	}
+}
+
+// Backspace deletes the last rune of the query.
+func (s *Search) Backspace() {
+	selected, selectedSet := s.Selected()
+	s.pristine = false
+	if s.query == "" {
+		return
+	}
+	_, sz := utf8.DecodeLastRuneInString(s.query)
+	s.query = s.query[:len(s.query)-sz]
+	if selectedSet {
+		s.rescan(selected.Seq, true)
+	} else {
+		s.rescan(s.originSeq, s.originSet)
+	}
+}
+
+func (s *Search) rescan(anchor uint64, anchorSet bool) {
+	s.matches = nil
+	s.olderMore = false
+	s.newerMore = false
+	s.selected = 0
+	s.scrollOff = 0
+	s.notice = ""
+	if s.query == "" || !anchorSet || !s.frozenSet {
+		return
+	}
+
+	match := substringMatcher(s.query)
+	older, olderMore := scanOlder(s.buf, match, anchor, searchPageSize)
+	newer, newerMore := scanNewer(s.buf, match, anchor, s.frozenTail, searchPageSize)
+	s.matches = append(older, newer...)
+	s.olderMore = olderMore
+	s.newerMore = newerMore
+
+	// Prefer the exact anchor when it still matches. Otherwise start at the
+	// closest older match, falling forward only when none exists.
+	for i := range s.matches {
+		if s.matches[i].Seq == anchor {
+			s.selected = i
+			s.adjustScroll()
+			return
+		}
+	}
+	if len(older) > 0 {
+		s.selected = len(older) - 1
+	}
+	s.adjustScroll()
+}
+
+// SelectOlder moves toward earlier scrollback, loading another result page
+// on demand. It stops rather than wrapping at the oldest match.
+func (s *Search) SelectOlder() {
+	if len(s.matches) == 0 {
+		return
+	}
+	s.notice = ""
+	if s.selected > 0 {
+		s.selected--
+		s.adjustScroll()
+		return
+	}
+	if !s.olderMore || s.matches[0].Seq == 0 {
+		s.notice = "Oldest match"
+		return
+	}
+	page, more := scanOlder(s.buf, substringMatcher(s.query), s.matches[0].Seq-1, searchPageSize)
+	if len(page) == 0 {
+		s.olderMore = false
+		s.notice = "Oldest match"
+		return
+	}
+	s.matches = append(page, s.matches...)
+	s.selected = len(page) - 1
+	s.olderMore = more
+	s.adjustScroll()
+}
+
+// SelectNewer moves toward the live tail, loading another result page on
+// demand. It stops rather than wrapping at the newest match.
+func (s *Search) SelectNewer() {
+	if len(s.matches) == 0 {
+		return
+	}
+	s.notice = ""
+	if s.selected < len(s.matches)-1 {
+		s.selected++
+		s.adjustScroll()
+		return
+	}
+	if !s.newerMore {
+		s.notice = "Newest match"
+		return
+	}
+	page, more := scanNewer(s.buf, substringMatcher(s.query), s.matches[len(s.matches)-1].Seq, s.frozenTail, searchPageSize)
+	if len(page) == 0 {
+		s.newerMore = false
+		s.notice = "Newest match"
+		return
+	}
+	s.matches = append(s.matches, page...)
+	s.selected++
+	s.newerMore = more
+	s.adjustScroll()
+}
+
+func (s *Search) adjustScroll() {
+	visible := min(searchMaxVisible, len(s.matches))
+	if visible == 0 {
+		s.scrollOff = 0
+		return
+	}
+	s.scrollOff = s.selected - visible/2
+	if s.scrollOff < 0 {
+		s.scrollOff = 0
+	}
+	if maxOffset := len(s.matches) - visible; s.scrollOff > maxOffset {
+		s.scrollOff = maxOffset
+	}
+}
+
+// Selected returns the currently selected match.
+func (s *Search) Selected() (SearchMatch, bool) {
+	if len(s.matches) == 0 || s.selected < 0 || s.selected >= len(s.matches) {
+		return SearchMatch{}, false
+	}
+	return s.matches[s.selected], true
+}
+
+// SetWidth updates the overlay width.
+func (s *Search) SetWidth(w int) {
+	s.width = w
+}
+
+// PreferredHeight returns the rendered height including border.
+func (s *Search) PreferredHeight() int {
+	rows := len(s.matches)
+	if rows > searchMaxVisible {
+		rows = searchMaxVisible
+	}
+	if rows == 0 {
+		rows = 1 // "No matches" placeholder
+	}
+	return 2 + rows + 2 // header + rows + help footer + border
+}
+
+// View renders the search overlay.
+func (s *Search) View() string {
+	var lines []string
+	overlay := s.styles.OverlayBorder
+	frameWidth := max(1, s.width-overlay.GetHorizontalBorderSize())
+	contentWidth := max(1, frameWidth-overlay.GetHorizontalPadding())
+
+	lines = append(lines, s.headerLine(contentWidth))
+
+	if len(s.matches) == 0 {
+		empty := "  " + "No matches"
+		lines = append(lines, clipRow(s.styles.Muted.Render(empty), contentWidth))
+	} else {
+		start := s.scrollOff
+		end := start + searchMaxVisible
+		if end > len(s.matches) {
+			end = len(s.matches)
+		}
+		for i := start; i < end; i++ {
+			lines = append(lines, s.renderMatch(s.matches[i], contentWidth, i == s.selected))
+		}
+	}
+	lines = append(lines, s.footerLine(contentWidth))
+
+	content := strings.Join(lines, "\n")
+	return overlay.Width(frameWidth).Render(content)
+}
+
+// headerLine renders "Search: query█        cur/total", count right-aligned.
+func (s *Search) headerLine(width int) string {
+	count := "0/0"
+	if len(s.matches) > 0 {
+		if s.olderMore || s.newerMore {
+			count = fmt.Sprintf("%d+ matches", len(s.matches))
+		} else {
+			count = fmt.Sprintf("%d/%d", s.selected+1, len(s.matches))
+		}
+	}
+
+	label := "Search: "
+	query := text.VisualizeTerminalControls(s.query, false)
+	left := s.styles.Muted.Render(label) + query + "█"
+	leftWidth := len(label) + util.VisibleLen(query) + 1
+
+	pad := width - leftWidth - len(count)
+	if pad < 1 {
+		pad = 1
+	}
+	return clipRow(left+strings.Repeat(" ", pad)+s.styles.Muted.Render(count), width)
+}
+
+func (s *Search) footerLine(width int) string {
+	help := "↑ older  ↓ newer  Enter keep  Esc cancel"
+	if s.notice != "" {
+		help = s.notice + "  ·  " + help
+	}
+	return clipRow(s.styles.Muted.Render(help), width)
+}
+
+// renderMatch renders one match row, highlighting every occurrence.
+// Byte runs index into Stripped; render walks runes tracking their
+// byte offsets, so multi-byte text cannot misalign the highlight.
+func (s *Search) renderMatch(m SearchMatch, width int, selected bool) string {
+	prefix := "  "
+	if selected {
+		prefix = "> "
+	}
+
+	var b strings.Builder
+	runIdx := 0
+	for off, r := range m.Stripped {
+		for runIdx < len(m.ByteRuns) && off >= m.ByteRuns[runIdx][1] {
+			runIdx++
+		}
+		inMatch := runIdx < len(m.ByteRuns) &&
+			off >= m.ByteRuns[runIdx][0] && off < m.ByteRuns[runIdx][1]
+
+		ch := text.VisualizeTerminalControls(string(r), false)
+		switch {
+		case inMatch && selected:
+			b.WriteString(s.styles.OverlayMatchSelected.Render(ch))
+		case inMatch:
+			b.WriteString(s.styles.OverlayMatch.Render(ch))
+		case selected:
+			b.WriteString(s.styles.OverlaySelected.Render(ch))
+		default:
+			b.WriteString(s.styles.OverlayNormal.Render(ch))
+		}
+	}
+
+	var prefixStyled string
+	if selected {
+		prefixStyled = s.styles.OverlaySelected.Render(prefix)
+	} else {
+		prefixStyled = s.styles.OverlayNormal.Render(prefix)
+	}
+	return clipRow(prefixStyled+b.String(), max(1, width))
+}

--- a/ui/tui/widget/search_test.go
+++ b/ui/tui/widget/search_test.go
@@ -1,0 +1,364 @@
+package widget
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mmcdole/rune/ui/tui/style"
+	"github.com/mmcdole/rune/ui/tui/util"
+)
+
+func newTestBuffer(lines ...string) *ScrollbackBuffer {
+	buf := NewScrollbackBuffer(1000)
+	for _, l := range lines {
+		buf.Append(l)
+	}
+	return buf
+}
+
+func TestScanOlderReturnsChronologicalWindow(t *testing.T) {
+	buf := newTestBuffer("a thief", "quiet", "the THIEF again")
+	matches, more := scanOlder(buf, substringMatcher("thief"), buf.Seq(2), searchPageSize)
+	if more {
+		t.Error("small scan must not report more matches")
+	}
+	if len(matches) != 2 {
+		t.Fatalf("got %d matches, want 2", len(matches))
+	}
+	if matches[0].Stripped != "a thief" || matches[1].Stripped != "the THIEF again" {
+		t.Errorf("matches out of order: %q then %q", matches[0].Stripped, matches[1].Stripped)
+	}
+	if matches[0].Seq != buf.Seq(0) || matches[1].Seq != buf.Seq(2) {
+		t.Error("match seq numbers must identify the source rows")
+	}
+}
+
+func TestScanBackwardStripsANSIBeforeMatching(t *testing.T) {
+	// The escape sequence splits the word in the raw row; matching must
+	// run on stripped text, and columns must index the stripped row.
+	buf := newTestBuffer("xx \x1b[31mthi\x1b[1mef\x1b[0m yy")
+	matches, _ := scanOlder(buf, substringMatcher("thief"), buf.Seq(0), searchPageSize)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	m := matches[0]
+	if m.Stripped != "xx thief yy" {
+		t.Errorf("Stripped = %q", m.Stripped)
+	}
+	want := []util.ColRange{{Start: 3, End: 8}}
+	if len(m.Ranges) != 1 || m.Ranges[0] != want[0] {
+		t.Errorf("Ranges = %v, want %v", m.Ranges, want)
+	}
+}
+
+func TestScanBackwardWideRuneColumns(t *testing.T) {
+	buf := newTestBuffer("日本 thief")
+	matches, _ := scanOlder(buf, substringMatcher("thief"), buf.Seq(0), searchPageSize)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1", len(matches))
+	}
+	// Two double-width runes + space = column 5.
+	want := util.ColRange{Start: 5, End: 10}
+	if matches[0].Ranges[0] != want {
+		t.Errorf("Ranges[0] = %v, want %v", matches[0].Ranges[0], want)
+	}
+}
+
+func TestScanBackwardMultipleOccurrencesOneRow(t *testing.T) {
+	buf := newTestBuffer("The thief robbed another thief.")
+	matches, _ := scanOlder(buf, substringMatcher("thief"), buf.Seq(0), searchPageSize)
+	if len(matches) != 1 {
+		t.Fatalf("one row must yield one match, got %d", len(matches))
+	}
+	want := []util.ColRange{{Start: 4, End: 9}, {Start: 25, End: 30}}
+	if len(matches[0].Ranges) != 2 || matches[0].Ranges[0] != want[0] || matches[0].Ranges[1] != want[1] {
+		t.Errorf("Ranges = %v, want %v", matches[0].Ranges, want)
+	}
+}
+
+func TestScanBackwardNonOverlapping(t *testing.T) {
+	buf := newTestBuffer("aaa")
+	matches, _ := scanOlder(buf, substringMatcher("aa"), buf.Seq(0), searchPageSize)
+	if len(matches) != 1 || len(matches[0].Ranges) != 1 {
+		t.Fatalf("overlapping occurrences must not double-count: %+v", matches)
+	}
+}
+
+func TestScanBackwardNonASCIIQuery(t *testing.T) {
+	buf := newTestBuffer("der STRASSE entlang", "die straße")
+	matches, _ := scanOlder(buf, substringMatcher("straße"), buf.Seq(1), searchPageSize)
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches, want 1 (simple fold does not equate ß/SS)", len(matches))
+	}
+	if matches[0].Stripped != "die straße" {
+		t.Errorf("matched %q", matches[0].Stripped)
+	}
+
+	matches, _ = scanOlder(buf, substringMatcher("STRAßE"), buf.Seq(1), searchPageSize)
+	if len(matches) != 1 {
+		t.Errorf("case-folded non-ASCII query should match, got %d", len(matches))
+	}
+}
+
+func TestScanOlderPagesNearestMatches(t *testing.T) {
+	buf := NewScrollbackBuffer(1000)
+	for i := 0; i < 300; i++ {
+		buf.Append(fmt.Sprintf("thief %d", i))
+	}
+	matches, more := scanOlder(buf, substringMatcher("thief"), buf.Seq(299), searchPageSize)
+	if len(matches) != searchPageSize {
+		t.Fatalf("got %d matches, want page %d", len(matches), searchPageSize)
+	}
+	if !more {
+		t.Error("page with older matches remaining must report more")
+	}
+	if matches[0].Stripped != "thief 50" || matches[len(matches)-1].Stripped != "thief 299" {
+		t.Errorf("page = %q ... %q, want chronological nearest window",
+			matches[0].Stripped, matches[len(matches)-1].Stripped)
+	}
+
+	// Exactly one page, all scanned: no older matches remain.
+	buf2 := NewScrollbackBuffer(1000)
+	for i := 0; i < searchPageSize; i++ {
+		buf2.Append("thief")
+	}
+	_, more = scanOlder(buf2, substringMatcher("thief"), buf2.Seq(searchPageSize-1), searchPageSize)
+	if more {
+		t.Error("scan that reached the oldest row must not report more")
+	}
+}
+
+func newTestSearch(lines ...string) *Search {
+	return NewSearch(newTestBuffer(lines...), style.DefaultStyles())
+}
+
+func TestSearchOpenPreservesQueryAndTypingReplaces(t *testing.T) {
+	s := newTestSearch("a thief", "a guard")
+	s.SetWidth(60)
+
+	s.Open("thief", SearchScope{})
+	if len(s.matches) != 1 {
+		t.Fatalf("open with query should scan: %d matches", len(s.matches))
+	}
+
+	// Reopen without a query: last query kept.
+	s.Open("", SearchScope{})
+	if s.Query() != "thief" {
+		t.Errorf("Query = %q, want preserved %q", s.Query(), "thief")
+	}
+
+	// First rune typed after open replaces the preserved query.
+	s.TypeRunes([]rune("g"))
+	if s.Query() != "g" {
+		t.Errorf("Query = %q, want %q (pristine replace)", s.Query(), "g")
+	}
+	s.TypeRunes([]rune("uard"))
+	if s.Query() != "guard" {
+		t.Errorf("Query = %q, want %q", s.Query(), "guard")
+	}
+	if len(s.matches) != 1 || s.matches[0].Stripped != "a guard" {
+		t.Errorf("typing must rescan: %+v", s.matches)
+	}
+
+	s.Backspace()
+	if s.Query() != "guar" {
+		t.Errorf("Backspace: Query = %q, want %q", s.Query(), "guar")
+	}
+}
+
+func TestSearchSelectionUsesChronologicalOlderNewerWithoutWrapping(t *testing.T) {
+	s := newTestSearch("thief 1", "thief 2", "thief 3")
+	s.Open("thief", SearchScope{})
+
+	if m, ok := s.Selected(); !ok || m.Stripped != "thief 3" {
+		t.Fatalf("initial selection should be the newest match, got %+v", m)
+	}
+	s.SelectOlder()
+	if m, _ := s.Selected(); m.Stripped != "thief 2" {
+		t.Errorf("SelectOlder should step backward, got %q", m.Stripped)
+	}
+	s.SelectOlder()
+	s.SelectOlder() // stops at oldest
+	if m, _ := s.Selected(); m.Stripped != "thief 1" {
+		t.Errorf("selection should stop at oldest, got %q", m.Stripped)
+	}
+	s.SelectNewer()
+	if m, _ := s.Selected(); m.Stripped != "thief 2" {
+		t.Errorf("SelectNewer should step forward, got %q", m.Stripped)
+	}
+}
+
+func TestSearchStartsAtScrolledOriginRatherThanNewestPage(t *testing.T) {
+	buf := NewScrollbackBuffer(1000)
+	for i := 0; i < 10; i++ {
+		text := "quiet"
+		if i == 5 {
+			text = "nearby thief"
+		}
+		buf.Append(text)
+	}
+	origin := buf.Seq(9)
+	for i := 0; i < searchPageSize+20; i++ {
+		buf.Append(fmt.Sprintf("newer thief %d", i))
+	}
+
+	s := NewSearch(buf, style.DefaultStyles())
+	s.Open("thief", SearchScope{OriginSeq: origin, OriginSet: true})
+	m, ok := s.Selected()
+	if !ok || m.Stripped != "nearby thief" {
+		t.Fatalf("selected %+v, want closest older match at the viewport origin", m)
+	}
+}
+
+func TestSearchLoadsAnotherOlderPageWithoutWrapping(t *testing.T) {
+	buf := NewScrollbackBuffer(1000)
+	for i := 0; i < 300; i++ {
+		buf.Append(fmt.Sprintf("thief %d", i))
+	}
+	s := NewSearch(buf, style.DefaultStyles())
+	s.Open("thief", SearchScope{})
+
+	// The initial page covers 50..299 with 299 selected. The 250th older
+	// step crosses that loaded edge and selects 49 from the next page.
+	for i := 0; i < searchPageSize; i++ {
+		s.SelectOlder()
+	}
+	m, ok := s.Selected()
+	if !ok || m.Stripped != "thief 49" {
+		t.Fatalf("selected %+v, want first selection from the next older page", m)
+	}
+	if len(s.matches) != 300 || s.olderMore {
+		t.Fatalf("loaded matches/more = %d/%v, want complete 300/false", len(s.matches), s.olderMore)
+	}
+}
+
+func TestSearchFreezesCorpusUntilReopen(t *testing.T) {
+	buf := newTestBuffer("thief before open")
+	s := NewSearch(buf, style.DefaultStyles())
+	s.Open("thief", SearchScope{})
+	buf.Append("thief after open")
+
+	// First typing replaces the preserved query and forces a rescan. The row
+	// appended after Open must remain outside this search session.
+	s.TypeRunes([]rune("thief"))
+	if len(s.matches) != 1 || s.matches[0].Stripped != "thief before open" {
+		t.Fatalf("frozen search included later output: %+v", s.matches)
+	}
+}
+
+func TestSearchReopenResumesCommittedSequence(t *testing.T) {
+	buf := newTestBuffer("thief 1", "quiet", "thief 2", "thief 3")
+	s := NewSearch(buf, style.DefaultStyles())
+	s.Open("thief", SearchScope{})
+	s.SelectOlder()
+	committed, _ := s.Selected()
+
+	s.Open("", SearchScope{OriginSeq: buf.Seq(3), OriginSet: true, ResumeSeq: committed.Seq, ResumeSet: true})
+	resumed, ok := s.Selected()
+	if !ok || resumed.Seq != committed.Seq {
+		t.Fatalf("resumed %+v, want committed sequence %d", resumed, committed.Seq)
+	}
+}
+
+func TestSearchViewHeaderAndRows(t *testing.T) {
+	s := newTestSearch("one thief", "two", "THIEF two")
+	s.SetWidth(60)
+	s.Open("thief", SearchScope{})
+
+	view := s.View()
+	if !strings.Contains(view, "2/2") {
+		t.Errorf("header should show newest as the final chronological match, view:\n%s", view)
+	}
+	if !strings.Contains(view, "Search:") || !strings.Contains(view, "thief█") {
+		t.Errorf("header should show the query with cursor, view:\n%s", view)
+	}
+	if !strings.Contains(view, "THIEF two") {
+		t.Errorf("view should list the newest match, view:\n%s", view)
+	}
+
+	if !strings.Contains(view, "↑ older") || !strings.Contains(view, "↓ newer") {
+		t.Errorf("footer should explain temporal navigation, view:\n%s", view)
+	}
+	s.SelectOlder()
+	if view := s.View(); !strings.Contains(view, "1/2") {
+		t.Errorf("count should follow selection, view:\n%s", view)
+	}
+}
+
+func TestSearchViewNoMatches(t *testing.T) {
+	s := newTestSearch("nothing here")
+	s.SetWidth(60)
+	s.Open("zzz", SearchScope{})
+
+	view := s.View()
+	if !strings.Contains(view, "0/0") || !strings.Contains(view, "No matches") {
+		t.Errorf("empty result view wrong:\n%s", view)
+	}
+	if _, ok := s.Selected(); ok {
+		t.Error("Selected must report none for an empty result")
+	}
+}
+
+func TestSearchViewPartialCount(t *testing.T) {
+	buf := NewScrollbackBuffer(1000)
+	for i := 0; i < 300; i++ {
+		buf.Append("thief")
+	}
+	s := NewSearch(buf, style.DefaultStyles())
+	s.SetWidth(60)
+	s.Open("thief", SearchScope{})
+
+	if view := s.View(); !strings.Contains(view, "250+ matches") {
+		t.Errorf("partial scan should avoid a false ordinal, view:\n%s", view)
+	}
+}
+
+func TestSearchPreferredHeight(t *testing.T) {
+	s := newTestSearch("thief 1", "thief 2")
+	s.SetWidth(60)
+	s.Open("thief", SearchScope{})
+	// header + 2 rows + help footer + border
+	if got := s.PreferredHeight(); got != 6 {
+		t.Errorf("PreferredHeight = %d, want 6", got)
+	}
+	s.Open("", SearchScope{})
+	s.TypeRunes([]rune("zzz"))
+	// header + placeholder + help footer + border
+	if got := s.PreferredHeight(); got != 5 {
+		t.Errorf("PreferredHeight = %d, want 5", got)
+	}
+}
+
+func TestSearchPreferredHeightCapsAtFiveResults(t *testing.T) {
+	lines := make([]string, 20)
+	for i := range lines {
+		lines[i] = fmt.Sprintf("thief %d", i)
+	}
+	s := newTestSearch(lines...)
+	s.Open("thief", SearchScope{})
+	// header + five rows + help footer + border
+	if got := s.PreferredHeight(); got != 9 {
+		t.Errorf("PreferredHeight = %d, want 9", got)
+	}
+}
+
+func TestSearchSeqStableAcrossEviction(t *testing.T) {
+	buf := NewScrollbackBuffer(5)
+	buf.Append("the thief")
+	for i := 0; i < 4; i++ {
+		buf.Append("filler")
+	}
+	s := NewSearch(buf, style.DefaultStyles())
+	s.Open("thief", SearchScope{})
+	m, ok := s.Selected()
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	// Evict the matched row: its seq no longer resolves, matches are a
+	// snapshot and simply point at a gone row.
+	buf.Append("evictor")
+	if _, ok := buf.IndexOf(m.Seq); ok {
+		t.Error("matched row should be evicted in this scenario")
+	}
+}

--- a/ui/tui/widget/viewport.go
+++ b/ui/tui/widget/viewport.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/x/ansi"
+	"github.com/mmcdole/rune/ui/tui/style"
 	"github.com/mmcdole/rune/ui/tui/util"
 )
 
@@ -37,6 +38,7 @@ type ScrollbackBuffer struct {
 	tail     int
 	count    int
 	capacity int
+	appended uint64 // rows ever appended; assigns eviction-stable sequence numbers
 }
 
 // NewScrollbackBuffer creates a new ring buffer.
@@ -54,6 +56,7 @@ func NewScrollbackBuffer(capacity int) *ScrollbackBuffer {
 func (sb *ScrollbackBuffer) Append(row string) {
 	sb.lines[sb.tail] = row
 	sb.tail = (sb.tail + 1) % sb.capacity
+	sb.appended++
 
 	if sb.count < sb.capacity {
 		sb.count++
@@ -76,6 +79,23 @@ func (sb *ScrollbackBuffer) At(i int) string {
 	return sb.lines[actualIndex]
 }
 
+// Seq returns the absolute sequence number of the row at index i.
+// Indices shift as the full ring evicts old rows; sequence numbers
+// never do, so they can anchor positions across appends.
+func (sb *ScrollbackBuffer) Seq(i int) uint64 {
+	return sb.appended - uint64(sb.count) + uint64(i)
+}
+
+// IndexOf maps an absolute sequence number back to a current index;
+// ok is false when that row has been evicted (or never existed).
+func (sb *ScrollbackBuffer) IndexOf(seq uint64) (int, bool) {
+	oldest := sb.appended - uint64(sb.count)
+	if seq < oldest || seq >= sb.appended {
+		return 0, false
+	}
+	return int(seq - oldest), true
+}
+
 // Viewport renders a window into the scrollback buffer.
 type Viewport struct {
 	buffer     *ScrollbackBuffer
@@ -87,13 +107,21 @@ type Viewport struct {
 	cacheValid bool
 	cachedView string
 	prompt     string
+	styles     style.Styles
+
+	// Search-match highlight, anchored by sequence number so appends
+	// and ring eviction cannot smear it onto a different row.
+	hlSet    bool
+	hlSeq    uint64
+	hlRanges []util.ColRange
 }
 
 // NewViewport creates a viewport for the given buffer.
-func NewViewport(buffer *ScrollbackBuffer) *Viewport {
+func NewViewport(buffer *ScrollbackBuffer, styles style.Styles) *Viewport {
 	return &Viewport{
 		buffer: buffer,
 		mode:   ModeLive,
+		styles: styles,
 	}
 }
 
@@ -162,11 +190,26 @@ func (v *Viewport) View() string {
 		}
 	}
 
+	hlIdx := -1
+	if v.hlSet {
+		if idx, ok := v.buffer.IndexOf(v.hlSeq); ok {
+			hlIdx = idx
+		}
+	}
+
 	for i := startIdx; i < endIdx; i++ {
 		if emptyLines > 0 || i > startIdx {
 			b.WriteByte('\n')
 		}
-		b.WriteString(clipRow(v.buffer.At(i), v.width))
+		row := v.buffer.At(i)
+		if i == hlIdx {
+			// Splice first, clip second: highlighting must not let a
+			// row exceed the terminal width.
+			row = util.HighlightRanges(row, v.hlRanges, func(s string) string {
+				return v.styles.OverlayMatch.Render(s)
+			})
+		}
+		b.WriteString(clipRow(row, v.width))
 	}
 
 	if hasPrompt {
@@ -293,6 +336,102 @@ func (v *Viewport) GotoTop() {
 	v.offset = v.maxOffset()
 	if v.offset > 0 {
 		v.mode = ModeScrolled
+	}
+	v.cacheValid = false
+}
+
+// CenterOn scrolls so the row with the given sequence number sits
+// vertically centered (as close as clamping allows). An evicted row
+// pins to the oldest surviving window, like OnNewRows.
+func (v *Viewport) CenterOn(seq uint64) {
+	idx, ok := v.buffer.IndexOf(seq)
+	if !ok {
+		v.offset = v.maxOffset()
+	} else {
+		v.offset = v.buffer.Count() - idx - (v.height+1)/2
+		if max := v.maxOffset(); v.offset > max {
+			v.offset = max
+		}
+		if v.offset < 0 {
+			v.offset = 0
+		}
+	}
+	if v.offset > 0 {
+		v.mode = ModeScrolled
+	} else {
+		v.mode = ModeLive
+		v.newLines = 0
+	}
+	v.cacheValid = false
+}
+
+// SetHighlight marks visible column ranges of the row with the given
+// sequence number to render restyled (search-match highlighting).
+func (v *Viewport) SetHighlight(seq uint64, ranges []util.ColRange) {
+	v.hlSet = true
+	v.hlSeq = seq
+	v.hlRanges = ranges
+	v.cacheValid = false
+}
+
+// ClearHighlight removes the search-match highlight.
+func (v *Viewport) ClearHighlight() {
+	if v.hlSet {
+		v.hlSet = false
+		v.hlRanges = nil
+		v.cacheValid = false
+	}
+}
+
+// ScrollPos is a sequence-anchored snapshot of the viewport position.
+// A raw offset would not survive appends: OnNewRows re-anchors a
+// scrolled viewport's offset on every append, and a snapshot taken
+// earlier would land newer by exactly the rows that arrived since.
+type ScrollPos struct {
+	BottomSeq uint64 // sequence of the bottom visible row at save time
+	Mode      ScrollMode
+	NewLines  int
+	Appended  uint64 // buffer append counter at save time
+}
+
+// SaveScroll captures the current position for a later RestoreScroll.
+func (v *Viewport) SaveScroll() ScrollPos {
+	p := ScrollPos{Mode: v.mode, NewLines: v.newLines, Appended: v.buffer.appended}
+	if c := v.buffer.Count(); c > 0 {
+		bottom := c - 1 - v.offset
+		if bottom < 0 {
+			bottom = 0
+		}
+		p.BottomSeq = v.buffer.Seq(bottom)
+	}
+	return p
+}
+
+// RestoreScroll returns to a saved position: the same text, not the
+// same distance from live. A live snapshot returns to live (tailing is
+// itself a position); a scrolled snapshot re-anchors on the saved
+// bottom row, counting rows that arrived meanwhile into NewLineCount,
+// and pins to the oldest surviving window if the row was evicted.
+func (v *Viewport) RestoreScroll(p ScrollPos) {
+	if p.Mode == ModeLive {
+		v.GotoBottom()
+		return
+	}
+	if idx, ok := v.buffer.IndexOf(p.BottomSeq); ok {
+		v.offset = v.buffer.Count() - 1 - idx
+	} else {
+		v.offset = v.maxOffset()
+	}
+	if max := v.maxOffset(); v.offset > max {
+		v.offset = max
+	}
+	if v.offset <= 0 {
+		v.offset = 0
+		v.mode = ModeLive
+		v.newLines = 0
+	} else {
+		v.mode = ModeScrolled
+		v.newLines = p.NewLines + int(v.buffer.appended-p.Appended)
 	}
 	v.cacheValid = false
 }

--- a/ui/tui/widget/viewport_test.go
+++ b/ui/tui/widget/viewport_test.go
@@ -5,12 +5,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mmcdole/rune/ui/tui/style"
 	"github.com/mmcdole/rune/ui/tui/util"
 )
 
 func newTestViewport(width, height int, lines ...string) (*Viewport, *ScrollbackBuffer) {
 	buf := NewScrollbackBuffer(1000)
-	v := NewViewport(buf)
+	v := NewViewport(buf, style.DefaultStyles())
 	v.SetSize(width, height)
 	for _, l := range lines {
 		buf.Append(l)
@@ -189,7 +190,7 @@ func TestViewportEmptyBufferRendersBlankRows(t *testing.T) {
 // (issue #60).
 func TestViewportScrolledSurvivesRingBufferEviction(t *testing.T) {
 	buf := NewScrollbackBuffer(8)
-	v := NewViewport(buf)
+	v := NewViewport(buf, style.DefaultStyles())
 	v.SetSize(40, 3)
 	for i := 1; i <= 8; i++ {
 		buf.Append(fmt.Sprintf("line %d", i))
@@ -257,5 +258,191 @@ func TestScrollbackBufferWrapsAtCapacity(t *testing.T) {
 	}
 	if buf.At(-1) != "" || buf.At(3) != "" {
 		t.Error("out-of-range At should return empty string")
+	}
+}
+
+func TestScrollbackBufferSeqSurvivesEviction(t *testing.T) {
+	buf := NewScrollbackBuffer(5)
+	for i := 1; i <= 8; i++ {
+		buf.Append(fmt.Sprintf("line %d", i))
+	}
+	// Lines 4-8 survive; seq numbers are 3-7 (0-based from first append).
+	if got := buf.Seq(0); got != 3 {
+		t.Errorf("Seq(0) = %d, want 3", got)
+	}
+	for i := 0; i < buf.Count(); i++ {
+		idx, ok := buf.IndexOf(buf.Seq(i))
+		if !ok || idx != i {
+			t.Errorf("IndexOf(Seq(%d)) = %d,%v, want %d,true", i, idx, ok, i)
+		}
+	}
+	if _, ok := buf.IndexOf(2); ok {
+		t.Error("IndexOf of an evicted seq must report ok=false")
+	}
+	if _, ok := buf.IndexOf(8); ok {
+		t.Error("IndexOf of a not-yet-appended seq must report ok=false")
+	}
+}
+
+func TestViewportCenterOn(t *testing.T) {
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	v, buf := newTestViewport(40, 5, lines...)
+
+	// Center on line 10 (seq 9): it should sit on the middle row.
+	v.CenterOn(buf.Seq(9))
+	rows := viewRows(v)
+	if rows[2] != "line 10" {
+		t.Errorf("center row = %q, want %q (rows %q)", rows[2], "line 10", rows)
+	}
+	if v.Mode() != ModeScrolled {
+		t.Error("centering into history should enter scrolled mode")
+	}
+
+	// Near the top: clamps so the frame stays full.
+	v.CenterOn(buf.Seq(0))
+	rows = viewRows(v)
+	if rows[0] != "line 1" {
+		t.Errorf("top clamp: rows = %q, want line 1 first", rows)
+	}
+
+	// Near the live edge: clamps to offset 0 and returns to live.
+	v.CenterOn(buf.Seq(19))
+	if v.Mode() != ModeLive {
+		t.Error("centering on the newest row should land live")
+	}
+
+	// Buffer smaller than the viewport: always live, never negative.
+	small, sbuf := newTestViewport(40, 10, "a", "b")
+	small.CenterOn(sbuf.Seq(0))
+	if small.Mode() != ModeLive {
+		t.Error("centering within a short buffer should stay live")
+	}
+}
+
+func TestViewportHighlightRendersOnRightRowOnly(t *testing.T) {
+	v, buf := newTestViewport(40, 3, "one thief", "two", "three", "four")
+	v.ScrollUp(1) // showing "one thief", "two", "three"
+	v.SetHighlight(buf.Seq(0), []util.ColRange{{Start: 4, End: 9}})
+
+	rows := viewRows(v)
+	if !strings.Contains(rows[0], "\x1b[") || !strings.Contains(rows[0], "thief") {
+		t.Errorf("highlighted row should carry escape codes: %q", rows[0])
+	}
+	for i := 1; i < len(rows); i++ {
+		if strings.Contains(rows[i], "\x1b[") {
+			t.Errorf("row %d should be unstyled, got %q", i, rows[i])
+		}
+	}
+
+	// The highlight follows its row: while scrolled, appends re-anchor
+	// the view and the highlight must stay on the same text.
+	buf.Append("five")
+	v.OnNewRows(1)
+	rows = viewRows(v)
+	if !strings.Contains(rows[0], "\x1b[") || !strings.Contains(rows[0], "thief") {
+		t.Errorf("after append the highlight must stay on its row; rows = %q", rows)
+	}
+
+	v.ClearHighlight()
+	for i, row := range viewRows(v) {
+		if strings.Contains(row, "\x1b[") {
+			t.Errorf("row %d still styled after ClearHighlight: %q", i, row)
+		}
+	}
+}
+
+func TestViewportSetHighlightInvalidatesCache(t *testing.T) {
+	v, buf := newTestViewport(40, 2, "alpha", "beta")
+	before := v.View()
+	v.SetHighlight(buf.Seq(1), []util.ColRange{{Start: 0, End: 4}})
+	if v.View() == before {
+		t.Error("SetHighlight must invalidate the cached view")
+	}
+}
+
+// Esc-restore must return to the same text, not the same distance from
+// live: appends during search re-anchor a scrolled viewport (OnNewRows),
+// and a raw saved offset would land newer by the rows that arrived.
+func TestViewportRestoreScrollSameTextAfterAppends(t *testing.T) {
+	var lines []string
+	for i := 1; i <= 10; i++ {
+		lines = append(lines, fmt.Sprintf("line %d", i))
+	}
+	v, buf := newTestViewport(40, 2, lines...)
+
+	v.ScrollUp(5) // showing lines 4,5
+	before := viewRows(v)
+	saved := v.SaveScroll()
+
+	v.CenterOn(buf.Seq(0)) // search preview moves the viewport
+	for i := 11; i <= 15; i++ {
+		buf.Append(fmt.Sprintf("line %d", i))
+		v.OnNewRows(1)
+	}
+
+	v.RestoreScroll(saved)
+	after := viewRows(v)
+	for i := range before {
+		if before[i] != after[i] {
+			t.Errorf("restore changed the visible text: %q -> %q", before, after)
+		}
+	}
+	if v.Mode() != ModeScrolled {
+		t.Error("restore of a scrolled snapshot should stay scrolled")
+	}
+	if v.NewLineCount() != 5 {
+		t.Errorf("NewLineCount = %d, want 5 (rows appended during search)", v.NewLineCount())
+	}
+}
+
+func TestViewportRestoreScrollFromLiveReturnsToLive(t *testing.T) {
+	v, buf := newTestViewport(40, 2, "one", "two", "three")
+	saved := v.SaveScroll()
+
+	v.CenterOn(buf.Seq(0))
+	buf.Append("four")
+	v.OnNewRows(1)
+
+	v.RestoreScroll(saved)
+	if v.Mode() != ModeLive || v.NewLineCount() != 0 {
+		t.Error("live snapshot must restore to live/tailing")
+	}
+	rows := viewRows(v)
+	if rows[len(rows)-1] != "four" {
+		t.Errorf("restored live view should show the newest line, got %q", rows)
+	}
+}
+
+func TestViewportRestoreScrollClampsAfterEviction(t *testing.T) {
+	buf := NewScrollbackBuffer(6)
+	v := NewViewport(buf, style.DefaultStyles())
+	v.SetSize(40, 2)
+	for i := 1; i <= 6; i++ {
+		buf.Append(fmt.Sprintf("line %d", i))
+		v.OnNewRows(1)
+	}
+
+	v.GotoTop() // anchored on lines 1,2
+	saved := v.SaveScroll()
+
+	// Evict the anchor entirely.
+	for i := 7; i <= 20; i++ {
+		buf.Append(fmt.Sprintf("line %d", i))
+		v.OnNewRows(1)
+	}
+
+	v.RestoreScroll(saved)
+	rows := viewRows(v)
+	if len(rows) != 2 {
+		t.Fatalf("View emitted %d rows, want 2: %q", len(rows), rows)
+	}
+	if rows[0] != "line 15" {
+		t.Errorf("evicted anchor should pin to the oldest surviving view, got %q", rows)
+	}
+	if v.Mode() != ModeScrolled {
+		t.Error("clamped restore should remain scrolled")
 	}
 }

--- a/website/src/content/docs/reference/api/state-lines.md
+++ b/website/src/content/docs/reference/api/state-lines.md
@@ -16,6 +16,7 @@ rune.state.connected     -- bool, connection status
 rune.state.address       -- server address, scheme included
 rune.state.scroll_mode   -- "live" or "scrolled"
 rune.state.scroll_lines  -- new lines arrived while scrolled
+rune.state.search_active -- true while scrollback search captures input
 rune.state.width         -- terminal width
 rune.state.height        -- terminal height
 
@@ -35,6 +36,7 @@ the current values, and writing any field raises an error.
 | `address` | string | The connected address, scheme included (e.g. `tls://mud.example.com:4000`) |
 | `scroll_mode` | string | `"live"`, or `"scrolled"` while scrolled back |
 | `scroll_lines` | number | New lines received while scrolled |
+| `search_active` | boolean | Whether the scrollback-search navigator is active |
 | `width` | number | Terminal width in columns |
 | `height` | number | Terminal height in rows |
 

--- a/website/src/content/docs/reference/api/ui.md
+++ b/website/src/content/docs/reference/api/ui.md
@@ -13,6 +13,7 @@ introductions, see [Layout & UI](/interface/layout/) and
 rune.ui.layout(config)               -- set the dock layout
 rune.ui.bar(name, render_fn, opts?)  -- register a bar renderer
 rune.ui.refresh_bars()               -- request an immediate re-render
+rune.ui.search(opts?)                -- open the scrollback-search overlay
 ```
 
 `rune.ui.bar` returns a [handle](/reference/api/#handles) and accepts
@@ -88,6 +89,38 @@ end)
 `rune.ui.refresh_bars()` requests an immediate re-render instead of
 waiting for the tick — call it after changing the state a renderer
 reads, e.g. in a GMCP vitals handler.
+
+### rune.ui.search
+
+```lua
+rune.ui.search(opts?)
+```
+
+- `opts` (table, optional) — `query` (string): the initial search
+  text. Omitted or empty reopens the overlay with the previous
+  search's query.
+
+Opens the scrollback-search overlay above the input line. It scans the
+main window's history (newest first, case-insensitive substring) and
+lists matching lines; the viewport follows the selection, centering
+each match with the matched text highlighted.
+
+Bound to `Ctrl+F` by default, and available as `/find [pattern]`.
+A bare `/find` (or `Ctrl+F`) reopens with the last query preserved;
+typing replaces it.
+
+Keys inside the overlay:
+
+| Key | Action |
+|-----|--------|
+| type / backspace | edit the query (rescans as you type) |
+| `Up` / `Down` | step to a newer / older match (the viewport follows) |
+| `Enter` | close, leaving the viewport at the match |
+| `Esc` / `Ctrl+C` | close and restore the scroll position from before the search |
+
+The match counter shows `current/total`; a total like `250+` means the
+scan stopped at its cap and older matches exist beyond it. After
+`Enter`, the usual scroll keys apply — `Ctrl+End` returns to live.
 
 ## Managing
 


### PR DESCRIPTION
## Summary

- add Ctrl+F, /find, and rune.ui.search scrollback search entry points
- navigate chronological matches from the current viewport with bounded on-demand paging
- preserve search/scroll separation, committed highlighting, and cancel restoration

## Validation

- make check
- make test
- make test-jit
- isolated real-terminal verification

Refs #10.

The issue remains open for follow-up search feedback.