### PR TITLE
lua: expose registry entries through get and action

### DIFF
--- a/lua/alias_test.go
+++ b/lua/alias_test.go
@@ -217,20 +217,20 @@ func TestAliasHandles(t *testing.T) {
 			want:  []string{"north"},
 		},
 		{
-			name: "exact disable by name",
+			name: "exact disable by phrase",
 			setup: `
-				rune.alias.exact('n', 'north', {name = 'go_north'})
-				rune.alias.disable('go_north')
+				rune.alias.exact('n', 'north')
+				rune.alias.disable('n')
 			`,
 			input: "n",
 			want:  []string{"n"},
 		},
 		{
-			name: "exact enable by name",
+			name: "exact enable by phrase",
 			setup: `
-				rune.alias.exact('n', 'north', {name = 'go_north'})
-				rune.alias.disable('go_north')
-				rune.alias.enable('go_north')
+				rune.alias.exact('n', 'north')
+				rune.alias.disable('n')
+				rune.alias.enable('n')
 			`,
 			input: "n",
 			want:  []string{"north"},

--- a/lua/api_docs_coverage_test.go
+++ b/lua/api_docs_coverage_test.go
@@ -20,6 +20,7 @@ var undocumentedInternal = map[string]bool{
 	"rune.caller_source":       true,
 	"rune.substitute_captures": true,
 	"rune.registry.new":        true,
+	"rune.registry.keyed_opts": true,
 	"rune.command.dispatch":    true,
 	"rune.alias.process":       true,
 	"rune.hooks.call":          true,
@@ -33,6 +34,7 @@ var undocumentedPrefixes = []string{
 // registry contract on reference/api/index.md (#managing), rather than
 // enumerated on every namespace page.
 var sharedContractSuffixes = map[string]bool{
+	"get":          true,
 	"enable":       true,
 	"disable":      true,
 	"remove":       true,

--- a/lua/commands_test.go
+++ b/lua/commands_test.go
@@ -15,11 +15,11 @@ func TestListingCommandsShowRegistrations(t *testing.T) {
 	defer cleanup()
 
 	if err := engine.DoString("setup", `
-		rune.alias.exact("zap", "cast zap", { name = "my-alias" })
+		rune.alias.exact("zap", "cast zap")
 		rune.trigger.contains("dragon", "flee", { name = "my-trigger" })
 		rune.timer.every(60, function() end, { name = "my-timer" })
 		rune.hooks.on("output", function() end, { name = "my-hook" })
-		rune.bind("f12", function() end, { name = "my-bind" })
+		rune.bind("f12", function() end)
 		rune.ui.bar("my-bar", function() return "bar" end)
 		rune.group.disable("my-group")
 	`); err != nil {

--- a/lua/core/15_registry.lua
+++ b/lua/core/15_registry.lua
@@ -8,6 +8,7 @@
 -- Usage:
 --   local reg = rune.registry.new{
 --       kind = "trigger",               -- label for messages
+--       action_field = "action",        -- data field holding the callback
 --       on_add = function(data) end,    -- optional, after insertion
 --       on_remove = function(data) end, -- optional, after removal
 --   }
@@ -23,7 +24,15 @@
 --   once     -- opts.once, module removes the item after first fire
 --   _handle  -- back-reference to the handle
 --
--- Handle API: :enable() :disable() :remove() :name() :group()
+-- Name is the ONLY identity. Registries whose entries have a natural
+-- key (a bind's key, a bar's layout name, a command's name, an exact
+-- alias's phrase) pass that key as the name via rune.registry.keyed_opts,
+-- so `reg:get(key)` and the management suite address the same thing the
+-- user typed. Those registries must not also upsert by their own index:
+-- the name upsert below already replaces the old entry, firing on_remove
+-- for it before on_add for the new one.
+--
+-- Handle API: :enable() :disable() :remove() :name() :group() :action()
 
 rune.registry = {}
 
@@ -53,13 +62,42 @@ function Handle:group()
     return self._data.group
 end
 
+-- The registered action: a function, or the command string for the
+-- string-action forms. Calling it directly bypasses the enabled/group
+-- checks and the failure quarantine, so this is for capturing and
+-- wrapping an existing entry, not for dispatch.
+function Handle:action()
+    return self._data[self._registry.action_field]
+end
+
 local Registry = {}
 Registry.__index = Registry
+
+-- Build the opts table for a registry whose entries have a natural key,
+-- making that key the name. An explicit name is refused rather than
+-- silently ignored: two identities for one entry is the bug this avoids.
+function rune.registry.keyed_opts(key, opts, label)
+    if opts ~= nil and type(opts) ~= "table" then
+        error(label .. ": opts must be a table", 3)
+    end
+    if opts and opts.name ~= nil then
+        error(label .. ": name is not accepted here, the key is the name", 3)
+    end
+    local merged = {}
+    if opts then
+        for k, v in pairs(opts) do
+            merged[k] = v
+        end
+    end
+    merged.name = key
+    return merged
+end
 
 function rune.registry.new(opts)
     opts = opts or {}
     return setmetatable({
         kind = opts.kind or "item",
+        action_field = opts.action_field or "action",
         on_add = opts.on_add,
         on_remove = opts.on_remove,
         list = {},     -- all items, sorted by (priority, id)

--- a/lua/core/15_registry.lua
+++ b/lua/core/15_registry.lua
@@ -74,20 +74,28 @@ local Registry = {}
 Registry.__index = Registry
 
 -- Build the opts table for a registry whose entries have a natural key,
--- making that key the name. An explicit name is refused rather than
--- silently ignored: two identities for one entry is the bug this avoids.
+-- making that key the name.
+--
+-- A name used to be a second identity for the same entry, which is the
+-- bug this avoids. It is now dropped with a notice rather than raised:
+-- raising aborts the rest of the user's script, so one stale option in
+-- an old init.lua would cost every registration below it. The notice
+-- names the key to use instead.
 function rune.registry.keyed_opts(key, opts, label)
     if opts ~= nil and type(opts) ~= "table" then
         error(label .. ": opts must be a table", 3)
-    end
-    if opts and opts.name ~= nil then
-        error(label .. ": name is not accepted here, the key is the name", 3)
     end
     local merged = {}
     if opts then
         for k, v in pairs(opts) do
             merged[k] = v
         end
+    end
+    if merged.name ~= nil and merged.name ~= key then
+        local source = rune.caller_source(2)
+        rune.echo(rune.style.yellow("[Deprecated]") .. " " .. label ..
+            ": name '" .. tostring(merged.name) .. "' ignored, manage it as '" ..
+            key .. "'" .. (source and (" @" .. source) or ""))
     end
     merged.name = key
     return merged

--- a/lua/core/20_hooks.lua
+++ b/lua/core/20_hooks.lua
@@ -51,6 +51,7 @@ end
 
 local registry = rune.registry.new{
     kind = "hook",
+    action_field = "handler",
     on_add = function(data)
         local handlers = by_event[data.event]
         if not handlers then
@@ -88,6 +89,10 @@ function rune.hooks.on(event, handler, opts)
 end
 
 -- Management by name
+function rune.hooks.get(name)
+    return registry:get(name)
+end
+
 function rune.hooks.disable(name)
     return registry:disable(name)
 end

--- a/lua/core/30_binds.lua
+++ b/lua/core/30_binds.lua
@@ -6,24 +6,25 @@
 -- API:
 --   rune.bind(key, callback, opts?)  -- Bind a key ("ctrl+r", "f1", "j")
 --   rune.unbind(key)                 -- Remove a binding
+--   rune.binds.get(key)              -- The binding's handle, or nil
 --   rune.binds.list()                -- For /binds
 --
--- Options: name, group (see 15_registry.lua). A disabled bind (or one
--- in a disabled group) swallows its key without running the callback.
+-- The key is the registry name, so rune.binds.disable("ctrl+g") and
+-- rune.binds.get("ctrl+g") address a bind by the same string you bound.
+-- Options: group (see 15_registry.lua). A disabled bind (or one in a
+-- disabled group) swallows its key without running the callback.
 --
 -- Go's role is transport only: the UI forwards keys present in
 -- rune.binds._keys(), and rune.binds._dispatch(key) runs the callback.
 
-local by_key = {} -- key -> data
+local by_key = {} -- key -> data, the dispatch index
 
 local registry = rune.registry.new{
     kind = "bind",
+    action_field = "callback",
     on_add = function(data)
-        -- Upsert by key: rebinding a key replaces the old binding
-        local old = by_key[data.key]
-        if old and old ~= data then
-            old._handle:remove()
-        end
+        -- Rebinding a key replaces the old binding through the registry's
+        -- name upsert, which has already removed it by the time we get here.
         by_key[data.key] = data
         rune._ui.config_changed()
     end,
@@ -39,21 +40,22 @@ rune.binds = {}
 
 -- Bind a key to a callback. Returns a handle.
 function rune.bind(key, callback, opts)
+    if type(key) ~= "string" or key == "" then
+        error("rune.bind: key must be a non-empty string", 2)
+    end
+    if type(callback) ~= "function" then
+        error("rune.bind: callback must be a function", 2)
+    end
     return registry:add({
         key = key,
         callback = callback,
         source = rune.caller_source(1),
-    }, opts)
+    }, rune.registry.keyed_opts(key, opts, "rune.bind"))
 end
 
 -- Remove a binding by key. Returns true if one existed.
 function rune.unbind(key)
-    local data = by_key[key]
-    if data then
-        data._handle:remove()
-        return true
-    end
-    return false
+    return registry:remove(key)
 end
 
 -- INTERNAL: called by Go when a bound key is pressed.
@@ -80,7 +82,11 @@ function rune.binds._keys()
     return keys
 end
 
--- Management by name
+-- Management by key (the key is the name)
+function rune.binds.get(name)
+    return registry:get(name)
+end
+
 function rune.binds.disable(name)
     return registry:disable(name)
 end

--- a/lua/core/35_bars.lua
+++ b/lua/core/35_bars.lua
@@ -5,24 +5,24 @@
 --
 -- API:
 --   rune.ui.bar(name, render_fn, opts?) -- Register a bar renderer
+--   rune.bars.get(name)                 -- The bar's handle, or nil
 --   rune.bars.list()                    -- For /bars
 --
 -- render_fn receives the terminal width and returns a string or a
 -- table {left, center, right}. Go calls rune.bars._render_all on its
--- tick and pushes the results to the UI; re-registering a name gives
--- the renderer a fresh start.
+-- tick and pushes the results to the UI. The bar's layout name is its
+-- registry name, so re-registering it replaces the old renderer (and
+-- resets its failure streak, since the entry is fresh) and
+-- rune.bars.disable("status") addresses the bar you see.
 
-local by_bar = {} -- bar name -> data
+local by_bar = {} -- bar name -> data, the render index
 
 local registry = rune.registry.new{
     kind = "bar",
+    action_field = "renderer",
     on_add = function(data)
-        -- Upsert by bar name: re-registering replaces (and resets
-        -- any failure streak, since the entry is fresh)
-        local old = by_bar[data.bar]
-        if old and old ~= data then
-            old._handle:remove()
-        end
+        -- Any previous bar of this name was removed by the registry's
+        -- name upsert before this runs.
         by_bar[data.bar] = data
     end,
     on_remove = function(data)
@@ -37,11 +37,17 @@ rune.bars = {}
 -- rune.ui.bar lives on the rune.ui table (created by the UI layer
 -- registration); defined here because this module owns the registry.
 function rune.ui.bar(name, render_fn, opts)
+    if type(name) ~= "string" or name == "" then
+        error("rune.ui.bar: name must be a non-empty string", 2)
+    end
+    if type(render_fn) ~= "function" then
+        error("rune.ui.bar: render_fn must be a function", 2)
+    end
     return registry:add({
         bar = name,
         renderer = render_fn,
         source = rune.caller_source(1),
-    }, opts)
+    }, rune.registry.keyed_opts(name, opts, "rune.ui.bar"))
 end
 
 -- INTERNAL: called by Go on the render tick.
@@ -63,7 +69,11 @@ function rune.bars._render_all(width)
     return out
 end
 
--- Management by name (registry name, not bar name)
+-- Management by bar name (the bar name is the registry name)
+function rune.bars.get(name)
+    return registry:get(name)
+end
+
 function rune.bars.disable(name)
     return registry:disable(name)
 end

--- a/lua/core/40_timers.lua
+++ b/lua/core/40_timers.lua
@@ -120,6 +120,10 @@ function rune.timer.every(seconds, action, opts)
 end
 
 -- Management by name
+function rune.timer.get(name)
+    return registry:get(name)
+end
+
 function rune.timer.disable(name)
     return registry:disable(name)
 end

--- a/lua/core/45_aliases.lua
+++ b/lua/core/45_aliases.lua
@@ -84,13 +84,11 @@ end
 
 local registry = rune.registry.new{
     kind = "alias",
+    action_field = "action",
     on_add = function(data)
         if data.is_exact then
-            -- Upsert by normalized phrase: replace any previous exact alias
-            local old = exact[data.pattern]
-            if old and old ~= data then
-                old._handle:remove()
-            end
+            -- An exact alias is named for its normalized phrase, so any
+            -- previous alias on that phrase is already gone by now.
             exact[data.pattern] = data
             index_exact(data)
         end
@@ -120,6 +118,8 @@ rune.alias = {}
 
 -- Match a literal command phrase. Whitespace separates words rather
 -- than being part of the phrase, matching the input parser's behavior.
+-- The normalized phrase is the alias's name, so rune.alias.get("gc")
+-- and rune.alias.disable("gc") address it by what you typed to make it.
 function rune.alias.exact(phrase, action, opts)
     if type(phrase) ~= "string" then
         error("rune.alias.exact: phrase must be a string", 2)
@@ -129,7 +129,8 @@ function rune.alias.exact(phrase, action, opts)
     if normalized == "" then
         error("rune.alias.exact: phrase must contain at least one word", 2)
     end
-    return create_alias(normalized, action, opts, true)
+    return create_alias(normalized, action,
+        rune.registry.keyed_opts(normalized, opts, "rune.alias.exact"), true)
 end
 
 -- Go regexp match on full input line
@@ -143,7 +144,11 @@ function rune.alias.regex(pattern, action, opts)
     return create_alias(pattern, action, opts, false)
 end
 
--- Management by name
+-- Management by name (an exact alias is named for its phrase)
+function rune.alias.get(name)
+    return registry:get(name)
+end
+
 function rune.alias.disable(name)
     return registry:disable(name)
 end

--- a/lua/core/50_triggers.lua
+++ b/lua/core/50_triggers.lua
@@ -131,6 +131,10 @@ function rune.trigger.regex(pattern, action, opts)
 end
 
 -- Management by name
+function rune.trigger.get(name)
+    return registry:get(name)
+end
+
 function rune.trigger.disable(name)
     return registry:disable(name)
 end

--- a/lua/core/55_commands.lua
+++ b/lua/core/55_commands.lua
@@ -9,16 +9,14 @@ local green, red, yellow, cyan, dim =
     rune.style.green, rune.style.red, rune.style.yellow,
     rune.style.cyan, rune.style.gray
 
-local by_cmd = {} -- command name -> data
+local by_cmd = {} -- command name -> data, the dispatch index
 
 local registry = rune.registry.new{
     kind = "command",
+    action_field = "handler",
     on_add = function(data)
-        -- Upsert by command name: re-adding replaces the old handler
-        local old = by_cmd[data.command]
-        if old and old ~= data then
-            old._handle:remove()
-        end
+        -- The command name is the registry name, so re-adding one has
+        -- already removed the old entry through the name upsert.
         by_cmd[data.command] = data
     end,
     on_remove = function(data)
@@ -45,16 +43,12 @@ function rune.command.add(name, handler, description, opts)
     if description ~= nil and type(description) ~= "string" then
         error("rune.command.add: description must be a string", 2)
     end
-    if opts ~= nil and type(opts) ~= "table" then
-        error("rune.command.add: opts must be a table", 2)
-    end
-
     return registry:add({
         command = name,
         handler = handler,
         description = description or "",
         source = rune.caller_source(1),
-    }, { name = name, group = opts and opts.group })
+    }, rune.registry.keyed_opts(name, opts, "rune.command.add"))
 end
 
 -- Remove a slash command by name. Returns true if one existed.
@@ -62,10 +56,10 @@ function rune.command.remove(name)
     return registry:remove(name)
 end
 
--- Get a slash command handler (unwrapped, no quarantine)
+-- The command's handle, or nil. Its :action() is the raw handler,
+-- which is how you wrap a built-in command.
 function rune.command.get(name)
-    local data = by_cmd[name]
-    return data and data.handler or nil
+    return registry:get(name)
 end
 
 -- INTERNAL: run a command protected (called by the core input hook).
@@ -246,7 +240,9 @@ rune.command.add("aliases", function(args)
         local group_str = a.group and ("  " .. cyan("<" .. a.group .. ">")) or ""
         local flags = {}
         if a.once then flags[#flags + 1] = "once" end
-        local name_str = a.name and (" " .. dim("name:") .. a.name) or ""
+        -- An exact alias is named for its phrase, already in the match column.
+        local name_str = (a.name and a.name ~= a.match)
+            and (" " .. dim("name:") .. a.name) or ""
         local flags_str = #flags > 0 and ("  " .. dim("(" .. table.concat(flags, ", ") .. ")")) or ""
         local src_str = a.source and ("  " .. dim("@" .. a.source)) or ""
         rune.echo(string.format("  %s %-8s %s %s %s %s%s%s%s",
@@ -342,13 +338,13 @@ rune.command.add("binds", function(args)
         rune.echo("  " .. dim("(none)"))
         return
     end
+    -- The key is the name, so there is no separate name column to print.
     for _, b in ipairs(binds) do
         local status = b.enabled and green("[on] ") or red("[off]")
         local group_str = b.group and ("  " .. cyan("<" .. b.group .. ">")) or ""
-        local name_str = b.name and ("  " .. dim("name:") .. b.name) or ""
         local src_str = b.source and ("  " .. dim("@" .. b.source)) or ""
-        rune.echo(string.format("  %s %-16s%s%s%s",
-            status, yellow(b.key), group_str, name_str, src_str))
+        rune.echo(string.format("  %s %-16s%s%s",
+            status, yellow(b.key), group_str, src_str))
     end
 end, "List all key bindings")
 

--- a/lua/core/70_gmcp.lua
+++ b/lua/core/70_gmcp.lua
@@ -41,6 +41,7 @@ end
 
 local registry = rune.registry.new{
     kind = "gmcp",
+    action_field = "handler",
     on_add = function(data)
         local handlers = by_package[data.package]
         if not handlers then
@@ -80,6 +81,10 @@ end
 
 function rune.gmcp.remove(name)
     return registry:remove(name)
+end
+
+function rune.gmcp.get(name)
+    return registry:get(name)
 end
 
 function rune.gmcp.enable(name)

--- a/lua/engine_test.go
+++ b/lua/engine_test.go
@@ -488,7 +488,7 @@ func TestRegistrationsRecordSource(t *testing.T) {
 	script := `
 		rune.hooks.on("output", function() end, {name = "h"})
 		rune.trigger.contains("x", "look", {name = "t"})
-		rune.alias.exact("n", "north", {name = "a"})
+		rune.alias.exact("n", "north")
 		rune.timer.after(60, function() end, {name = "tm"})
 
 		local function source_of(list, name)
@@ -502,7 +502,7 @@ func TestRegistrationsRecordSource(t *testing.T) {
 		for _, entry in ipairs({
 			{"hook", rune.hooks.list(), "h"},
 			{"trigger", rune.trigger.list(), "t"},
-			{"alias", rune.alias.list(), "a"},
+			{"alias", rune.alias.list(), "n"},
 			{"timer", rune.timer.list(), "tm"},
 		}) do
 			local src = source_of(entry[2], entry[3])

--- a/lua/registry_identity_test.go
+++ b/lua/registry_identity_test.go
@@ -87,32 +87,103 @@ func TestCoreRegistrationsAreAddressable(t *testing.T) {
 	`)
 }
 
-// One entry, one identity: an explicit name would be a second one.
-func TestKeyedRegistriesRejectAnExplicitName(t *testing.T) {
-	engine, _, cleanup := setupTest(t)
-	defer cleanup()
-
+// One entry, one identity: a legacy name is dropped with a notice. It
+// must not raise, because raising would abort the rest of the script
+// that carried it, costing every registration below the stale line.
+func TestKeyedRegistriesDeprecateAnExplicitName(t *testing.T) {
 	cases := []struct {
-		name string
-		code string
+		name    string
+		code    string
+		key     string
+		present string // a management call proving the entry registered
 	}{
-		{"bind", `rune.bind("f1", function() end, { name = "other" })`},
-		{"bar", `rune.ui.bar("clock", function() return "" end, { name = "other" })`},
-		{"exact alias", `rune.alias.exact("gc", "get corpse", { name = "other" })`},
-		{"command", `rune.command.add("greet", function() end, "d", { name = "other" })`},
+		{
+			name:    "bind",
+			code:    `rune.bind("f1", function() end, { name = "other" })`,
+			key:     "f1",
+			present: `assert(rune.binds.get("f1"), "the bind must still register")`,
+		},
+		{
+			name:    "bar",
+			code:    `rune.ui.bar("clock", function() return "" end, { name = "other" })`,
+			key:     "clock",
+			present: `assert(rune.bars.get("clock"), "the bar must still register")`,
+		},
+		{
+			name:    "exact alias",
+			code:    `rune.alias.exact("gc", "get corpse", { name = "other" })`,
+			key:     "gc",
+			present: `assert(rune.alias.get("gc"), "the alias must still register")`,
+		},
+		{
+			name:    "command",
+			code:    `rune.command.add("greet", function() end, "d", { name = "other" })`,
+			key:     "greet",
+			present: `assert(rune.command.get("greet"), "the command must still register")`,
+		},
 	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			err := engine.DoString("reject", c.code)
-			if err == nil {
-				t.Fatal("expected an explicit name to be refused")
+			engine, host, cleanup := setupTest(t)
+			defer cleanup()
+			host.DrainPrintCalls()
+
+			if err := engine.DoString("legacy", c.code); err != nil {
+				t.Fatalf("a legacy name must not raise: %v", err)
 			}
-			if !strings.Contains(err.Error(), "the key is the name") {
-				t.Fatalf("error should explain the rule, got: %v", err)
+
+			printed := strings.Join(host.DrainPrintCalls(), "\n")
+			if !strings.Contains(printed, "[Deprecated]") {
+				t.Fatalf("expected a deprecation notice, got: %q", printed)
 			}
+			if !strings.Contains(printed, c.key) {
+				t.Fatalf("the notice must name the key to use, got: %q", printed)
+			}
+
+			assertLua(t, engine, c.present)
 		})
 	}
+}
+
+// A script that never used the option must stay quiet, and a name that
+// simply repeats the key is not a migration problem either.
+func TestNoNoticeWithoutALegacyName(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+	host.DrainPrintCalls()
+
+	if err := engine.DoString("quiet", `
+		rune.bind("f3", function() end)
+		rune.bind("f4", function() end, { group = "combat" })
+		rune.bind("f6", function() end, { name = "f6" })
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if printed := strings.Join(host.DrainPrintCalls(), "\n"); printed != "" {
+		t.Fatalf("expected no notice, got: %q", printed)
+	}
+}
+
+// The whole point of not raising: everything after the stale line loads.
+func TestALegacyNameDoesNotAbortTheScript(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	if err := engine.DoString("init.lua", `
+		rune.alias.exact("before", "loaded first")
+		rune.bind("f5", function() end, { name = "legacy-name" })
+		rune.alias.exact("after", "loaded after the stale option")
+	`); err != nil {
+		t.Fatalf("the script must survive a legacy name: %v", err)
+	}
+
+	assertLua(t, engine, `
+		assert(rune.alias.get("before"), "registrations before the stale line must survive")
+		assert(rune.alias.get("after"), "registrations after the stale line must survive")
+		assert(rune.binds.get("f5"), "the bind itself must register under its key")
+	`)
 }
 
 // Re-registering a natural key replaces rather than accumulates, and the

--- a/lua/registry_identity_test.go
+++ b/lua/registry_identity_test.go
@@ -1,0 +1,229 @@
+package lua
+
+// Tests for the single-identity rule (15_registry.lua): a registry entry
+// with a natural key (a bind's key, a bar's layout name, a command's name,
+// an exact alias's phrase) is registered under that key as its name, so
+// the whole management suite addresses it by the string the user typed.
+// Anything that registers under two identities is the bug these cover.
+
+import (
+	"strings"
+	"testing"
+)
+
+// Registrations made without opts still answer to the management suite,
+// which is what the two-identity split used to prevent.
+func TestNaturalKeyIsTheName(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	cases := []struct {
+		name  string
+		setup string
+		check string
+	}{
+		{
+			name:  "bind",
+			setup: `rune.bind("ctrl+g", function() end)`,
+			check: `
+				assert(rune.binds.get("ctrl+g"), "bind not addressable by key")
+				assert(rune.binds.get("ctrl+g"):name() == "ctrl+g", "key must be the name")
+				assert(rune.binds.disable("ctrl+g"), "disable by key must report success")
+			`,
+		},
+		{
+			name:  "bar",
+			setup: `rune.ui.bar("vitals", function() return "" end)`,
+			check: `
+				assert(rune.bars.get("vitals"), "bar not addressable by layout name")
+				assert(rune.bars.disable("vitals"), "disable by bar name must report success")
+			`,
+		},
+		{
+			name:  "exact alias",
+			setup: `rune.alias.exact("gc", "get all from corpse")`,
+			check: `
+				assert(rune.alias.get("gc"), "exact alias not addressable by phrase")
+				assert(rune.alias.disable("gc"), "disable by phrase must report success")
+			`,
+		},
+		{
+			name:  "multi-word exact alias uses its normalized phrase",
+			setup: `rune.alias.exact("chat   off", "chatlog off")`,
+			check: `assert(rune.alias.get("chat off"), "phrase must be normalized before naming")`,
+		},
+		{
+			name:  "command",
+			setup: `rune.command.add("greet", function() end, "Greet")`,
+			check: `
+				assert(rune.command.get("greet"), "command not addressable by name")
+				assert(rune.command.disable("greet"), "disable by command name must report success")
+			`,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := engine.DoString("setup", c.setup); err != nil {
+				t.Fatal(err)
+			}
+			assertLua(t, engine, c.check)
+		})
+	}
+}
+
+// The core's own registrations are made without opts, so they are the
+// real regression target: before the single-identity rule they were
+// unreachable by name.
+func TestCoreRegistrationsAreAddressable(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	assertLua(t, engine, `
+		assert(rune.bars.get("status"), "the core status bar must be addressable")
+		assert(rune.bars.disable("status"), "the core status bar must be manageable")
+		assert(rune.binds.get("pageup"), "a default keymap bind must be addressable")
+		assert(rune.command.get("quit"), "a built-in command must be addressable")
+	`)
+}
+
+// One entry, one identity: an explicit name would be a second one.
+func TestKeyedRegistriesRejectAnExplicitName(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	cases := []struct {
+		name string
+		code string
+	}{
+		{"bind", `rune.bind("f1", function() end, { name = "other" })`},
+		{"bar", `rune.ui.bar("clock", function() return "" end, { name = "other" })`},
+		{"exact alias", `rune.alias.exact("gc", "get corpse", { name = "other" })`},
+		{"command", `rune.command.add("greet", function() end, "d", { name = "other" })`},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := engine.DoString("reject", c.code)
+			if err == nil {
+				t.Fatal("expected an explicit name to be refused")
+			}
+			if !strings.Contains(err.Error(), "the key is the name") {
+				t.Fatalf("error should explain the rule, got: %v", err)
+			}
+		})
+	}
+}
+
+// Re-registering a natural key replaces rather than accumulates, and the
+// replacement is what you get back. The old handle going away must not
+// take the live entry's index slot with it.
+func TestReRegisteringAKeyReplaces(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	assertLua(t, engine, `
+		local count_before = rune.binds.count()
+		local first = rune.bind("ctrl+g", function() end)
+		local second = rune.bind("ctrl+g", function() end)
+
+		assert(rune.binds.get("ctrl+g") == second, "get must return the replacement")
+		assert(rune.binds.get("ctrl+g") ~= first, "the old handle must not linger")
+		assert(rune.binds.count() == count_before + 1, "replacing must not grow the registry")
+
+		-- Removing the displaced handle is a no-op that must not evict the
+		-- live binding from the dispatch index.
+		first:remove()
+		assert(rune.binds.get("ctrl+g") == second, "removing the old handle must not evict the new one")
+	`)
+}
+
+// h:action() returns the registered action across registries, which is
+// the supported way to wrap an existing callback.
+func TestHandleActionReturnsTheRegisteredAction(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	assertLua(t, engine, `
+		local fn = function() end
+		rune.bind("f2", fn)
+		assert(rune.binds.get("f2"):action() == fn, "bind action must be the callback")
+
+		local render = function() return "" end
+		rune.ui.bar("clock", render)
+		assert(rune.bars.get("clock"):action() == render, "bar action must be the renderer")
+
+		local handler = function() end
+		rune.command.add("greet", handler, "Greet")
+		assert(rune.command.get("greet"):action() == handler, "command action must be the handler")
+
+		-- A string action comes back as the string, not wrapped in a function.
+		rune.trigger.contains("hungry", "eat bread", { name = "feeder" })
+		assert(rune.trigger.get("feeder"):action() == "eat bread", "string actions must round-trip")
+
+		local on_out = function() end
+		rune.hooks.on("output", on_out, { name = "watcher" })
+		assert(rune.hooks.get("watcher"):action() == on_out, "hook action must be the handler")
+	`)
+}
+
+// The documented pattern for extending a built-in: capture the action,
+// re-register the key, call through.
+func TestWrappingABuiltInCommand(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+
+	if err := engine.DoString("setup", `
+		local original = assert(rune.command.get("echo")):action()
+		rune.command.add("echo", function(args)
+			original("wrapped: " .. args)
+		end, "Echo, wrapped")
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	engine.OnInput("/echo hello")
+
+	printed := strings.Join(host.DrainPrintCalls(), "\n")
+	if !strings.Contains(printed, "wrapped: hello") {
+		t.Fatalf("wrapper did not call through, got: %q", printed)
+	}
+}
+
+// The same pattern for a default bind, verbatim as the guides print it.
+func TestWrappingADefaultBind(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	assertLua(t, engine, `
+		wrapped = false
+		local scroll = assert(rune.binds.get("pageup")):action()
+		rune.bind("pageup", function()
+			scroll()
+			wrapped = true
+		end)
+	`)
+
+	assertLua(t, engine, `
+		assert(rune.binds._dispatch("pageup"), "pageup should still be bound")
+		assert(wrapped, "the wrapper did not run")
+	`)
+}
+
+// get() addresses only what is registered, and unbinding takes the key
+// out of the index it was registered under.
+func TestGetReturnsNilForUnknownAndRemoved(t *testing.T) {
+	engine, _, cleanup := setupTest(t)
+	defer cleanup()
+
+	assertLua(t, engine, `
+		assert(rune.binds.get("f9") == nil, "unknown key must be nil")
+		assert(rune.trigger.get("nope") == nil, "unknown trigger name must be nil")
+
+		rune.bind("f9", function() end)
+		assert(rune.binds.get("f9"), "bind should be present after binding")
+		assert(rune.unbind("f9"), "unbind must report success")
+		assert(rune.binds.get("f9") == nil, "unbound key must be gone")
+		assert(rune.unbind("f9") == false, "unbinding twice must report failure")
+	`)
+}

--- a/website/src/content/docs/cookbook/quake-console.md
+++ b/website/src/content/docs/cookbook/quake-console.md
@@ -13,7 +13,7 @@ rune.pane.create("chat")
 
 rune.bind("`", function()
     rune.pane.toggle("chat")
-end, { name = "chat-console" })
+end)
 
 local style = rune.style
 local function mirror(tag, color, name, msg)

--- a/website/src/content/docs/interface/bars.md
+++ b/website/src/content/docs/interface/bars.md
@@ -68,8 +68,8 @@ too.
 
 ## Managing
 
-By name: `rune.bars.disable/enable/remove(name)` — the full management
-suite is in the [API reference](/reference/api/#managing). In the client,
+By name: `rune.bars.disable/enable/remove(name)`. The full list is in
+the [API reference](/reference/api/#managing). In the client,
 `/bars` lists every bar with its state, group, and the `file:line` that
 registered it.
 

--- a/website/src/content/docs/reference/api/alias.md
+++ b/website/src/content/docs/reference/api/alias.md
@@ -12,10 +12,16 @@ the server. For a task-oriented introduction, see
 ```lua
 rune.alias.exact(phrase, action, opts?)   -- leading command phrase matches literally
 rune.alias.regex(pattern, action, opts?)  -- Go regexp on the full input line
+rune.alias.get(name)                      -- the alias's handle, or nil
 ```
 
 Both constructors return a [handle](/reference/api/#handles) and accept
-the [common options](/reference/api/#options).
+the [common options](/reference/api/#options), except that an exact
+alias is named for its normalized phrase, so passing `name` to
+`rune.alias.exact` is an error. `rune.alias.disable("chat off")` then
+addresses it by that phrase; see
+[items that name themselves](/reference/api/#items-that-name-themselves).
+Regex aliases have no natural key and take `name` as usual.
 
 ## Matching
 
@@ -85,8 +91,8 @@ consume the input entirely (the function already did the work).
 ## Managing
 
 Standard registry management applies:
-`rune.alias.enable/disable/remove(name)`, `.list()`, `.count()`,
-`.clear()`, `.remove_group(group)` — see
+`rune.alias.get/enable/disable/remove(name)`, `.list()`, `.count()`,
+`.clear()`, `.remove_group(group)`. See
 [Registries](/reference/api/#managing). `/aliases` lists everything.
 
 **Related:** [Aliases guide](/scripting/aliases/) ·

--- a/website/src/content/docs/reference/api/alias.md
+++ b/website/src/content/docs/reference/api/alias.md
@@ -16,12 +16,12 @@ rune.alias.get(name)                      -- the alias's handle, or nil
 ```
 
 Both constructors return a [handle](/reference/api/#handles) and accept
-the [common options](/reference/api/#options), except that an exact
-alias is named for its normalized phrase, so passing `name` to
-`rune.alias.exact` is an error. `rune.alias.disable("chat off")` then
-addresses it by that phrase; see
-[items that name themselves](/reference/api/#items-that-name-themselves).
-Regex aliases have no natural key and take `name` as usual.
+the [common options](/reference/api/#options). They differ in how they
+are [named](/reference/api/#names): an exact alias is named for its
+normalized phrase, so `rune.alias.disable("chat off")` addresses it and a
+`name` in `opts` is ignored with a notice. A regex alias is a matcher
+rather than a phrase, and several can match one line, so it takes `name`
+as usual.
 
 ## Matching
 

--- a/website/src/content/docs/reference/api/bind.md
+++ b/website/src/content/docs/reference/api/bind.md
@@ -11,15 +11,28 @@ introduction, see [Keybindings](/scripting/keybindings/).
 ```lua
 rune.bind(key, callback, opts?)   -- bind a key; rebinding replaces (upsert by key)
 rune.unbind(key)                  -- remove a binding; true if one existed
+rune.binds.get(key)               -- the binding's handle, or nil
 ```
 
 `rune.bind` returns a [handle](/reference/api/#handles) and accepts the
-[common options](/reference/api/#options) `name` and `group`. A disabled
-bind (or one in a disabled group) swallows its key without running the
-callback.
+[common option](/reference/api/#options) `group`. The key is the registry
+name, so passing `name` is an error; see
+[items that name themselves](/reference/api/#items-that-name-themselves).
+A disabled bind (or one in a disabled group) swallows its key without
+running the callback.
 
 ```lua
-rune.bind("f1", function() rune.send("north") end, {name = "go-north"})
+rune.bind("f1", function() rune.send("north") end, {group = "combat"})
+```
+
+To extend a default rather than discard it, capture its action first:
+
+```lua
+local scroll = assert(rune.binds.get("pageup")):action()
+rune.bind("pageup", function()
+    scroll()
+    rune.echo("scrolled")
+end)
 ```
 
 ## Key formats
@@ -94,9 +107,9 @@ delete-word.
 
 ## Managing
 
-Standard registry management applies:
-`rune.binds.enable/disable/remove(name)`, `.list()`, `.count()`,
-`.clear()`, `.remove_group(group)` — see
+Standard registry management applies, addressed by key:
+`rune.binds.get/enable/disable/remove(key)`, `.list()`, `.count()`,
+`.clear()`, `.remove_group(group)`. See
 [Registries](/reference/api/#managing). `/binds` lists everything.
 
 **Related:** [Keybindings guide](/scripting/keybindings/) ·

--- a/website/src/content/docs/reference/api/bind.md
+++ b/website/src/content/docs/reference/api/bind.md
@@ -15,11 +15,10 @@ rune.binds.get(key)               -- the binding's handle, or nil
 ```
 
 `rune.bind` returns a [handle](/reference/api/#handles) and accepts the
-[common option](/reference/api/#options) `group`. The key is the registry
-name, so passing `name` is an error; see
-[items that name themselves](/reference/api/#items-that-name-themselves).
-A disabled bind (or one in a disabled group) swallows its key without
-running the callback.
+[common option](/reference/api/#options) `group`. The key is the bind's
+[name](/reference/api/#names), so a `name` in `opts` is ignored with a
+notice. A disabled bind (or one in a disabled group) swallows its key
+without running the callback.
 
 ```lua
 rune.bind("f1", function() rune.send("north") end, {group = "combat"})

--- a/website/src/content/docs/reference/api/command.md
+++ b/website/src/content/docs/reference/api/command.md
@@ -19,8 +19,8 @@ rune.command.list()                                   -- array of {name, descrip
 
 `add` returns a [handle](/reference/api/#handles); `opts` accepts
 `group` from the [common options](/reference/api/#options). The command
-name is the registry name, so passing `name` in `opts` is an error;
-see [items that name themselves](/reference/api/#items-that-name-themselves).
+is its own [name](/reference/api/#names), so a `name` in `opts` is
+ignored with a notice.
 
 To wrap a built-in, capture its action before replacing it:
 

--- a/website/src/content/docs/reference/api/command.md
+++ b/website/src/content/docs/reference/api/command.md
@@ -11,15 +11,26 @@ task-oriented introduction, see [Slash Commands](/scripting/commands/).
 ```lua
 rune.command.add(name, handler, description?, opts?)  -- register /name
 rune.command.remove(name)                             -- unregister; true if it existed
-rune.command.get(name)                                -- the raw handler, or nil
+rune.command.get(name)                                -- the command's handle, or nil
 rune.command.enable(name)                             -- re-enable (also recovers from quarantine)
 rune.command.disable(name)                            -- disable without unregistering
 rune.command.list()                                   -- array of {name, description, enabled, group, source}
 ```
 
 `add` returns a [handle](/reference/api/#handles); `opts` accepts
-`group` from the [common options](/reference/api/#options) (the item's
-name is the command name itself).
+`group` from the [common options](/reference/api/#options). The command
+name is the registry name, so passing `name` in `opts` is an error;
+see [items that name themselves](/reference/api/#items-that-name-themselves).
+
+To wrap a built-in, capture its action before replacing it:
+
+```lua
+local quit = assert(rune.command.get("quit")):action()
+rune.command.add("quit", function(args)
+    rune.send("save")
+    quit(args)
+end, "Save, then exit")
+```
 
 ### rune.command.add
 
@@ -52,7 +63,7 @@ and input handling keeps working. Fix the error and
 ## Managing
 
 Standard registry management applies:
-`rune.command.enable/disable/remove(name)`, `.list()` — see
+`rune.command.get/enable/disable/remove(name)`, `.list()`. See
 [Registries](/reference/api/#managing). `/help` lists everything.
 
 **Related:** [Slash Commands guide](/scripting/commands/) ·

--- a/website/src/content/docs/reference/api/gmcp.md
+++ b/website/src/content/docs/reference/api/gmcp.md
@@ -101,7 +101,7 @@ rune.gmcp.subscribe("Room", 2)
 
 ## Managing
 
-`rune.gmcp.enable/disable/remove(name)` manage handlers by name;
+`rune.gmcp.get/enable/disable/remove(name)` manage handlers by name;
 `rune.gmcp.list()` returns them — see
 [Registries](/reference/api/#managing). `/gmcp` shows negotiation
 state, subscriptions, and handlers; `/gmcp send <package> [json]`

--- a/website/src/content/docs/reference/api/gmcp.md
+++ b/website/src/content/docs/reference/api/gmcp.md
@@ -59,7 +59,7 @@ the server is reported and dropped before any handler runs.
 rune.gmcp.send(package, value?) -> true | nil, err
 ```
 
-- `package` (string) — the message name (`"Char.Skills.Get"`).
+- `package` (string) — the message name (`"Core.Hello"`).
 - `value` (optional) — a string, number, boolean, or JSON-able table;
   `nil` sends the bare package name.
 
@@ -68,7 +68,7 @@ not connected, GMCP not negotiated, or the value cannot be encoded.
 Failures are also echoed to the screen.
 
 ```lua
-rune.gmcp.send("Char.Skills.Get", { group = "combat" })
+rune.gmcp.send("Core.Hello", { client = "rune", version = rune.version })
 rune.gmcp.send("Core.Ping")
 ```
 

--- a/website/src/content/docs/reference/api/hooks.md
+++ b/website/src/content/docs/reference/api/hooks.md
@@ -155,7 +155,7 @@ harvesting, priority 200).
 ## Managing
 
 Standard registry management applies:
-`rune.hooks.enable/disable/remove(name)`, `.list()`, `.count()`,
+`rune.hooks.get/enable/disable/remove(name)`, `.list()`, `.count()`,
 `.clear()`, `.remove_group(group)` — see
 [Registries](/reference/api/#managing). `/hooks` lists everything.
 

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -64,29 +64,38 @@ Every registration has a name. It is what you pass to
 [`get`, `enable`, `disable` and `remove`](#managing), what a
 re-registration replaces on, and what the listing commands show.
 
-For most registries you supply it:
-
-```lua
-rune.trigger.contains("food", "eat bread", { name = "feeder" })
-```
-
-Four give themselves one:
+Most registries take the name from you. Four take it from what you passed
+first:
 
 | Creation function | Name | Because |
 |---|---|---|
-| `rune.bind(key, ...)` | the key, `"ctrl+g"` | one bind per key |
-| `rune.ui.bar(name, ...)` | the layout name, `"status"` | one renderer per slot |
-| `rune.command.add(name, ...)` | the command, `"greet"` | one handler per `/command` |
-| `rune.alias.exact(phrase, ...)` | the normalized phrase, `"chat off"` | one expansion per typed phrase |
+| `rune.trigger.*` | the `name` you give it | several triggers can match one line |
+| `rune.alias.regex` | the `name` you give it | several can match one line |
+| `rune.timer.*` | the `name` you give it | nothing about a timer is unique |
+| `rune.hooks.on` | the `name` you give it | several handlers per event |
+| `rune.gmcp.on` | the `name` you give it | several handlers per package |
+| `rune.bind` | the key, `"ctrl+g"` | one bind per key |
+| `rune.ui.bar` | the layout name, `"status"` | one renderer per slot |
+| `rune.command.add` | the command, `"greet"` | one handler per `/command` |
+| `rune.alias.exact` | the phrase, `"chat off"` | one expansion per typed phrase |
 
-Each holds one entry per key, so there is nothing a separate name would
-distinguish. That is why `rune.binds.disable("ctrl+g")` and
+Read down the last column and the split explains itself: where several
+entries can share a first argument you name them, and where only one can
+exist the first argument is already the name.
+
+Either way the management calls look the same:
+
+```lua
+rune.trigger.contains("food", "eat bread", { name = "feeder" })
+rune.bind("ctrl+g", toggle_map)
+
+rune.trigger.disable("feeder")
+rune.binds.disable("ctrl+g")
+```
+
+That is also why `rune.binds.disable("ctrl+g")` and
 `rune.bars.get("status")` reach the core's own binds and bars, which are
-registered without options.
-
-The test for any registry: can two entries share the same first argument?
-Triggers, timers, hooks, GMCP handlers and regex aliases can, so you name
-them. The four above cannot, so they are named for you.
+registered without options at all.
 
 These four accepted a `name` option before rune 0.9. Passing one now is
 ignored with a `[Deprecated]` notice giving the key to manage it by, so

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -49,9 +49,14 @@ Every creation function (`rune.trigger.*`, `rune.alias.*`,
 | `h:remove()` | Unregister (timers also accept `h:cancel()`) |
 | `h:name()` | The item's name, or nil |
 | `h:group()` | The item's group, or nil |
+| `h:action()` | The registered action: the function, or the string for string actions |
 
 Methods are chainable. See
 [The Scripting Model](/scripting/model/#handles) for usage.
+
+`h:action()` returns the callback as registered, so calling it runs
+neither the enabled and group checks nor the failure quarantine. It is
+for capturing an existing action and wrapping it, not for dispatch.
 
 ## Options
 
@@ -59,12 +64,28 @@ Common `opts` fields accepted by every creation function:
 
 | Option | Type | Default | Applies to |
 |---|---|---|---|
-| `name` | string | none | All — unique ID; same name replaces (upsert) |
-| `group` | string | none | All — membership for batch operations |
-| `priority` | number | 50 | Regex aliases, triggers, hooks — lower runs first |
-| `once` | bool | false | Aliases, triggers — remove after first match |
+| `name` | string | none | Triggers, timers, hooks, GMCP handlers, regex aliases. Unique ID; same name replaces (upsert) |
+| `group` | string | none | All: membership for batch operations |
+| `priority` | number | 50 | Regex aliases, triggers, hooks. Lower runs first |
+| `once` | bool | false | Aliases, triggers. Remove after first match |
 
 Page-specific extras (e.g. trigger `gag`/`raw`) are listed on each page.
+
+### Items that name themselves
+
+An entry with a natural key is registered under that key, and passing
+`name` for one is an error rather than a second identity:
+
+| Creation function | Its name |
+|---|---|
+| `rune.bind(key, ...)` | the key, `"ctrl+g"` |
+| `rune.ui.bar(name, ...)` | the bar's layout name, `"status"` |
+| `rune.command.add(name, ...)` | the command, `"greet"` |
+| `rune.alias.exact(phrase, ...)` | the normalized phrase, `"chat off"` |
+
+So `rune.binds.disable("ctrl+g")` and `rune.bars.get("status")` address
+these by the same string you registered them with, including the core's
+own binds, bars and commands.
 
 ## Managing
 
@@ -73,6 +94,7 @@ by item name:
 
 | Function | Effect |
 |---|---|
+| `.get(name)` | The item's handle, or nil |
 | `.enable(name)` / `.disable(name)` | Toggle an item |
 | `.remove(name)` | Unregister an item |
 | `.list()` | All items with name, enabled state, group, and source `file:line` |

--- a/website/src/content/docs/reference/api/index.md
+++ b/website/src/content/docs/reference/api/index.md
@@ -58,39 +58,59 @@ Methods are chainable. See
 neither the enabled and group checks nor the failure quarantine. It is
 for capturing an existing action and wrapping it, not for dispatch.
 
+## Names
+
+Every registration has a name. It is what you pass to
+[`get`, `enable`, `disable` and `remove`](#managing), what a
+re-registration replaces on, and what the listing commands show.
+
+For most registries you supply it:
+
+```lua
+rune.trigger.contains("food", "eat bread", { name = "feeder" })
+```
+
+Four give themselves one:
+
+| Creation function | Name | Because |
+|---|---|---|
+| `rune.bind(key, ...)` | the key, `"ctrl+g"` | one bind per key |
+| `rune.ui.bar(name, ...)` | the layout name, `"status"` | one renderer per slot |
+| `rune.command.add(name, ...)` | the command, `"greet"` | one handler per `/command` |
+| `rune.alias.exact(phrase, ...)` | the normalized phrase, `"chat off"` | one expansion per typed phrase |
+
+Each holds one entry per key, so there is nothing a separate name would
+distinguish. That is why `rune.binds.disable("ctrl+g")` and
+`rune.bars.get("status")` reach the core's own binds and bars, which are
+registered without options.
+
+The test for any registry: can two entries share the same first argument?
+Triggers, timers, hooks, GMCP handlers and regex aliases can, so you name
+them. The four above cannot, so they are named for you.
+
+These four accepted a `name` option before rune 0.9. Passing one now is
+ignored with a `[Deprecated]` notice giving the key to manage it by, so
+older scripts keep loading; only management calls that used the old name
+need changing.
+
 ## Options
 
 Common `opts` fields accepted by every creation function:
 
 | Option | Type | Default | Applies to |
 |---|---|---|---|
-| `name` | string | none | Triggers, timers, hooks, GMCP handlers, regex aliases. Unique ID; same name replaces (upsert) |
 | `group` | string | none | All: membership for batch operations |
 | `priority` | number | 50 | Regex aliases, triggers, hooks. Lower runs first |
 | `once` | bool | false | Aliases, triggers. Remove after first match |
 
-Page-specific extras (e.g. trigger `gag`/`raw`) are listed on each page.
-
-### Items that name themselves
-
-An entry with a natural key is registered under that key, and passing
-`name` for one is an error rather than a second identity:
-
-| Creation function | Its name |
-|---|---|
-| `rune.bind(key, ...)` | the key, `"ctrl+g"` |
-| `rune.ui.bar(name, ...)` | the bar's layout name, `"status"` |
-| `rune.command.add(name, ...)` | the command, `"greet"` |
-| `rune.alias.exact(phrase, ...)` | the normalized phrase, `"chat off"` |
-
-So `rune.binds.disable("ctrl+g")` and `rune.bars.get("status")` address
-these by the same string you registered them with, including the core's
-own binds, bars and commands.
+`name` sets the name where the registry does not set its own; see
+[Names](#names). Page-specific extras (e.g. trigger `gag`/`raw`) are
+listed on each page.
 
 ## Managing
 
-Every registry namespace exposes the same management suite, addressed
-by item name:
+Every registry namespace exposes the same functions, each taking the
+item's name:
 
 | Function | Effect |
 |---|---|

--- a/website/src/content/docs/reference/api/timer.md
+++ b/website/src/content/docs/reference/api/timer.md
@@ -67,7 +67,7 @@ your script so they come back on reload.
 ## Managing
 
 Standard registry management applies:
-`rune.timer.enable/disable/remove(name)`, `.cancel(name)`, `.list()`,
+`rune.timer.get/enable/disable/remove(name)`, `.cancel(name)`, `.list()`,
 `.count()`, `.clear()`, `.remove_group(group)` — see
 [Registries](/reference/api/#managing). `/timers` lists everything.
 

--- a/website/src/content/docs/reference/api/trigger.md
+++ b/website/src/content/docs/reference/api/trigger.md
@@ -178,7 +178,7 @@ Behavior:
 ## Managing
 
 Standard registry management applies:
-`rune.trigger.enable/disable/remove(name)`, `.list()`, `.count()`,
+`rune.trigger.get/enable/disable/remove(name)`, `.list()`, `.count()`,
 `.clear()`, `.remove_group(group)` — see
 [Registries](/reference/api/#managing). `/triggers` lists everything;
 `/test <line>` feeds a fake complete line through the output-trigger

--- a/website/src/content/docs/reference/api/ui.md
+++ b/website/src/content/docs/reference/api/ui.md
@@ -12,12 +12,15 @@ introductions, see [Layout & UI](/interface/layout/) and
 ```lua
 rune.ui.layout(config)               -- set the dock layout
 rune.ui.bar(name, render_fn, opts?)  -- register a bar renderer
+rune.bars.get(name)                  -- the bar's handle, or nil
 rune.ui.refresh_bars()               -- request an immediate re-render
 rune.ui.search(opts?)                -- open the scrollback-search overlay
 ```
 
 `rune.ui.bar` returns a [handle](/reference/api/#handles) and accepts
-the [common options](/reference/api/#options).
+the [common option](/reference/api/#options) `group`. The bar's layout
+name is its registry name, so passing `name` in `opts` is an error; see
+[items that name themselves](/reference/api/#items-that-name-themselves).
 
 ### rune.ui.layout
 
@@ -67,8 +70,8 @@ A bar or pane renders only if a layout dock names it — see
 rune.ui.bar(name, render_fn, opts?) -> handle
 ```
 
-- `name` (string) — the bar's layout name (`"status"` replaces the
-  built-in status bar).
+- `name` (string): the bar's layout name, and its registry name
+  (`"status"` replaces the built-in status bar).
 - `render_fn` (function) — `function(width)`; called on the render
   tick (roughly every 250ms) with the terminal width. Return a string,
   a `{left, center, right}` table, or `nil` to skip this render.
@@ -124,11 +127,10 @@ scan stopped at its cap and older matches exist beyond it. After
 
 ## Managing
 
-Standard registry management applies:
-`rune.bars.enable/disable/remove(name)`, `.list()`, `.count()`,
-`.clear()`, `.remove_group(group)` — see
-[Registries](/reference/api/#managing). These address the `name`
-option, not the bar name. `/bars` lists everything.
+Standard registry management applies, addressed by the bar's layout name:
+`rune.bars.get/enable/disable/remove(name)`, `.list()`, `.count()`,
+`.clear()`, `.remove_group(group)`. See
+[Registries](/reference/api/#managing). `/bars` lists everything.
 
 **Related:** [Bars guide](/interface/bars/) ·
 [rune.pane](/reference/api/pane/) ·

--- a/website/src/content/docs/reference/api/ui.md
+++ b/website/src/content/docs/reference/api/ui.md
@@ -19,8 +19,8 @@ rune.ui.search(opts?)                -- open the scrollback-search overlay
 
 `rune.ui.bar` returns a [handle](/reference/api/#handles) and accepts
 the [common option](/reference/api/#options) `group`. The bar's layout
-name is its registry name, so passing `name` in `opts` is an error; see
-[items that name themselves](/reference/api/#items-that-name-themselves).
+name is its [name](/reference/api/#names), so a `name` in `opts` is
+ignored with a notice.
 
 ### rune.ui.layout
 

--- a/website/src/content/docs/scripting/aliases.md
+++ b/website/src/content/docs/scripting/aliases.md
@@ -149,7 +149,7 @@ rune.alias.exact("s", "sneak south", { group = "sneaky" })
 Every constructor returns a handle:
 
 ```lua
-local h = rune.alias.exact("k", "kill", { name = "quick-kill" })
+local h = rune.alias.exact("k", "kill")
 h:disable()  h:enable()  h:remove()
 ```
 

--- a/website/src/content/docs/scripting/aliases.md
+++ b/website/src/content/docs/scripting/aliases.md
@@ -97,14 +97,20 @@ condition.
 
 ## Options
 
-Aliases take the [common options](/scripting/model/#options): `name`,
-`group`, `priority` (order among regex aliases), and `once`. No
-alias-specific extras.
+Aliases take the [common options](/scripting/model/#options): `group`,
+`priority` (order among regex aliases), and `once`. No alias-specific
+extras.
 
+The two constructors are [named](/scripting/model/#names) differently.
 An exact alias is named for its phrase, so `rune.alias.disable("gc")`
-works without you naming anything, and passing `name` to
-`rune.alias.exact` is an error. Regex aliases have no such key and take
-`name` as usual.
+works without you naming anything, and a `name` in `opts` is ignored with
+a notice. A regex alias is a matcher rather than a phrase, and several can
+match one line, so it takes `name` like a trigger does.
+
+Note that `rune.alias.exact` and [`rune.trigger.exact`](/scripting/triggers/)
+do not mean the same thing here. An alias phrase is something you type, so
+it names the alias. A trigger's exact line is something you match, and
+several triggers can match it, so a trigger still needs a `name`.
 
 ## Examples
 
@@ -153,8 +159,8 @@ local h = rune.alias.exact("k", "kill")
 h:disable()  h:enable()  h:remove()
 ```
 
-By name: `rune.alias.disable/enable/remove(name)` — the full management
-suite is in the [API reference](/reference/api/#managing). In the client,
+By name: `rune.alias.disable/enable/remove(name)`. The full list is in
+the [API reference](/reference/api/#managing). In the client,
 `/aliases` shows every alias with its state, group, and the `file:line`
 that registered it.
 

--- a/website/src/content/docs/scripting/aliases.md
+++ b/website/src/content/docs/scripting/aliases.md
@@ -101,6 +101,11 @@ Aliases take the [common options](/scripting/model/#options): `name`,
 `group`, `priority` (order among regex aliases), and `once`. No
 alias-specific extras.
 
+An exact alias is named for its phrase, so `rune.alias.disable("gc")`
+works without you naming anything, and passing `name` to
+`rune.alias.exact` is an error. Regex aliases have no such key and take
+`name` as usual.
+
 ## Examples
 
 Chaining and repeats compose with aliases, since expansion runs on the

--- a/website/src/content/docs/scripting/commands.md
+++ b/website/src/content/docs/scripting/commands.md
@@ -34,7 +34,7 @@ registry name.
 
 Commands take the [common option](/scripting/model/#options) `group`.
 The command name is the registry `name`, so re-adding a name replaces
-it, and passing `name` yourself is an error.
+it. Passing `name` yourself is ignored with a deprecation notice.
 
 ## Examples
 

--- a/website/src/content/docs/scripting/commands.md
+++ b/website/src/content/docs/scripting/commands.md
@@ -33,8 +33,8 @@ registry name.
 ## Options
 
 Commands take the [common option](/scripting/model/#options) `group`.
-The command name doubles as the registry `name`, so re-adding a name
-replaces it.
+The command name is the registry `name`, so re-adding a name replaces
+it, and passing `name` yourself is an error.
 
 ## Examples
 
@@ -53,10 +53,11 @@ rune.command.add("pather", function(args)
 end, "Walk saved paths")
 ```
 
-Overriding a built-in. Re-adding a name replaces it, so you can wrap:
+Overriding a built-in. Re-adding a name replaces it, so you can wrap.
+`get` returns the command's handle; `:action()` is the raw handler:
 
 ```lua
-local quit = rune.command.get("quit")
+local quit = assert(rune.command.get("quit")):action()
 rune.command.add("quit", function(args)
     rune.send("save")
     quit(args)
@@ -66,7 +67,7 @@ end, "Save, then exit")
 ## Managing
 
 By name: `rune.command.enable/disable/remove(name)`, plus
-`rune.command.get(name)` for the raw handler — full signatures in the
+`rune.command.get(name)` for its handle. Full signatures in the
 [rune.command reference](/reference/api/command/). In the client, `/help`
 lists every command, including script-added ones, with descriptions and
 sources.

--- a/website/src/content/docs/scripting/gmcp.md
+++ b/website/src/content/docs/scripting/gmcp.md
@@ -32,8 +32,8 @@ sent it, and `raw` is the JSON text.
 ## Sending
 
 ```lua
-rune.gmcp.send("Char.Skills.Get", { group = "combat" })  -- any JSON-able Lua value
-rune.gmcp.send("Core.Ping")                              -- bare package
+rune.gmcp.send("Core.Hello", { client = "rune", version = rune.version })  -- any JSON-able Lua value
+rune.gmcp.send("Core.Ping")                                                -- bare package
 ```
 
 Returns `true` or `nil, err` (not connected, GMCP not negotiated).

--- a/website/src/content/docs/scripting/hooks.md
+++ b/website/src/content/docs/scripting/hooks.md
@@ -125,8 +125,8 @@ first, default 50).
 ## Managing
 
 Every constructor returns a handle with `:enable()`, `:disable()`, and
-`:remove()`. By name: `rune.hooks.disable/enable/remove(name)` — the full
-management suite is in the [API reference](/reference/api/#managing). In
+`:remove()`. By name: `rune.hooks.disable/enable/remove(name)`. The full
+list is in the [API reference](/reference/api/#managing). In
 the client, `/hooks` lists every handler, including the core's own, since
 the client registers its behavior through the same API.
 

--- a/website/src/content/docs/scripting/keybindings.md
+++ b/website/src/content/docs/scripting/keybindings.md
@@ -40,9 +40,22 @@ structured text enters the [verbatim composer](/interface/input/#multiline-verba
 
 ## Options
 
-Binds take the [common options](/scripting/model/#options) `name` and
-`group`. Rebinding a key always replaces whatever was on it, named or
-not.
+Binds take the [common option](/scripting/model/#options) `group`. The
+key is the bind's name, so rebinding a key always replaces whatever was
+on it, and `rune.binds.disable("ctrl+g")` addresses it by the same
+string you bound.
+
+To extend a default instead of discarding it, capture its action first.
+`rune.binds.get(key)` returns the handle; `:action()` is the raw
+callback:
+
+```lua
+local scroll = assert(rune.binds.get("pageup")):action()
+rune.bind("pageup", function()
+    scroll()
+    rune.echo("scrolled")
+end)
+```
 
 ## Examples
 
@@ -70,7 +83,7 @@ Rebinding a key in your `init.lua` replaces the default.
 
 ## Managing
 
-By name: `rune.binds.disable/enable/remove(name)` — the full management
+By key: `rune.binds.get/disable/enable/remove(key)`. The full management
 suite is in the [API reference](/reference/api/#managing). In the client,
 `/binds` lists every binding with its state, group, and the `file:line`
 that registered it.

--- a/website/src/content/docs/scripting/keybindings.md
+++ b/website/src/content/docs/scripting/keybindings.md
@@ -10,7 +10,7 @@ can rebind.
 
 ```lua
 rune.bind("f1", function() rune.send("cast shield") end)
-rune.bind("ctrl+g", function() rune.pane.toggle("map") end, { name = "map-toggle" })
+rune.bind("ctrl+g", function() rune.pane.toggle("map") end)
 rune.unbind("f1")
 ```
 

--- a/website/src/content/docs/scripting/keybindings.md
+++ b/website/src/content/docs/scripting/keybindings.md
@@ -83,8 +83,8 @@ Rebinding a key in your `init.lua` replaces the default.
 
 ## Managing
 
-By key: `rune.binds.get/disable/enable/remove(key)`. The full management
-suite is in the [API reference](/reference/api/#managing). In the client,
+By key: `rune.binds.get/disable/enable/remove(key)`. The full list is in
+the [API reference](/reference/api/#managing). In the client,
 `/binds` lists every binding with its state, group, and the `file:line`
 that registered it.
 

--- a/website/src/content/docs/scripting/model.md
+++ b/website/src/content/docs/scripting/model.md
@@ -12,25 +12,26 @@ If you haven't written a trigger or an alias yet, start with
 [Triggers](/scripting/triggers/) and come back. This page makes more sense
 once you have registered a few things.
 
-## Options
+## Names
 
-Every creation function takes an optional `opts` table as its last argument.
-Four fields work everywhere:
+Every registration has a name. It is what you pass to `get`, `enable`,
+`disable` and `remove`, what a re-registration replaces on, and what
+`/triggers`, `/binds` and the other listings show.
 
-| Option | Type | Default | Description |
-|---|---|---|---|
-| `name` | string | none | Unique ID for management. |
-| `group` | string | none | Group membership for batch enable/disable/remove. |
-| `priority` | number | 50 | Execution order where multiple items can match (regex aliases, triggers, hooks). Lower runs first. |
-| `once` | bool | false | Auto-remove after the first match (aliases, triggers). |
+For most registries you supply it:
 
-Naming an item does more than label it. Registering the same name again
-replaces the old entry instead of adding a second one, which is what keeps
-`/reload` from stacking a duplicate trigger every time you edit a script.
-Name anything you expect to re-register.
+```lua
+rune.trigger.contains("food", "eat bread", { name = "feeder" })
+rune.trigger.disable("feeder")
+```
 
-Some things name themselves. A key binding, a bar, a slash command and an
-exact alias each have an obvious identity already, so that is their name:
+Naming does more than label. Registering the same name again replaces the
+old entry instead of adding a second one, which is what keeps `/reload`
+from stacking a duplicate trigger every time you edit a script. Name
+anything you expect to re-register.
+
+Four registries give themselves a name, because the thing you pass first
+already identifies one entry:
 
 ```lua
 rune.bind("ctrl+g", toggle_map)          -- named "ctrl+g"
@@ -42,13 +43,31 @@ rune.binds.disable("ctrl+g")
 rune.bars.disable("status")
 ```
 
-Those four take `group` but not `name`, since a second identity is what
-the single name is there to prevent. Everything else, including regex
-aliases, takes `name` as an ordinary option.
+There is one bind per key, one renderer per bar slot, one handler per
+`/command`, and one expansion per typed phrase, so a separate name would
+have nothing to distinguish. It is also why you can reach the core's own
+binds and bars, which are registered without options at all.
+
+The test for any registry: can two entries share the same first argument?
+Triggers, timers, hooks, GMCP handlers and regex aliases can, so you name
+them. The four above cannot, so they are named for you. Passing `name` to
+one of them is ignored, with a notice telling you the key to manage it by.
+
+## Options
+
+Every creation function takes an optional `opts` table as its last argument.
+Three fields work everywhere:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `group` | string | none | Group membership for batch enable/disable/remove. |
+| `priority` | number | 50 | Execution order where multiple items can match (regex aliases, triggers, hooks). Lower runs first. |
+| `once` | bool | false | Auto-remove after the first match (aliases, triggers). |
+
+`name` sets the name where the registry does not set its own, as above.
 
 Individual registries add their own options. Triggers take `gag` and `raw`,
-for example. Each [API reference page](/reference/api/) lists its extras; the
-four above work everywhere.
+for example. Each [API reference page](/reference/api/) lists its extras.
 
 ## String and function actions
 

--- a/website/src/content/docs/scripting/model.md
+++ b/website/src/content/docs/scripting/model.md
@@ -18,40 +18,43 @@ Every registration has a name. It is what you pass to `get`, `enable`,
 `disable` and `remove`, what a re-registration replaces on, and what
 `/triggers`, `/binds` and the other listings show.
 
-For most registries you supply it:
+Most registries take the name from you. Four take it from what you passed
+first:
+
+| Creation function | Name | Because |
+|---|---|---|
+| `rune.trigger.*` | the `name` you give it | several triggers can match one line |
+| `rune.alias.regex` | the `name` you give it | several can match one line |
+| `rune.timer.*` | the `name` you give it | nothing about a timer is unique |
+| `rune.hooks.on` | the `name` you give it | several handlers per event |
+| `rune.gmcp.on` | the `name` you give it | several handlers per package |
+| `rune.bind` | the key, `"ctrl+g"` | one bind per key |
+| `rune.ui.bar` | the layout name, `"status"` | one renderer per slot |
+| `rune.command.add` | the command, `"greet"` | one handler per `/command` |
+| `rune.alias.exact` | the phrase, `"chat off"` | one expansion per typed phrase |
+
+Read down the last column and the split explains itself: where several
+entries can share a first argument you name them, and where only one can
+exist the first argument is already the name.
+
+Either way you manage it the same way:
 
 ```lua
 rune.trigger.contains("food", "eat bread", { name = "feeder" })
+rune.bind("ctrl+g", toggle_map)
+
 rune.trigger.disable("feeder")
-```
-
-Naming does more than label. Registering the same name again replaces the
-old entry instead of adding a second one, which is what keeps `/reload`
-from stacking a duplicate trigger every time you edit a script. Name
-anything you expect to re-register.
-
-Four registries give themselves a name, because the thing you pass first
-already identifies one entry:
-
-```lua
-rune.bind("ctrl+g", toggle_map)          -- named "ctrl+g"
-rune.ui.bar("status", render)            -- named "status"
-rune.command.add("greet", greet)         -- named "greet"
-rune.alias.exact("gc", "get all corpse") -- named "gc"
-
 rune.binds.disable("ctrl+g")
-rune.bars.disable("status")
 ```
 
-There is one bind per key, one renderer per bar slot, one handler per
-`/command`, and one expansion per typed phrase, so a separate name would
-have nothing to distinguish. It is also why you can reach the core's own
-binds and bars, which are registered without options at all.
+Registering the same name again replaces the old entry rather than adding
+a second one. That is what keeps `/reload` from stacking a duplicate
+trigger each time you edit a script, so name anything you expect to
+re-register.
 
-The test for any registry: can two entries share the same first argument?
-Triggers, timers, hooks, GMCP handlers and regex aliases can, so you name
-them. The four above cannot, so they are named for you. Passing `name` to
-one of them is ignored, with a notice telling you the key to manage it by.
+Passing `name` to one of the four is ignored, with a notice telling you
+the key to manage it by. It is also why you can reach the core's own binds
+and bars, which are registered without options at all.
 
 ## Options
 

--- a/website/src/content/docs/scripting/model.md
+++ b/website/src/content/docs/scripting/model.md
@@ -29,6 +29,23 @@ replaces the old entry instead of adding a second one, which is what keeps
 `/reload` from stacking a duplicate trigger every time you edit a script.
 Name anything you expect to re-register.
 
+Some things name themselves. A key binding, a bar, a slash command and an
+exact alias each have an obvious identity already, so that is their name:
+
+```lua
+rune.bind("ctrl+g", toggle_map)          -- named "ctrl+g"
+rune.ui.bar("status", render)            -- named "status"
+rune.command.add("greet", greet)         -- named "greet"
+rune.alias.exact("gc", "get all corpse") -- named "gc"
+
+rune.binds.disable("ctrl+g")
+rune.bars.disable("status")
+```
+
+Those four take `group` but not `name`, since a second identity is what
+the single name is there to prevent. Everything else, including regex
+aliases, takes `name` as an ordinary option.
+
 Individual registries add their own options. Triggers take `gag` and `raw`,
 for example. Each [API reference page](/reference/api/) lists its extras; the
 four above work everywhere.
@@ -85,10 +102,17 @@ rune.trigger.contains("spam", nil, { gag = true, name = "spam-gag" })
 rune.trigger.disable("spam-gag")
 ```
 
-Every registry exposes the same functions, taking the item name: `enable`,
-`disable`, `remove`, plus `list()`, `count()`, `clear()`, and
+Every registry exposes the same functions, taking the item name: `get`,
+`enable`, `disable`, `remove`, plus `list()`, `count()`, `clear()`, and
 `remove_group(group)`. The full contract is in the
 [API reference](/reference/api/#managing).
+
+`get` returns the handle, which is how you reach something you did not
+register yourself:
+
+```lua
+rune.bars.get("status"):disable()
+```
 
 ## Handles
 
@@ -103,12 +127,25 @@ h:enable()   -- resume
 h:remove()   -- unregister
 h:name()     -- "spam-gag"
 h:group()    -- nil (no group set)
+h:action()   -- the registered action
 ```
 
 Methods chain, which is handy for registering something already switched off:
 
 ```lua
 rune.trigger.contains("Weather:", nil, {gag = true}):disable()
+```
+
+`h:action()` gives back what you registered, which is how you extend
+something instead of replacing it. Calling the result runs it directly,
+skipping the enabled and group checks and the failure quarantine:
+
+```lua
+local scroll = assert(rune.binds.get("pageup")):action()
+rune.bind("pageup", function()
+    scroll()
+    rune.echo("scrolled")
+end)
 ```
 
 ## Groups

--- a/website/src/content/docs/scripting/timers.md
+++ b/website/src/content/docs/scripting/timers.md
@@ -71,7 +71,7 @@ h:disable()  h:enable()  h:cancel()   -- :cancel() is an alias for :remove()
 ```
 
 By name: `rune.timer.disable/enable/remove(name)` (`rune.timer.cancel` is
-the same as `remove`) — the full management suite is in the
+the same as `remove`). The full list is in the
 [API reference](/reference/api/#managing). In the client, `/timers` shows
 every timer with its state, mode and interval, action, group, name, and
 the `file:line` that registered it.

--- a/website/src/content/docs/scripting/triggers.md
+++ b/website/src/content/docs/scripting/triggers.md
@@ -83,8 +83,12 @@ end)
 
 ## Options
 
-Triggers take the [common options](/scripting/model/#options) — `name`,
-`group`, `priority`, `once` — plus:
+Triggers take the [common options](/scripting/model/#options) `group`,
+`priority` and `once`, plus a [`name`](/scripting/model/#names) to manage
+one by. A pattern cannot serve as the name, since several triggers can
+match the same line: that is what makes a highlighter and a tagger compose.
+For the same reason `rune.trigger.exact` does not name a trigger the way
+`rune.alias.exact` names an alias. Trigger-specific options:
 
 | Option | Effect |
 |---|---|
@@ -213,8 +217,8 @@ local h = rune.trigger.contains("hungry", "eat bread", { name = "auto-eat" })
 h:disable()  h:enable()  h:remove()
 ```
 
-By name: `rune.trigger.disable/enable/remove(name)` — the full management
-suite is in the [API reference](/reference/api/#managing). In the client,
+By name: `rune.trigger.disable/enable/remove(name)`. The full list is in
+the [API reference](/reference/api/#managing). In the client,
 `/triggers` shows every trigger with its state, mode, flags, group, and the
 `file:line` that registered it.
 


### PR DESCRIPTION
Closes #110.

Registry namespaces now expose `get(name)`, returning the current handle, and handles expose `action()`, returning the raw registered action. Binds, bars, commands, and exact aliases use their natural key as the registry name, so lookup, replacement, and management all use one identity.

## Why one identity

The registry had two independent upsert keys. `Registry:add` upserted by `opts.name`, and four registries ran a second upsert of their own in `on_add`: binds by key, bars by bar name, exact aliases by phrase, commands by command name. Commands did both at once, passing `{name = name}` and keeping a `by_cmd` table, so the same replacement happened twice through two mechanisms.

The split meant half of a namespace took one kind of identifier and half took another, and the mismatch failed quietly. The core status bar registers as `rune.ui.bar("status", fn)` with no opts, so it had no registry name and `rune.bars.disable("status")` returned false without doing anything. The same was true of every default keymap bind.

Making the natural key the name removes the second upsert entirely rather than working around it, and makes the management suite reach the core's own registrations for the first time.

## Compatibility

`rune.bind`, `rune.ui.bar`, `rune.alias.exact` and `rune.command.add` accepted a `name` option before this change. Passing one now emits a notice naming the key to manage the entry by:

```
[Deprecated] rune.bind: name 'map-toggle' ignored, manage it as 'ctrl+g' @init.lua:12
```

This warns rather than raises on purpose. Raising aborts the rest of the script that carried the stale option, so one legacy line in an `init.lua` would cost every registration below it, and the on-screen message about the client loading normally is about the client rather than the user's config. Verified against a three-line script: with a raise, the registration after the stale line was lost; with the notice, the script loads in full.

Only management calls that passed the old name need changing, and the notice says what to change them to. `rune.command.add` already discarded a user-supplied name silently across v0.5 through v0.8, so for commands this makes existing behavior audible rather than changing it.

## Breaking

`rune.command.get` returns a handle rather than the raw handler. Append `:action()` to recover it:

```lua
local quit = assert(rune.command.get("quit")):action()
```

A handle is not callable, so the break surfaces on the next `/reload` with the source `file:line` attached rather than going quiet. This is the only hard break; the four keyed constructors take the warning path above.

## Docs

`name` was documented as a common option accepted by every creation function, which was never true after this change and was already inconsistent with commands. The reference and scripting pages now lead with names: one table covering all nine registries, ordered so the reason column reads "several" for the ones you name and "one" for the ones named for you, with the options table covering the three fields that really are common.

`rune.alias.exact` names an alias for its phrase but `rune.trigger.exact` does not name a trigger, since several triggers can match one line. That is called out on both pages, as it is the one place the rule misleads.
