### PR TITLE
lua: reject invalid command registrations

### DIFF
--- a/lua/commands_test.go
+++ b/lua/commands_test.go
@@ -64,6 +64,38 @@ func TestListingCommandsShowRegistrations(t *testing.T) {
 	}
 }
 
+// Invalid user metadata must fail at registration, before it can poison
+// the command registry consumed by /help and the inline command picker.
+func TestCommandRegistrationRejectsTableDescriptionWithoutBreakingHelp(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	err := engine.DoString("user.lua", `
+		rune.command.add("autoreconnect", function() end, {
+			name = "automatic-reconnect-command",
+			group = "connection",
+		})
+	`)
+	if err == nil {
+		t.Error("registration with a table description succeeded")
+	} else if !strings.Contains(err.Error(), "description must be a string") {
+		t.Errorf("registration error = %q, want description type error", err)
+	}
+
+	host.DrainPrintCalls()
+	engine.OnInput("/help")
+	printed := strings.Join(host.DrainPrintCalls(), "\n")
+	if strings.Contains(printed, "error:") {
+		t.Errorf("/help was broken by the rejected command:\n%s", printed)
+	}
+	if !strings.Contains(printed, "/connect") {
+		t.Errorf("/help did not list built-in commands:\n%s", printed)
+	}
+	if strings.Contains(printed, "/autoreconnect") {
+		t.Errorf("rejected command remained registered:\n%s", printed)
+	}
+}
+
 // TestErrorTagIsRed pins the presentation convention (05_style.lua):
 // [Error] tags are red, tag only, message plain - checked on the two
 // highest-traffic paths, the default error handler and unknown

--- a/lua/core/55_commands.lua
+++ b/lua/core/55_commands.lua
@@ -33,6 +33,19 @@ rune.command = {}
 -- Add a slash command. opts: group (see 15_registry.lua).
 -- Returns a handle with :enable/:disable/:remove.
 function rune.command.add(name, handler, description, opts)
+    if type(name) ~= "string" then
+        error("rune.command.add: name must be a string", 2)
+    end
+    if type(handler) ~= "function" then
+        error("rune.command.add: handler must be a function", 2)
+    end
+    if description ~= nil and type(description) ~= "string" then
+        error("rune.command.add: description must be a string", 2)
+    end
+    if opts ~= nil and type(opts) ~= "table" then
+        error("rune.command.add: opts must be a table", 2)
+    end
+
     return registry:add({
         command = name,
         handler = handler,


### PR DESCRIPTION
## Summary

- reject invalid command metadata before it enters the registry
- keep `/help` and the command picker usable after a bad registration
- cover the reported autoreconnect registration

## Validation

- `go test ./...`
- isolated terminal verification with malformed and corrected registrations

Refs #97.