### PR TITLE
Support multi-word exact aliases

### DIFF
--- a/lua/alias_test.go
+++ b/lua/alias_test.go
@@ -5,7 +5,10 @@ package lua
 // semantics (upsert, once) live in registry_test.go; the e2e wiring
 // proof in test/e2e/scenarios/aliases.json.
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestAliasMatching(t *testing.T) {
 	runFeatureCases(t, []featureCase{
@@ -20,6 +23,83 @@ func TestAliasMatching(t *testing.T) {
 			setup: `rune.alias.exact('k', 'kill')`,
 			input: "k orc",
 			want:  []string{"kill orc"},
+		},
+		{
+			name:  "multi-word exact with arguments",
+			setup: `rune.alias.exact('chat off', 'chatlog off')`,
+			input: "chat off temporarily",
+			want:  []string{"chatlog off temporarily"},
+		},
+		{
+			name:  "multi-word exact function receives arguments",
+			setup: `rune.alias.exact('chat off', function(args, ctx) rune.send_raw(args .. '|' .. ctx.args) end)`,
+			input: "chat off temporarily",
+			want:  []string{"temporarily|temporarily"},
+		},
+		{
+			name:  "multi-word exact preserves internal argument whitespace",
+			setup: `rune.alias.exact('chat off', function(args) rune.send_raw('[' .. args .. ']') end)`,
+			input: "chat off   temporarily  later",
+			want:  []string{"[temporarily  later]"},
+		},
+		{
+			name: "longest exact phrase wins",
+			setup: `
+				rune.alias.exact('chat off', 'specific', {priority = 100})
+				rune.alias.exact('chat', 'general', {priority = 1})
+			`,
+			input: "chat off temporarily",
+			want:  []string{"specific temporarily"},
+		},
+		{
+			name:  "multi-word exact requires a word boundary",
+			setup: `rune.alias.exact('chat off', 'matched')`,
+			input: "chat offline",
+			want:  []string{"chat offline"},
+		},
+		{
+			name: "disabled longer phrase falls back to shorter exact alias",
+			setup: `
+				rune.alias.exact('chat', 'general')
+				local specific = rune.alias.exact('chat off', 'specific')
+				specific:disable()
+			`,
+			input: "chat off temporarily",
+			want:  []string{"general off temporarily"},
+		},
+		{
+			name: "removed longer phrase falls back to shorter exact alias",
+			setup: `
+				rune.alias.exact('chat', 'general')
+				local specific = rune.alias.exact('chat off', 'specific')
+				specific:remove()
+			`,
+			input: "chat off temporarily",
+			want:  []string{"general off temporarily"},
+		},
+		{
+			name:  "multi-word exact treats whitespace as a token separator",
+			setup: `rune.alias.exact('chat off', 'matched')`,
+			input: "chat\t  off   temporarily",
+			want:  []string{"matched temporarily"},
+		},
+		{
+			name:  "multi-word exact normalizes registration whitespace",
+			setup: "rune.alias.exact('  chat\\t off  ', 'matched')",
+			input: "chat off",
+			want:  []string{"matched"},
+		},
+		{
+			name: "equivalent exact phrase replaces previous alias",
+			setup: `
+				rune.alias.exact('chat off', 'old')
+				rune.alias.exact('chat  off', 'new')
+				local aliases = rune.alias.list()
+				assert(rune.alias.count() == 1)
+				assert(#aliases == 1 and aliases[1].match == 'chat off')
+			`,
+			input: "chat off",
+			want:  []string{"new"},
 		},
 		{
 			name:  "exact no match - different command",
@@ -88,6 +168,38 @@ func TestAliasMatching(t *testing.T) {
 			want:  []string{"regex-matched"},
 		},
 	})
+}
+
+func TestExactAliasRejectsEmptyPhrase(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	err := engine.DoString("user.lua", `rune.alias.exact(" \t ", "look")`)
+	if err == nil {
+		t.Fatal("empty exact alias phrase was accepted")
+	}
+	if !strings.Contains(err.Error(), "must contain at least one word") {
+		t.Fatalf("registration error = %q, want empty phrase error", err)
+	}
+	if err := engine.DoString("assert.lua", `assert(rune.alias.count() == 0)`); err != nil {
+		t.Fatalf("rejected alias remained registered: %v", err)
+	}
+}
+
+func TestExactAliasRejectsNonStringPhrase(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	err := engine.DoString("user.lua", `rune.alias.exact({}, "look")`)
+	if err == nil {
+		t.Fatal("non-string exact alias phrase was accepted")
+	}
+	if !strings.Contains(err.Error(), "phrase must be a string") {
+		t.Fatalf("registration error = %q, want phrase type error", err)
+	}
+	if err := engine.DoString("assert.lua", `assert(rune.alias.count() == 0)`); err != nil {
+		t.Fatalf("rejected alias remained registered: %v", err)
+	}
 }
 
 func TestAliasHandles(t *testing.T) {

--- a/lua/commands_test.go
+++ b/lua/commands_test.go
@@ -96,6 +96,48 @@ func TestCommandRegistrationRejectsTableDescriptionWithoutBreakingHelp(t *testin
 	}
 }
 
+func TestCommandRegistrationRejectsInvalidName(t *testing.T) {
+	cases := []struct {
+		name   string
+		setup  string
+		assert string
+	}{
+		{
+			name:   "empty",
+			setup:  `rune.command.add("", function() end)`,
+			assert: `assert(rune.command.get("") == nil)`,
+		},
+		{
+			name:   "multiple words",
+			setup:  `rune.command.add("chat off", function() end)`,
+			assert: `assert(rune.command.get("chat off") == nil)`,
+		},
+		{
+			name:   "tab separated",
+			setup:  `rune.command.add("chat\toff", function() end)`,
+			assert: `assert(rune.command.get("chat\toff") == nil)`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			engine, _, cleanup := setupTest(t)
+			defer cleanup()
+
+			err := engine.DoString("user.lua", tc.setup)
+			if err == nil {
+				t.Fatal("invalid command name was accepted")
+			}
+			if !strings.Contains(err.Error(), "name must be a non-empty single word") {
+				t.Fatalf("registration error = %q, want command name error", err)
+			}
+			if err := engine.DoString("assert.lua", tc.assert); err != nil {
+				t.Fatalf("rejected command remained registered: %v", err)
+			}
+		})
+	}
+}
+
 // TestErrorTagIsRed pins the presentation convention (05_style.lua):
 // [Error] tags are red, tag only, message plain - checked on the two
 // highest-traffic paths, the default error handler and unknown

--- a/lua/core/45_aliases.lua
+++ b/lua/core/45_aliases.lua
@@ -3,7 +3,7 @@
 -- Built on rune.registry (15_registry.lua).
 --
 -- API (literal matching):
---   rune.alias.exact(key, action, opts?)      -- Match command word exactly (literal)
+--   rune.alias.exact(phrase, action, opts?)   -- Match a literal command phrase
 --
 -- API (regex matching):
 --   rune.alias.regex(pattern, action, opts?)  -- Go regexp on full input line
@@ -18,7 +18,7 @@
 --
 -- Action can be:
 --   - String: expansion text, %1 %2 etc substituted from captures (regex only)
---   - Function (exact):  function(args, ctx)  -- args = string after command word
+--   - Function (exact):  function(args, ctx)  -- args = text after matched phrase
 --   - Function (regex):  function(matches, ctx) -- matches = array of captures
 --
 -- Context object:
@@ -26,28 +26,81 @@
 --   ctx.name  = alias name (if set)
 --   ctx.group = alias group (if set)
 --   ctx.type  = "alias"
---   ctx.args  = args string (exact only)
+--   ctx.args  = text after matched phrase (exact only)
 --   ctx.matches = captures array (regex only)
 
--- Exact-command index: command word -> data, kept in sync with the
--- registry so exact lookup stays O(1).
+-- Exact-command indexes. The phrase map supports upsert/listing; the word
+-- trie lets dispatch follow only registered prefixes and stop at the first
+-- impossible continuation.
 local exact = {}
+local exact_root = { children = {} }
+
+local function index_exact(data)
+    local node = exact_root
+    local words = {}
+    for word in data.pattern:gmatch("%S+") do
+        words[#words + 1] = word
+        local child = node.children[word]
+        if not child then
+            child = { children = {} }
+            node.children[word] = child
+        end
+        node = child
+    end
+    node.data = data
+    data._exact_words = words
+end
+
+local function unindex_exact(data)
+    local words = data._exact_words
+    if not words then
+        return
+    end
+
+    local node = exact_root
+    local path = { node }
+    for _, word in ipairs(words) do
+        node = node.children[word]
+        if not node then
+            data._exact_words = nil
+            return
+        end
+        path[#path + 1] = node
+    end
+
+    if node.data == data then
+        node.data = nil
+    end
+    for i = #words, 1, -1 do
+        local child = path[i + 1]
+        if child.data == nil and next(child.children) == nil then
+            path[i].children[words[i]] = nil
+        else
+            break
+        end
+    end
+    data._exact_words = nil
+end
 
 local registry = rune.registry.new{
     kind = "alias",
     on_add = function(data)
         if data.is_exact then
-            -- Upsert by command word: replace any previous exact alias
+            -- Upsert by normalized phrase: replace any previous exact alias
             local old = exact[data.pattern]
             if old and old ~= data then
                 old._handle:remove()
             end
             exact[data.pattern] = data
+            index_exact(data)
         end
     end,
     on_remove = function(data)
-        if data.is_exact and exact[data.pattern] == data then
-            exact[data.pattern] = nil
+        if data.is_exact then
+            if exact[data.pattern] == data then
+                exact[data.pattern] = nil
+            end
+            unindex_exact(data)
         end
     end,
 }
@@ -65,9 +118,18 @@ end
 -- Public API
 rune.alias = {}
 
--- Match command word exactly (first word of input, literal)
-function rune.alias.exact(command, action, opts)
-    return create_alias(command, action, opts, true)
+-- Match a literal command phrase. Whitespace separates words rather
+-- than being part of the phrase, matching the input parser's behavior.
+function rune.alias.exact(phrase, action, opts)
+    if type(phrase) ~= "string" then
+        error("rune.alias.exact: phrase must be a string", 2)
+    end
+    local normalized = phrase:gsub("%s+", " ")
+    normalized = normalized:gsub("^ ", ""):gsub(" $", "")
+    if normalized == "" then
+        error("rune.alias.exact: phrase must contain at least one word", 2)
+    end
+    return create_alias(normalized, action, opts, true)
 end
 
 -- Go regexp match on full input line
@@ -188,38 +250,55 @@ function rune.alias.process(input)
         end
     end
 
-    -- Then try exact aliases (command word match)
-    local cmd, args = input:match("^(%S+)%s*(.*)")
-    if cmd then
-        local data = exact[cmd]
-        if data and registry:active(data) then
-            local result = nil
-
-            if type(data.action) == "function" then
-                -- For exact aliases, pass args string (not matches array)
-                local ctx = {
-                    line = input,
-                    name = data.name,
-                    group = data.group,
-                    type = "alias",
-                    args = args,
-                }
-                result = run_action(data, args, ctx)
-            elseif type(data.action) == "string" then
-                -- Exact alias expansion: append args
-                if args and args ~= "" then
-                    result = data.action .. " " .. args
-                else
-                    result = data.action
-                end
+    -- Then walk the exact-alias trie. Retaining the last active candidate
+    -- makes the most specific (longest) phrase win.
+    local data, matched_end = nil, nil
+    local node = exact_root
+    local token_start, token_end = input:find("%S+")
+    if token_start == 1 then
+        while token_start do
+            local token = input:sub(token_start, token_end)
+            node = node.children[token]
+            if not node then
+                break
             end
-
-            if data.once then
-                data._handle:remove()
+            local candidate = node.data
+            if candidate and registry:active(candidate) then
+                data = candidate
+                matched_end = token_end
             end
-
-            return true, result
+            token_start, token_end = input:find("%S+", token_end + 1)
         end
+    end
+    if data then
+        local args_start = input:find("%S", matched_end + 1)
+        local args = args_start and input:sub(args_start) or ""
+        local result = nil
+
+        if type(data.action) == "function" then
+            -- For exact aliases, pass args string (not matches array)
+            local ctx = {
+                line = input,
+                name = data.name,
+                group = data.group,
+                type = "alias",
+                args = args,
+            }
+            result = run_action(data, args, ctx)
+        elseif type(data.action) == "string" then
+            -- Exact alias expansion: append args
+            if args and args ~= "" then
+                result = data.action .. " " .. args
+            else
+                result = data.action
+            end
+        end
+
+        if data.once then
+            data._handle:remove()
+        end
+
+        return true, result
     end
 
     return false, nil

--- a/lua/core/55_commands.lua
+++ b/lua/core/55_commands.lua
@@ -36,6 +36,9 @@ function rune.command.add(name, handler, description, opts)
     if type(name) ~= "string" then
         error("rune.command.add: name must be a string", 2)
     end
+    if name == "" or name:find("%s") then
+        error("rune.command.add: name must be a non-empty single word", 2)
+    end
     if type(handler) ~= "function" then
         error("rune.command.add: handler must be a function", 2)
     end

--- a/test/e2e/scenarios/regressions/95-multi-word-exact-alias.json
+++ b/test/e2e/scenarios/regressions/95-multi-word-exact-alias.json
@@ -1,0 +1,18 @@
+{
+  "description": "Regression: multi-word exact aliases were registered and listed but could never match because exact dispatch only looked up the first input word.",
+  "scenarios": [
+    {
+      "name": "multi-word exact alias executes",
+      "issue": "https://github.com/mmcdole/rune/issues/95",
+      "init_lua": [
+        "rune.alias.exact('chat off', function(args)",
+        "  rune.echo('E2E-CHAT-OFF=' .. args)",
+        "end)"
+      ],
+      "steps": [
+        { "type": "chat off" },
+        { "expect_printed": "E2E-CHAT-OFF=" }
+      ]
+    }
+  ]
+}

--- a/website/src/content/docs/reference/api/alias.md
+++ b/website/src/content/docs/reference/api/alias.md
@@ -1,6 +1,6 @@
 ---
 title: rune.alias
-description: Full signatures for expanding and transforming your input — exact word and regex matching.
+description: Full signatures for expanding and transforming your input — literal phrase and regex matching.
 ---
 
 Aliases match your input and transform or expand it before it reaches
@@ -10,7 +10,7 @@ the server. For a task-oriented introduction, see
 ## Quick reference
 
 ```lua
-rune.alias.exact(command, action, opts?)  -- first word matches literally
+rune.alias.exact(phrase, action, opts?)   -- leading command phrase matches literally
 rune.alias.regex(pattern, action, opts?)  -- Go regexp on the full input line
 ```
 
@@ -19,31 +19,34 @@ the [common options](/reference/api/#options).
 
 ## Matching
 
-Regex aliases are checked first, in `priority` order; if none match,
-the first word of the input is looked up among exact aliases. Only one
-alias fires per command. A string result — whether from a string action
-or returned by a function — is fed back through
+Regex aliases are checked first, in `priority` order. If none match, an
+exact alias can match one or more complete words at the beginning of what
+you type. When more than one matches, the longest active phrase wins, so
+`"chat off"` takes precedence over `"chat"`. Only one alias fires per
+command. A string result — whether from a string action or returned by a
+function — is fed back through
 [`rune.send`](/reference/api/core/), so aliases can expand to other
 aliases; a depth limit catches loops.
 
 ### rune.alias.exact
 
 ```lua
-rune.alias.exact(command, action, opts?) -> handle
+rune.alias.exact(phrase, action, opts?) -> handle
 ```
 
-- `command` (string) — matched literally against the first word of the
-  input. Registering the same word again replaces the previous exact
-  alias.
+- `phrase` (string) — one or more words matched literally at the start of
+  the input. Whitespace separates words and is normalized, so `chat off`
+  also matches `chat   off`. Registering the same normalized phrase again
+  replaces the previous exact alias.
 - `action` (string | function) — an expansion string (trailing
   arguments are appended: with `rune.alias.exact("g", "get")`, typing
   `g sword` sends `get sword`), or `function(args, ctx)` where `args`
-  is everything after the command word.
+  is everything after the matched phrase.
 - `opts` (table, optional) — [common options](/reference/api/#options).
 
 ```lua
-rune.alias.exact("heal", function(args, ctx)
-    rune.send("cast heal " .. (args ~= "" and args or "self"))
+rune.alias.exact("chat off", function(args, ctx)
+    rune.echo("chatlog: off" .. (args ~= "" and " (" .. args .. ")" or ""))
 end)
 ```
 

--- a/website/src/content/docs/reference/api/command.md
+++ b/website/src/content/docs/reference/api/command.md
@@ -27,8 +27,8 @@ name is the command name itself).
 rune.command.add(name, handler, description?, opts?) -> handle
 ```
 
-- `name` (string) — the command name, without the slash. Re-adding the
-  same name replaces the old handler (upsert).
+- `name` (string) — a non-empty, single-word command name without the
+  slash. Re-adding the same name replaces the old handler (upsert).
 - `handler` (function) — `function(args)`; `args` is everything after
   `/name ` as a single string (`""` when there are no arguments).
 - `description` (string, optional) — shown in `/help` and the `/`

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -61,7 +61,7 @@ Common `opts` fields accepted by every creation function:
 |---|---|---|---|
 | `name` | string | none | All — unique ID; same name replaces (upsert) |
 | `group` | string | none | All — membership for batch operations |
-| `priority` | number | 50 | Aliases, triggers, hooks — lower runs first |
+| `priority` | number | 50 | Regex aliases, triggers, hooks — lower runs first |
 | `once` | bool | false | Aliases, triggers — remove after first match |
 
 Page-specific extras (e.g. trigger `gag`/`raw`) are listed on each page.

--- a/website/src/content/docs/scripting/aliases.md
+++ b/website/src/content/docs/scripting/aliases.md
@@ -1,10 +1,10 @@
 ---
 title: Aliases
-description: Expand what you type before it reaches the server, with exact words or regex patterns and string or function actions.
+description: Expand what you type before it reaches the server, with literal phrases or regex patterns and string or function actions.
 ---
 
 An alias rewrites what you type before it goes to the server. Two decisions
-define one: how it matches (an exact command word, or a regex over the
+define one: how it matches (a literal command phrase, or a regex over the
 whole line) and what it does (a string to send, or a Lua function to run).
 
 The simplest form is a word that expands, with anything you typed after it
@@ -28,16 +28,26 @@ end)
 
 Both forms register the same way and are managed the same way.
 
+Literal aliases can contain more than one word. The matched phrase is the
+command head and anything after it remains available as arguments:
+
+```lua
+rune.alias.exact("chat off", "chatlog off")
+-- "chat off now" -> chatlog off now
+```
+
 ## Creating
 
 ```lua
-rune.alias.exact(word, action, opts?)     -- matches the first word you type
+rune.alias.exact(phrase, action, opts?)   -- matches leading words literally
 rune.alias.regex(pattern, action, opts?)  -- Go regexp against the whole line
 ```
 
-Exact aliases are an O(1) lookup on the command word; use them for most
-cases. Regex aliases see the entire input line and can capture pieces of
-it. They run in `priority` order before exact aliases are tried.
+Exact aliases match literal words at the start of what you type. If phrases
+overlap, the longest active phrase wins. Whitespace separates phrase words,
+so `chat off` also matches `chat   off`. Regex aliases see the entire input
+line and can capture pieces of it. They run in `priority` order before exact
+aliases are tried.
 
 Regex patterns are validated at registration: a bad pattern raises
 immediately instead of failing silently at match time.
@@ -46,7 +56,7 @@ immediately instead of failing silently at match time.
 
 **A string** is a plain expansion.
 
-- For `exact` aliases, whatever you typed after the word is appended:
+- For `exact` aliases, whatever you typed after the matched phrase is appended:
   `rune.alias.exact("k", "kill")` turns `k rat` into `kill rat`.
 - For `regex` aliases, `%1`, `%2`, and so on are substituted from the
   pattern's captures. This is how you reorder or reuse arguments:
@@ -64,7 +74,7 @@ entirely.
 The function's first argument depends on the match type:
 
 ```lua
--- exact: (args, ctx). args is the text after the command word.
+-- exact: (args, ctx). args is the text after the matched phrase.
 rune.alias.exact("heal", function(args, ctx)
     if args == "" then
         rune.echo(rune.style.yellow("heal who?"))

--- a/website/src/content/docs/scripting/commands.md
+++ b/website/src/content/docs/scripting/commands.md
@@ -19,9 +19,11 @@ listings never drift from what is actually registered.
 rune.command.add(name, handler, description?, opts?)
 ```
 
-The handler is a function; it receives everything after `/name ` as a
-single string (`""` when there are no arguments). The command name doubles
-as its registry name.
+The command name is one non-empty word without the slash. The handler
+receives everything after `/name ` as a single string (`""` when there
+are no arguments), so multi-word forms such as `/pather go town` are
+expressed as a command plus arguments. The command name doubles as its
+registry name.
 
 ## Options
 

--- a/website/src/content/docs/scripting/model.md
+++ b/website/src/content/docs/scripting/model.md
@@ -40,7 +40,7 @@ core fields:
 |---|---|---|---|
 | `name` | string | none | Unique ID for management. Registering the same name again **replaces** the old entry (upsert) — reloading a script never stacks duplicates. |
 | `group` | string | none | Group membership for batch enable/disable/remove. |
-| `priority` | number | 50 | Execution order where multiple items can match (aliases, triggers, hooks). Lower runs first. |
+| `priority` | number | 50 | Execution order where multiple items can match (regex aliases, triggers, hooks). Lower runs first. |
 | `once` | bool | false | Auto-remove after the first match (aliases, triggers). |
 
 Individual registries add their own options — triggers take `gag` and
@@ -85,7 +85,7 @@ Function actions receive a context table as their last argument:
 | `ctx.group` | The item's group, if set |
 | `ctx.type` | `"alias"`, `"trigger"`, `"timer"`, or `"hook"` |
 | `ctx.line` | The original line (a [line object](/reference/api/state-lines/) for triggers) |
-| `ctx.args` | Argument string (exact aliases) |
+| `ctx.args` | Text after the matched phrase (exact aliases) |
 | `ctx.matches` | Capture array (regex matches) |
 | `ctx:remove()` | Remove this item from inside its own callback |
 


### PR DESCRIPTION
`rune.alias.exact("chat off", ...)` currently registers and appears in `/aliases`, but it cannot fire because exact dispatch only checks the first input word.

This extends exact aliases to one or more literal words. The longest enabled phrase wins, whitespace separates words, and remaining text is still passed to function actions or appended to string actions as `args`. Regex aliases keep their existing precedence.

`rune.command.add` continues to use one-word names and now rejects empty or multi-word registrations instead of leaving unreachable entries behind. The alias and command documentation has been updated along with Lua-level and end-to-end regression coverage.

Tested with:

- `go test -race -shuffle=on ./...`
- `go test -tags luajit -race -shuffle=on ./...`
- `go vet ./...`
- `go vet -tags luajit ./...`
- `npm run build` in `website/`

Closes #95