### PR TITLE
Add window_size_changed Lua hook for responsive layouts

### DIFF
--- a/lua/engine.go
+++ b/lua/engine.go
@@ -462,19 +462,21 @@ func escapeRawJSONControlsInStrings(raw string) string {
 }
 
 // notify dispatches a fire-and-forget event through the Lua hook registry.
-func (e *Engine) notify(event string, args ...string) {
+func (e *Engine) notify(event string, args ...any) {
 	callArgs := make([]any, len(args)+1)
 	callArgs[0] = event
-	for i, arg := range args {
-		callArgs[i+1] = arg
-	}
+	copy(callArgs[1:], args)
 
 	_, found, err := e.callHooks(0, callArgs...)
 	if !found {
 		e.reportHooksBroken()
 		// Errors must never disappear, even with hooks broken.
 		if event == "error" {
-			e.host.Print(text.Red("[Error] " + strings.Join(args, " ")))
+			parts := make([]string, len(args))
+			for i, arg := range args {
+				parts[i] = fmt.Sprint(arg)
+			}
+			e.host.Print(text.Red("[Error] " + strings.Join(parts, " ")))
 		}
 		return
 	}

--- a/lua/events.go
+++ b/lua/events.go
@@ -40,6 +40,12 @@ func (e *Engine) NotifyLoaded(path string) {
 	e.notify("loaded", path)
 }
 
+// NotifyWindowSizeChanged notifies Lua that the terminal size changed.
+// The caller updates rune.state first so handlers see matching values.
+func (e *Engine) NotifyWindowSizeChanged(width, height int) {
+	e.notify("window_size_changed", width, height)
+}
+
 // NotifyInputChanged notifies Lua that the input's current text changed.
 func (e *Engine) NotifyInputChanged(text string) {
 	e.notify("input_changed", text)

--- a/session/mocks_test.go
+++ b/session/mocks_test.go
@@ -128,6 +128,7 @@ type mockUI struct {
 	submissions   []input.Submission
 	inputCursor   []int
 	bindsPushed   map[string]bool // last UpdateBinds payload
+	layoutPushes  int             // UpdateLayout call count
 	events        chan ui.UIEvent
 	done          chan struct{}
 }
@@ -206,7 +207,19 @@ func (m *mockUI) UpdateBinds(keys map[string]bool) {
 	defer m.mu.Unlock()
 	m.bindsPushed = keys
 }
-func (m *mockUI) UpdateLayout(top, bottom []ui.LayoutEntry) {}
+func (m *mockUI) UpdateLayout(top, bottom []ui.LayoutEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.layoutPushes++
+}
+
+func (m *mockUI) drainLayoutPushes() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	n := m.layoutPushes
+	m.layoutPushes = 0
+	return n
+}
 
 func (m *mockUI) pushedBinds() map[string]bool {
 	m.mu.Lock()

--- a/session/session.go
+++ b/session/session.go
@@ -366,6 +366,10 @@ func (s *Session) handleUIEvent(event ui.UIEvent) {
 			_ = s.net.SendFrame(s.connectionID, frame)
 		}
 		s.engine.UpdateState(s.clientState)
+		// State first, then the hook, then bars: handlers observe
+		// matching rune.state values, and a layout or bar change they
+		// make lands in this same resize cycle.
+		s.engine.NotifyWindowSizeChanged(event.Width, event.Height)
 		s.pushBarUpdates()
 	case ui.ScrollStateChangedMsg:
 		s.clientState.ScrollMode = event.Mode
@@ -412,6 +416,12 @@ func (s *Session) boot() error {
 	if err := s.initLua(); err != nil {
 		return err
 	}
+	// A rebuilt VM starts from default state; restore the live client
+	// state before any script runs so init.lua reads real dimensions
+	// and connection status from rune.state. No hook fires for this -
+	// scripts apply their initial layout from state, not from a
+	// synthetic resize event.
+	s.engine.UpdateState(s.clientState)
 	if err := s.loadCoreScripts(); err != nil {
 		return err
 	}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -1138,6 +1140,79 @@ func TestReloadIsDeferredAndRebuildsVM(t *testing.T) {
 	if err := s.engine.DoString("check", `assert(rune.hooks ~= nil)`); err != nil {
 		t.Errorf("scripting broken after reload: %v", err)
 	}
+}
+
+func TestWindowSizeChangeDispatchesHookWithStateInSync(t *testing.T) {
+	s, _, _ := newTestSession(t)
+
+	assertSessionLua(t, s.engine, `
+		captured = nil
+		rune.hooks.on("window_size_changed", function(w, h)
+			captured = {
+				w = w, h = h,
+				w_type = type(w), h_type = type(h),
+				state_w = rune.state.width, state_h = rune.state.height,
+			}
+		end)
+	`)
+
+	// The first reported size and later resizes share this path.
+	s.handleUIEvent(ui.WindowSizeChangedMsg{Width: 120, Height: 40})
+
+	assertSessionLua(t, s.engine, `
+		assert(captured, "window_size_changed did not fire")
+		assert(captured.w_type == "number" and captured.h_type == "number",
+			"args must be numbers")
+		assert(captured.w == 120 and captured.h == 40,
+			"args " .. tostring(captured.w) .. "x" .. tostring(captured.h))
+		assert(captured.state_w == 120 and captured.state_h == 40,
+			"rune.state must already hold the new size during the callback")
+	`)
+}
+
+func TestResizeHookLayoutChangeAppliesInSameCycle(t *testing.T) {
+	s, _, uiMock := newTestSession(t)
+
+	assertSessionLua(t, s.engine, `
+		rune.hooks.on("window_size_changed", function(w)
+			if w < 80 then
+				rune.ui.layout({ bottom = { "input" } })
+			end
+		end)
+	`)
+	uiMock.drainLayoutPushes()
+
+	s.handleUIEvent(ui.WindowSizeChangedMsg{Width: 60, Height: 40})
+
+	if uiMock.drainLayoutPushes() == 0 {
+		t.Error("layout change from a resize handler was not pushed during the resize cycle")
+	}
+}
+
+func TestReloadRestoresDimensionsWithoutSyntheticResize(t *testing.T) {
+	s, _, _ := newTestSession(t)
+	s.handleUIEvent(ui.WindowSizeChangedMsg{Width: 100, Height: 30})
+
+	initLua := `
+		width_at_load = rune.state.width
+		height_at_load = rune.state.height
+		resize_fired = false
+		rune.hooks.on("window_size_changed", function() resize_fired = true end)
+	`
+	initPath := filepath.Join(s.config.ConfigDir, "init.lua")
+	if err := os.WriteFile(initPath, []byte(initLua), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	s.handleReloadRequested()
+
+	assertSessionLua(t, s.engine, `
+		assert(width_at_load == 100 and height_at_load == 30,
+			"init.lua must see the restored size, got " ..
+			tostring(width_at_load) .. "x" .. tostring(height_at_load))
+		assert(rune.state.width == 100 and rune.state.height == 30)
+		assert(resize_fired == false, "reload must not fire a synthetic resize")
+	`)
 }
 
 func TestHistoryDedupAndTrim(t *testing.T) {

--- a/website/src/content/docs/reference/api/hooks.md
+++ b/website/src/content/docs/reference/api/hooks.md
@@ -141,8 +141,26 @@ All handlers run; return values are ignored.
 | `loaded` | path | After `/load` or `rune.load` loads a file (not for startup auto-load) |
 | `error` | message | On reported errors |
 | `input_changed` | text | As the input line changes while typing |
+| `window_size_changed` | width, height | On the first reported terminal size and every resize; `rune.state.width`/`height` already hold the new values |
 | `gmcp` | package, data, raw JSON | On every GMCP message, before package-specific `rune.gmcp.on` handlers |
 | `gmcp_enabled` | none | GMCP negotiated; the core handler sends `Core.Hello` |
+
+`window_size_changed` receives the terminal columns and rows as numbers,
+so a script can switch layouts at its own breakpoint:
+
+```lua
+rune.hooks.on("window_size_changed", function(width, height)
+    if width < 80 then
+        rune.ui.layout({ bottom = { "input" } })
+    else
+        rune.ui.layout({ bottom = { "input", "status" } })
+    end
+end)
+```
+
+`/reload` does not fire it; apply your initial layout from
+`rune.state.width` when your script loads, and use the hook for later
+changes.
 
 ## Named core handlers
 

--- a/website/src/content/docs/reference/api/state-lines.md
+++ b/website/src/content/docs/reference/api/state-lines.md
@@ -40,6 +40,10 @@ the current values, and writing any field raises an error.
 | `width` | number | Terminal width in columns |
 | `height` | number | Terminal height in rows |
 
+To react to resizes rather than poll, register a
+[`window_size_changed` hook](/reference/api/hooks/#notification-events);
+it fires with the new width and height after these fields update.
+
 Because it's always current, `rune.state` is the natural input for
 [bar renderers](/interface/bars/):
 


### PR DESCRIPTION
Closes #100.

Scripts can now react when the terminal is resized:

```lua
rune.hooks.on("window_size_changed", function(width, height)
    -- width is columns, height is rows
end)
```

It fires for the first reported size and every resize after that. It is a normal notification hook, so priorities, groups, and failure quarantine all work as usual.

On a resize, the Session updates its state, reports the size through NAWS, updates `rune.state`, dispatches the hook, then refreshes bars. That order means `rune.state.width`/`height` always match the callback arguments, and a layout change made inside the handler takes effect during the same resize cycle.

This also fixes a gap on `/reload`: the rebuilt Lua VM used to start with default state (width 0, disconnected) until the next state change. Boot now restores the live client state before any script runs, so `init.lua` can read real dimensions from `rune.state` right away. Reload does not fire a synthetic resize event.

Tests cover hook dispatch with numeric args, state/callback agreement, same-cycle layout changes, and reload keeping the dimensions without firing the hook. The hook reference documents the new event.