### PR TITLE
Add numpad key support

### DIFF
--- a/lua/api_config.go
+++ b/lua/api_config.go
@@ -14,6 +14,7 @@ type Config struct {
 	CommandSeparator string
 	HistoryCharacter string
 	KeepInput        bool
+	Numpad           bool
 }
 
 func defaultConfig() Config {
@@ -21,6 +22,7 @@ func defaultConfig() Config {
 		CommandSeparator: ";",
 		HistoryCharacter: "!",
 		KeepInput:        false,
+		Numpad:           false,
 	}
 }
 
@@ -50,6 +52,8 @@ func (e *Engine) registerConfigFuncs() {
 				c.Return(e.config.HistoryCharacter)
 			case "keep_input":
 				c.Return(e.config.KeepInput)
+			case "numpad":
+				c.Return(e.config.Numpad)
 			default:
 				return c.Errorf("unknown config key %q", key)
 			}
@@ -85,6 +89,8 @@ func (e *Engine) registerConfigFuncs() {
 				e.config.HistoryCharacter = value
 			case "keep_input":
 				e.config.KeepInput = c.Bool(2)
+			case "numpad":
+				e.config.Numpad = c.Bool(2)
 			default:
 				return c.Errorf("unknown config key %q", key)
 			}

--- a/lua/config_test.go
+++ b/lua/config_test.go
@@ -13,6 +13,7 @@ func TestConfigGetReturnsGoDefaults(t *testing.T) {
 		assert(rune.config.get("command_separator") == ";")
 		assert(rune.config.get("history_character") == "!")
 		assert(rune.config.get("keep_input") == false)
+		assert(rune.config.get("numpad") == false)
 	`); err != nil {
 		t.Fatalf("read config defaults: %v", err)
 	}
@@ -25,6 +26,8 @@ func TestConfigSetUpdatesRecognizedValue(t *testing.T) {
 	if err := engine.DoString("set config", `
 		rune.config.set("keep_input", true)
 		assert(rune.config.get("keep_input") == true)
+		rune.config.set("numpad", true)
+		assert(rune.config.get("numpad") == true)
 	`); err != nil {
 		t.Fatalf("set recognized config value: %v", err)
 	}
@@ -146,6 +149,7 @@ func TestConfigBootPublishesOneFinalTypedConfig(t *testing.T) {
 		rune.config.set("command_separator", "|")
 		rune.config.set("history_character", "^")
 		rune.config.set("keep_input", true)
+		rune.config.set("numpad", true)
 	`); err != nil {
 		t.Fatalf("stage config during boot: %v", err)
 	}
@@ -156,7 +160,7 @@ func TestConfigBootPublishesOneFinalTypedConfig(t *testing.T) {
 	engine.CommitConfig()
 	engine.CommitConfig()
 
-	want := []Config{{CommandSeparator: "|", HistoryCharacter: "^", KeepInput: true}}
+	want := []Config{{CommandSeparator: "|", HistoryCharacter: "^", KeepInput: true, Numpad: true}}
 	if got := host.DrainConfigChanges(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("committed config publications = %+v, want %+v", got, want)
 	}
@@ -208,6 +212,24 @@ func TestConfigRuntimeChangePublishesTypedConfigImmediately(t *testing.T) {
 	}
 }
 
+func TestConfigNumpadRuntimeChangePublishesImmediately(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+	engine.CommitConfig()
+	host.DrainConfigChanges()
+
+	if err := engine.DoString("enable numpad", `
+		rune.config.set("numpad", true)
+	`); err != nil {
+		t.Fatalf("change numpad config: %v", err)
+	}
+
+	want := []Config{{CommandSeparator: ";", HistoryCharacter: "!", Numpad: true}}
+	if got := host.DrainConfigChanges(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("numpad config publications = %+v, want %+v", got, want)
+	}
+}
+
 func TestPresentationChangesDoNotRepublishConfig(t *testing.T) {
 	engine, host, cleanup := setupTest(t)
 	defer cleanup()
@@ -242,6 +264,9 @@ func TestConfigRejectsWrongTypeWithoutMutation(t *testing.T) {
 		local ok = pcall(rune.config.set, "keep_input", "yes")
 		assert(not ok)
 		assert(rune.config.get("keep_input") == true)
+		ok = pcall(rune.config.set, "numpad", "yes")
+		assert(not ok)
+		assert(rune.config.get("numpad") == false)
 	`); err != nil {
 		t.Fatalf("validate config type before mutation: %v", err)
 	}
@@ -260,6 +285,7 @@ func TestConfigRejectsUnknownKeys(t *testing.T) {
 		assert(rune.config.get("command_separator") == ";")
 		assert(rune.config.get("history_character") == "!")
 		assert(rune.config.get("keep_input") == false)
+		assert(rune.config.get("numpad") == false)
 	`); err != nil {
 		t.Fatalf("reject unknown config keys: %v", err)
 	}

--- a/session/lua_state.go
+++ b/session/lua_state.go
@@ -9,7 +9,10 @@ import (
 // typed, one-way boundary; it never re-enters Lua or invalidates unrelated
 // presentation state.
 func (s *Session) OnConfigChange(config lua.Config) {
-	s.ui.UpdateConfig(ui.Config{KeepInput: config.KeepInput})
+	s.ui.UpdateConfig(ui.Config{
+		KeepInput: config.KeepInput,
+		Numpad:    config.Numpad,
+	})
 }
 
 // OnPresentationChange implements lua.Host.

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1322,6 +1322,9 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 	if uiMock.pushedConfig().KeepInput {
 		t.Fatal("keep_input must default off")
 	}
+	if uiMock.pushedConfig().Numpad {
+		t.Fatal("numpad must default off")
+	}
 
 	assertSessionLua(t, s.engine, `rune.config.set("keep_input", true)`)
 	if !uiMock.pushedConfig().KeepInput {
@@ -1332,8 +1335,16 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 		t.Fatalf("runtime config pushes = %+v, want one keep_input=true", pushes)
 	}
 
+	assertSessionLua(t, s.engine, `rune.config.set("numpad", true)`)
+	if !uiMock.pushedConfig().Numpad {
+		t.Fatal("numpad=true did not reach the UI")
+	}
+	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || !pushes[0].Numpad {
+		t.Fatalf("runtime config pushes = %+v, want one numpad=true", pushes)
+	}
+
 	// Parser settings use the same config publication path. Each update must
-	// retain the current UI-facing keep_input value.
+	// retain the current UI-facing values.
 	assertSessionLua(t, s.engine, `
 		rune.config.set("command_separator", "|")
 		rune.config.set("history_character", "^")
@@ -1343,8 +1354,8 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 		t.Fatalf("parser config pushes = %+v, want exactly two snapshots", pushes)
 	}
 	for i, push := range pushes {
-		if !push.KeepInput {
-			t.Fatalf("parser config push %d reset keep_input: %+v", i, push)
+		if !push.KeepInput || !push.Numpad {
+			t.Fatalf("parser config push %d reset UI config: %+v", i, push)
 		}
 	}
 
@@ -1353,7 +1364,10 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 	if uiMock.pushedConfig().KeepInput {
 		t.Fatal("reload did not reset keep_input to its default")
 	}
-	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || pushes[0].KeepInput {
+	if uiMock.pushedConfig().Numpad {
+		t.Fatal("reload did not reset numpad to its default")
+	}
+	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || pushes[0].KeepInput || pushes[0].Numpad {
 		t.Fatalf("default reload pushes = %+v, want exactly one final false snapshot", pushes)
 	}
 	assertSessionLua(t, s.engine, `
@@ -1367,6 +1381,7 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 rune.config.set("command_separator", "||")
 rune.config.set("history_character", "?")
 rune.config.set("keep_input", true)
+rune.config.set("numpad", true)
 `
 	if err := os.WriteFile(initPath, []byte(initLua), 0o644); err != nil {
 		t.Fatal(err)
@@ -1375,13 +1390,17 @@ rune.config.set("keep_input", true)
 	if !uiMock.pushedConfig().KeepInput {
 		t.Fatal("reload did not reapply keep_input from init.lua")
 	}
-	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || !pushes[0].KeepInput {
+	if !uiMock.pushedConfig().Numpad {
+		t.Fatal("reload did not reapply numpad from init.lua")
+	}
+	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || !pushes[0].KeepInput || !pushes[0].Numpad {
 		t.Fatalf("configured reload pushes = %+v, want exactly one final true snapshot", pushes)
 	}
 	assertSessionLua(t, s.engine, `
 		assert(rune.config.get("command_separator") == "||")
 		assert(rune.config.get("history_character") == "?")
 		assert(rune.config.get("keep_input") == true)
+		assert(rune.config.get("numpad") == true)
 	`)
 }
 

--- a/ui/messages.go
+++ b/ui/messages.go
@@ -72,6 +72,9 @@ type Config struct {
 	// KeepInput keeps a submitted command selected in the input line, so Enter
 	// resends it and typing replaces it.
 	KeepInput bool
+	// Numpad asks terminals with legacy keypad support to report physical
+	// numpad keys separately from their number-row equivalents.
+	Numpad bool
 }
 
 // UpdateConfigMsg pushes UI-facing configuration from Session to UI.

--- a/ui/tui/input_mode.go
+++ b/ui/tui/input_mode.go
@@ -85,6 +85,7 @@ func newInputController(
 // breaking typing). Unbound scroll keys fall back to Go so scrollback
 // stays usable even in degraded mode.
 func (c *inputController) HandleKey(msg tea.KeyPressMsg) {
+	msg = normalizeNumpadText(msg)
 	isEscape := matchesKey(msg, tea.KeyEsc, 0)
 	if c.mode == ModeCompose && !isEscape {
 		c.input.ContinueCompose()
@@ -212,7 +213,19 @@ func (c *inputController) SetSubmission(submission input.Submission) {
 	}
 }
 
+func (c *inputController) dispatchNumpadEnterBind(msg tea.KeyPressMsg) bool {
+	name, _, ok := numpadKey(msg)
+	if !ok || name != "numpad_enter" || msg.Mod&keyModifiers != 0 || !c.isBound(name) {
+		return false
+	}
+	c.notify(ui.ExecuteBindMsg(name))
+	return true
+}
+
 func (c *inputController) handleNormalKey(msg tea.KeyPressMsg) {
+	if c.dispatchNumpadEnterBind(msg) {
+		return
+	}
 	// Accept both portable Ctrl+J and disambiguated Ctrl+Enter as the explicit
 	// way to start a multiline draft without pasting.
 	if isComposerNewline(msg) {
@@ -245,6 +258,9 @@ func (c *inputController) handleNormalKey(msg tea.KeyPressMsg) {
 }
 
 func (c *inputController) handleComposeKey(msg tea.KeyPressMsg) {
+	if c.dispatchNumpadEnterBind(msg) {
+		return
+	}
 	if matchesEnterKey(msg, 0) {
 		c.submitInput()
 		return

--- a/ui/tui/input_mode_test.go
+++ b/ui/tui/input_mode_test.go
@@ -294,6 +294,133 @@ func TestKeypadEnterSubmitsNormalAndComposerInput(t *testing.T) {
 	}
 }
 
+func TestNumpadBindUsesSameNameAcrossInputEncodings(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.KeyPressMsg
+	}{
+		{name: "DECKPAM", msg: tea.KeyPressMsg{Code: tea.KeyKp8}},
+		{name: "kitty", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Text: "8"}},
+		{name: "win32", msg: tea.KeyPressMsg{Code: '8', BaseCode: tea.KeyKp8, Text: "8"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newControllerHarness()
+			h.bound["numpad8"] = true
+
+			h.ctl.HandleKey(tt.msg)
+
+			if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("numpad8") {
+				t.Fatalf("numpad binds = %v, want [numpad8]", binds)
+			}
+			if got := h.ctl.input.Value(); got != "" {
+				t.Fatalf("bound numpad key typed %q", got)
+			}
+		})
+	}
+}
+
+func TestModifiedNumpadBindUsesSameNameAcrossInputEncodings(t *testing.T) {
+	encodings := []struct {
+		name string
+		msg  tea.KeyPressMsg
+	}{
+		{name: "DECKPAM", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModCtrl}},
+		{name: "kitty", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModCtrl}},
+		{name: "win32", msg: tea.KeyPressMsg{Code: '8', BaseCode: tea.KeyKp8, Text: "8", Mod: tea.ModCtrl}},
+	}
+	modes := []struct {
+		name  string
+		draft string
+	}{
+		{name: "normal", draft: "look"},
+		{name: "composer", draft: "say one\nsay two"},
+	}
+
+	for _, encoding := range encodings {
+		for _, mode := range modes {
+			t.Run(encoding.name+"/"+mode.name, func(t *testing.T) {
+				h := newControllerHarness()
+				h.bound["ctrl+numpad8"] = true
+				h.ctl.SetText(mode.draft)
+				h.events = nil
+
+				h.ctl.HandleKey(encoding.msg)
+
+				if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("ctrl+numpad8") {
+					t.Fatalf("modified numpad binds = %v, want [ctrl+numpad8]", binds)
+				}
+				if got := h.ctl.input.Value(); got != mode.draft {
+					t.Fatalf("modified numpad key changed input to %q", got)
+				}
+			})
+		}
+	}
+}
+
+func TestUnboundDECKPAMKeysTypeTheirCharacters(t *testing.T) {
+	h := newControllerHarness()
+
+	h.ctl.HandleKey(keyPress(tea.KeyKp8))
+	h.ctl.HandleKey(keyPress(tea.KeyKpMinus))
+	h.ctl.HandleKey(keyPress(tea.KeyKpEqual))
+
+	if got := h.ctl.input.Value(); got != "8-=" {
+		t.Fatalf("unbound DECKPAM input = %q, want %q", got, "8-=")
+	}
+	if binds := h.executeBinds(); len(binds) != 0 {
+		t.Fatalf("unbound DECKPAM keys dispatched binds: %v", binds)
+	}
+}
+
+func TestBoundNumpadEnterPrecedesSubmit(t *testing.T) {
+	tests := []struct {
+		name  string
+		draft string
+	}{
+		{name: "normal", draft: "look"},
+		{name: "composer", draft: "say one\nsay two"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newControllerHarness()
+			h.bound["numpad_enter"] = true
+			h.ctl.SetText(tt.draft)
+			h.events = nil
+
+			h.ctl.HandleKey(keyPress(tea.KeyKpEnter))
+
+			if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("numpad_enter") {
+				t.Fatalf("numpad Enter binds = %v, want [numpad_enter]", binds)
+			}
+			if len(h.submitted) != 0 {
+				t.Fatalf("bound numpad Enter submitted input: %+v", h.submitted)
+			}
+			if got := h.ctl.input.Value(); got != tt.draft {
+				t.Fatalf("bound numpad Enter changed draft to %q, want %q", got, tt.draft)
+			}
+		})
+	}
+}
+
+func TestBoundCtrlNumpadEnterKeepsReservedNewline(t *testing.T) {
+	h := newControllerHarness()
+	h.bound["ctrl+numpad_enter"] = true
+	h.ctl.SetText("hello")
+	h.events = nil
+
+	h.ctl.HandleKey(ctrlPress(tea.KeyKpEnter))
+
+	if got := h.ctl.input.Value(); got != "hello\n" {
+		t.Fatalf("input after Ctrl+numpad Enter = %q, want %q", got, "hello\n")
+	}
+	if binds := h.executeBinds(); len(binds) != 0 {
+		t.Fatalf("Ctrl+numpad Enter delegated to Lua: %v", binds)
+	}
+}
+
 // TestBracketedPasteBypassesPrintableBind guards the atomic-paste path: a
 // one-character paste must be inserted as data even when that same printable
 // key is configured as a hotkey for an empty input line.

--- a/ui/tui/keys.go
+++ b/ui/tui/keys.go
@@ -19,7 +19,76 @@ func matchesEnterKey(msg tea.KeyPressMsg, modifiers tea.KeyMod) bool {
 	return isEnterKey(msg) && msg.Mod&keyModifiers == modifiers
 }
 
-// keyToString returns Bubble Tea's canonical name at the Go/Lua bind boundary.
+// numpadCode returns Rune's bind name and printable fallback for a physical
+// numpad key code. Enter has no printable fallback; equal and comma have no
+// public bind name but still type normally.
+func numpadCode(code rune) (name, text string, ok bool) {
+	if code >= tea.KeyKp0 && code <= tea.KeyKp9 {
+		digit := string(rune('0') + code - tea.KeyKp0)
+		return "numpad" + digit, digit, true
+	}
+	switch code {
+	case tea.KeyKpEnter:
+		return "numpad_enter", "", true
+	case tea.KeyKpPlus:
+		return "numpad_plus", "+", true
+	case tea.KeyKpMinus:
+		return "numpad_minus", "-", true
+	case tea.KeyKpMultiply:
+		return "numpad_star", "*", true
+	case tea.KeyKpDivide:
+		return "numpad_slash", "/", true
+	case tea.KeyKpDecimal:
+		return "numpad_dot", ".", true
+	case tea.KeyKpEqual:
+		return "", "=", true
+	case tea.KeyKpComma, tea.KeyKpSep:
+		return "", ",", true
+	default:
+		return "", "", false
+	}
+}
+
+// numpadKey recognizes both the direct KeyKp* form used by SS3/kitty input
+// and the BaseCode form used by win32 input.
+func numpadKey(msg tea.KeyPressMsg) (name, text string, ok bool) {
+	if name, text, ok = numpadCode(msg.BaseCode); ok {
+		return name, text, true
+	}
+	return numpadCode(msg.Code)
+}
+
+func normalizeNumpadText(msg tea.KeyPressMsg) tea.KeyPressMsg {
+	_, text, ok := numpadKey(msg)
+	if !ok || text == "" {
+		return msg
+	}
+	if msg.Mod&(keyModifiers&^tea.ModShift) != 0 {
+		// Win32 input supplies the ordinary keypad character even for
+		// modified chords. Remove that synthetic text so the same chord
+		// routes like SS3 and kitty input, while preserving real AltGr text.
+		if msg.Text == text {
+			msg.Text = ""
+		}
+		return msg
+	}
+	if msg.Text == "" {
+		msg.Text = text
+	}
+	return msg
+}
+
+// keyToString returns Rune's canonical name at the Go/Lua bind boundary.
 func keyToString(msg tea.KeyPressMsg) string {
+	if name, _, ok := numpadKey(msg); ok {
+		if name == "" {
+			return ""
+		}
+		// Reuse Bubble Tea's modifier spelling and ordering while replacing its
+		// deliberately collapsed keypad name with Rune's physical-key name.
+		msg.Code = tea.KeyExtended
+		msg.BaseCode = 0
+		msg.Text = name
+	}
 	return msg.Keystroke()
 }

--- a/ui/tui/keys_test.go
+++ b/ui/tui/keys_test.go
@@ -14,7 +14,7 @@ func TestKeyToStringUsesCanonicalV2Names(t *testing.T) {
 	}{
 		{name: "escape", msg: tea.KeyPressMsg{Code: tea.KeyEsc}, want: "esc"},
 		{name: "page up", msg: tea.KeyPressMsg{Code: tea.KeyPgUp}, want: "pgup"},
-		{name: "keypad enter", msg: tea.KeyPressMsg{Code: tea.KeyKpEnter}, want: "enter"},
+		{name: "number row", msg: tea.KeyPressMsg{Code: '8', Text: "8"}, want: "8"},
 		{name: "modified navigation", msg: tea.KeyPressMsg{Code: tea.KeyHome, Mod: tea.ModCtrl}, want: "ctrl+home"},
 		{name: "extended function key", msg: tea.KeyPressMsg{Code: tea.KeyF20}, want: "f20"},
 		{name: "highest function key", msg: tea.KeyPressMsg{Code: tea.KeyF63}, want: "f63"},
@@ -28,5 +28,99 @@ func TestKeyToStringUsesCanonicalV2Names(t *testing.T) {
 				t.Fatalf("keyToString(%#v) = %q, want %q", tt.msg, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestKeyToStringUsesCanonicalNumpadNames(t *testing.T) {
+	tests := []struct {
+		code rune
+		want string
+	}{
+		{tea.KeyKp0, "numpad0"},
+		{tea.KeyKp1, "numpad1"},
+		{tea.KeyKp2, "numpad2"},
+		{tea.KeyKp3, "numpad3"},
+		{tea.KeyKp4, "numpad4"},
+		{tea.KeyKp5, "numpad5"},
+		{tea.KeyKp6, "numpad6"},
+		{tea.KeyKp7, "numpad7"},
+		{tea.KeyKp8, "numpad8"},
+		{tea.KeyKp9, "numpad9"},
+		{tea.KeyKpDecimal, "numpad_dot"},
+		{tea.KeyKpDivide, "numpad_slash"},
+		{tea.KeyKpMultiply, "numpad_star"},
+		{tea.KeyKpMinus, "numpad_minus"},
+		{tea.KeyKpPlus, "numpad_plus"},
+		{tea.KeyKpEnter, "numpad_enter"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			if got := keyToString(tea.KeyPressMsg{Code: tt.code}); got != tt.want {
+				t.Fatalf("keyToString(Code=%v) = %q, want %q", tt.code, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNumpadNameNormalizesInputEncodingsAndModifiers(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.KeyPressMsg
+		want string
+	}{
+		{name: "DECKPAM", msg: tea.KeyPressMsg{Code: tea.KeyKp8}, want: "numpad8"},
+		{name: "kitty", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Text: "8"}, want: "numpad8"},
+		{name: "win32", msg: tea.KeyPressMsg{Code: '8', BaseCode: tea.KeyKp8, Text: "8"}, want: "numpad8"},
+		{name: "modifier", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModCtrl}, want: "ctrl+numpad8"},
+		{name: "NumLock", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Text: "8", Mod: tea.ModNumLock}, want: "numpad8"},
+		{name: "Enter distinct from minus", msg: tea.KeyPressMsg{Code: tea.KeyKpEnter}, want: "numpad_enter"},
+		{name: "minus distinct from Enter", msg: tea.KeyPressMsg{Code: tea.KeyKpMinus}, want: "numpad_minus"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := keyToString(tt.msg); got != tt.want {
+				t.Fatalf("keyToString(%#v) = %q, want %q", tt.msg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeNumpadTextFillsOnlyPrintableUnmodifiedKeys(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  tea.KeyPressMsg
+		want string
+	}{
+		{name: "digit", msg: tea.KeyPressMsg{Code: tea.KeyKp8}, want: "8"},
+		{name: "operator", msg: tea.KeyPressMsg{Code: tea.KeyKpMinus}, want: "-"},
+		{name: "equal", msg: tea.KeyPressMsg{Code: tea.KeyKpEqual}, want: "="},
+		{name: "comma", msg: tea.KeyPressMsg{Code: tea.KeyKpComma}, want: ","},
+		{name: "separator", msg: tea.KeyPressMsg{Code: tea.KeyKpSep}, want: ","},
+		{name: "Shift", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModShift}, want: "8"},
+		{name: "NumLock", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModNumLock}, want: "8"},
+		{name: "existing text", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Text: "existing"}, want: "existing"},
+		{name: "Enter", msg: tea.KeyPressMsg{Code: tea.KeyKpEnter}, want: ""},
+		{name: "Ctrl chord", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModCtrl}, want: ""},
+		{name: "Alt chord", msg: tea.KeyPressMsg{Code: tea.KeyKp8, Mod: tea.ModAlt}, want: ""},
+		{name: "win32 Ctrl chord", msg: tea.KeyPressMsg{Code: '8', BaseCode: tea.KeyKp8, Text: "8", Mod: tea.ModCtrl}, want: ""},
+		{name: "AltGr text", msg: tea.KeyPressMsg{Code: '@', BaseCode: tea.KeyKp8, Text: "@", Mod: tea.ModCtrl | tea.ModAlt}, want: "@"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeNumpadText(tt.msg).Text; got != tt.want {
+				t.Fatalf("normalized Text = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUndocumentedNumpadKeysDoNotCollideWithOrdinaryBinds(t *testing.T) {
+	for _, code := range []rune{tea.KeyKpEqual, tea.KeyKpComma, tea.KeyKpSep} {
+		if got := keyToString(tea.KeyPressMsg{Code: code}); got != "" {
+			t.Fatalf("keyToString(Code=%v) = %q, want no bind name", code, got)
+		}
 	}
 }

--- a/ui/tui/tui.go
+++ b/ui/tui/tui.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
@@ -8,6 +9,7 @@ import (
 	"sync"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/mmcdole/rune/input"
 	"github.com/mmcdole/rune/ui"
@@ -16,6 +18,7 @@ import (
 // BubbleTeaUI implements ui.UI with Bubble Tea.
 type BubbleTeaUI struct {
 	program *tea.Program
+	output  io.Writer
 
 	// Message queue - buffered channel drained by a single goroutine.
 	// This decouples callers from tea.Program.Send() which can block.
@@ -28,6 +31,10 @@ type BubbleTeaUI struct {
 	// Shutdown coordination
 	done     chan struct{}
 	doneOnce sync.Once
+
+	keypadMu         sync.Mutex
+	keypadConfigured bool
+	keypadEnabled    bool
 }
 
 // NewBubbleTeaUI creates a new Bubble Tea-based UI.
@@ -36,7 +43,35 @@ func NewBubbleTeaUI() *BubbleTeaUI {
 		msgQueue: make(chan tea.Msg, 4096),
 		events:   make(chan ui.UIEvent, 2048),
 		done:     make(chan struct{}),
+		output:   os.Stdout,
 	}
+}
+
+func keypadModeSequence(enabled bool) string {
+	if enabled {
+		return ansi.KeypadApplicationMode
+	}
+	return ansi.KeypadNumericMode
+}
+
+func (b *BubbleTeaUI) writeKeypadMode(enabled bool) error {
+	_, err := io.WriteString(b.output, keypadModeSequence(enabled))
+	return err
+}
+
+func (b *BubbleTeaUI) updateKeypadMode(enabled bool) bool {
+	b.keypadMu.Lock()
+	defer b.keypadMu.Unlock()
+	changed := !b.keypadConfigured || b.keypadEnabled != enabled
+	b.keypadConfigured = true
+	b.keypadEnabled = enabled
+	return changed
+}
+
+func (b *BubbleTeaUI) keypadMode() bool {
+	b.keypadMu.Lock()
+	defer b.keypadMu.Unlock()
+	return b.keypadEnabled
 }
 
 // send queues a message for delivery to the Bubble Tea program.
@@ -72,9 +107,20 @@ func (b *BubbleTeaUI) CommitPrompt(text string) {
 }
 
 // Run starts the TUI and blocks until exit.
-func (b *BubbleTeaUI) Run() error {
+func (b *BubbleTeaUI) Run() (err error) {
 	model := NewModel(b.events)
-	b.program = tea.NewProgram(model)
+	b.program = tea.NewProgram(model, tea.WithOutput(b.output))
+
+	defer func() {
+		if resetErr := b.writeKeypadMode(false); err == nil {
+			err = resetErr
+		}
+		// The queue is deliberately never closed: send races the done signal
+		// in a select, and closing it would make a late Print panic.
+		b.doneOnce.Do(func() {
+			close(b.done)
+		})
+	}()
 
 	// Single goroutine drains message queue to Bubble Tea.
 	// This can block on Send() without affecting producers.
@@ -90,15 +136,7 @@ func (b *BubbleTeaUI) Run() error {
 	}()
 
 	// Run blocks until quit
-	_, err := b.program.Run()
-
-	// Signal shutdown. The queue is deliberately never closed: send()
-	// races the done signal in a select, and closing the channel would
-	// turn a late Print from the session into a send-on-closed panic.
-	b.doneOnce.Do(func() {
-		close(b.done)
-	})
-
+	_, err = b.program.Run()
 	return err
 }
 
@@ -156,7 +194,11 @@ func (b *BubbleTeaUI) UpdateLayout(top, bottom []ui.LayoutEntry) {
 
 // UpdateConfig sends UI-facing configuration from Session to UI.
 func (b *BubbleTeaUI) UpdateConfig(cfg ui.Config) {
+	keypadChanged := b.updateKeypadMode(cfg.Numpad)
 	b.send(ui.UpdateConfigMsg(cfg))
+	if keypadChanged {
+		b.send(tea.RawMsg{Msg: keypadModeSequence(cfg.Numpad)})
+	}
 }
 
 // ShowPicker displays a picker overlay with items.
@@ -216,8 +258,10 @@ func (b *BubbleTeaUI) OpenEditor(initial string) (string, bool) {
 
 	// Suspend TUI
 	if err := b.program.ReleaseTerminal(); err != nil {
+		_ = b.writeKeypadMode(false)
 		return "", false
 	}
+	_ = b.writeKeypadMode(false)
 
 	// Run editor. The fallback must exist on the platform: vi ships
 	// with effectively every Unix, notepad with every Windows.
@@ -235,11 +279,10 @@ func (b *BubbleTeaUI) OpenEditor(initial string) (string, bool) {
 
 	// Resume TUI
 	restoreErr := b.program.RestoreTerminal()
-	if err == nil && restoreErr != nil {
-		err = restoreErr
+	if restoreErr == nil {
+		_ = b.writeKeypadMode(b.keypadMode())
 	}
-
-	if err != nil {
+	if err != nil || restoreErr != nil {
 		return "", false
 	}
 

--- a/ui/tui/tui_test.go
+++ b/ui/tui/tui_test.go
@@ -1,6 +1,69 @@
 package tui
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/mmcdole/rune/ui"
+)
+
+func TestKeypadModeSequence(t *testing.T) {
+	if got := keypadModeSequence(true); got != ansi.KeypadApplicationMode {
+		t.Fatalf("enabled keypad sequence = %q, want %q", got, ansi.KeypadApplicationMode)
+	}
+	if got := keypadModeSequence(false); got != ansi.KeypadNumericMode {
+		t.Fatalf("disabled keypad sequence = %q, want %q", got, ansi.KeypadNumericMode)
+	}
+}
+
+func TestUpdateConfigQueuesKeypadModeOnlyWhenItChanges(t *testing.T) {
+	b := NewBubbleTeaUI()
+
+	b.UpdateConfig(ui.Config{Numpad: false})
+	if msg := <-b.msgQueue; msg != (ui.UpdateConfigMsg{Numpad: false}) {
+		t.Fatalf("first queued message = %#v, want disabled config", msg)
+	}
+	if msg := <-b.msgQueue; msg != (tea.RawMsg{Msg: ansi.KeypadNumericMode}) {
+		t.Fatalf("second queued message = %#v, want numeric keypad mode", msg)
+	}
+
+	b.UpdateConfig(ui.Config{KeepInput: true, Numpad: false})
+	if msg := <-b.msgQueue; msg != (ui.UpdateConfigMsg{KeepInput: true, Numpad: false}) {
+		t.Fatalf("unchanged keypad config message = %#v", msg)
+	}
+	if got := len(b.msgQueue); got != 0 {
+		t.Fatalf("unchanged keypad mode queued %d extra messages", got)
+	}
+
+	b.UpdateConfig(ui.Config{KeepInput: true, Numpad: true})
+	if msg := <-b.msgQueue; msg != (ui.UpdateConfigMsg{KeepInput: true, Numpad: true}) {
+		t.Fatalf("enabled keypad config message = %#v", msg)
+	}
+	if msg := <-b.msgQueue; msg != (tea.RawMsg{Msg: ansi.KeypadApplicationMode}) {
+		t.Fatalf("enabled keypad raw message = %#v, want application mode", msg)
+	}
+}
+
+func TestWriteKeypadModeUsesProgramOutput(t *testing.T) {
+	b := NewBubbleTeaUI()
+	var output bytes.Buffer
+	b.output = &output
+
+	if err := b.writeKeypadMode(true); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.writeKeypadMode(false); err != nil {
+		t.Fatal(err)
+	}
+
+	want := ansi.KeypadApplicationMode + ansi.KeypadNumericMode
+	if got := output.String(); got != want {
+		t.Fatalf("keypad lifecycle output = %q, want %q", got, want)
+	}
+}
 
 func TestNormalizeEditorTextPreservesWhitespace(t *testing.T) {
 	tests := []struct {

--- a/website/src/content/docs/reference/api/core.md
+++ b/website/src/content/docs/reference/api/core.md
@@ -169,6 +169,7 @@ rune.config.set(key, value)
 | `command_separator` | non-empty string | `";"` | Text that separates multiple commands entered on one line |
 | `history_character` | empty or one visible, non-space character | `"!"` | Character used for history expansion (`!`, `!!`, `!prefix`); empty disables it |
 | `keep_input` | boolean | `false` | After `Enter`, leave the text you typed selected; `Enter` repeats it and typing replaces it |
+| `numpad` | boolean | `false` | Ask legacy terminals to report physical numpad keys separately; see [Numpad keys](/scripting/keybindings/#numpad-keys) |
 
 An unknown key, a value of the wrong type, an empty `command_separator`, or an
 invalid history character raises an error and leaves the configuration unchanged.
@@ -177,6 +178,7 @@ invalid history character raises an error and leaves the configuration unchanged
 rune.config.set("keep_input", true)
 rune.config.set("command_separator", "|")
 rune.config.set("history_character", "^")
+rune.config.set("numpad", true)
 assert(rune.config.get("keep_input") == true)
 ```
 

--- a/website/src/content/docs/scripting/keybindings.md
+++ b/website/src/content/docs/scripting/keybindings.md
@@ -29,6 +29,8 @@ prefixes are lowercase.
 | Editing | `esc`, `tab`, `backspace`, `delete`, `insert` | `"esc"`, `"shift+tab"`, `"alt+backspace"` |
 | Navigation | `up`, `down`, `left`, `right`, `home`, `end`, `pgup`, `pgdown` | `"left"`, `"ctrl+home"`, `"shift+pgup"` |
 | Function keys | `f1` through `f63` | `"f1"`, `"f13"`, `"f20"` |
+| Numpad digits | `numpad0` through `numpad9` | `"numpad8"`, `"ctrl+numpad4"` |
+| Numpad operators | `numpad_dot`, `numpad_slash`, `numpad_star`, `numpad_minus`, `numpad_plus`, `numpad_enter` | `"numpad_plus"`, `"numpad_enter"` |
 | Modifiers | `ctrl`, `alt`, `shift`, `meta`, `hyper`, `super` | `"ctrl+r"`, `"shift+a"`, `"ctrl+alt+x"` |
 
 For multiple modifiers, use the order `ctrl+alt+shift+meta+hyper+super`, then
@@ -37,7 +39,41 @@ particular, extended function keys, modified navigation keys, and
 `meta`/`hyper`/`super` chords are not available in every terminal.
 
 Key names are exact. Use `esc`, `pgup`, and `pgdown`; `escape`, `pageup`, and
-`pagedown` are not aliases.
+`pagedown` are not aliases. Numpad names begin with `numpad`; `kp8` and
+`kpenter` are not aliases for `numpad8` and `numpad_enter`.
+
+### Numpad keys
+
+Terminals using an enhanced keyboard protocol report physical numpad keys to
+Rune automatically. Older terminals need application keypad mode, which is
+off by default. Enable it in `init.lua`:
+
+```lua
+rune.config.set("numpad", true)
+```
+
+The setting takes effect immediately. Turning it off returns the terminal to
+numeric keypad mode; Rune also does that while `$EDITOR` is open and whenever
+the client exits.
+
+NumLock generally needs to be on. Some legacy terminals, including urxvt and
+some xterm configurations, report application-keypad sequences only with it
+off. With no matching bind, numpad digits and operators type their usual
+characters, and `numpad_enter` acts like `enter`. In normal input, bound numpad
+digits and operators follow the same empty-or-selected rule as other printable
+binds.
+
+Terminal support varies. On a system with `timeout`, this probe requests
+application keypad mode for ten seconds and then restores the terminal:
+
+```sh
+(saved=$(stty -g); trap 'stty "$saved"; printf "\033>"' EXIT; printf '\033='; stty raw -echo; timeout 10 cat -v)
+```
+
+Press a numpad key while it runs. `^[Ox` for numpad 8 means the terminal
+supports application keypad mode; a bare `8` means it does not. Enhanced
+keyboard-protocol terminals may still support Rune's numpad binds even when
+this legacy probe prints a digit.
 
 ### Reserved input keys
 
@@ -98,6 +134,16 @@ Movement keys, grouped:
 rune.bind("f5", function() rune.send("north") end, { group = "movement" })
 rune.bind("f6", function() rune.send("south") end, { group = "movement" })
 -- /group movement off
+```
+
+Numpad movement:
+
+```lua
+rune.config.set("numpad", true) -- needed only for legacy terminal input
+rune.bind("numpad8", function() rune.send("north") end)
+rune.bind("numpad2", function() rune.send("south") end)
+rune.bind("numpad6", function() rune.send("east") end)
+rune.bind("numpad4", function() rune.send("west") end)
 ```
 
 Editing helpers using the input API:


### PR DESCRIPTION
Closes #91.

## Summary
- add the opt-in `numpad` setting and clean application-keypad lifecycle handling
- normalize SS3, Kitty, and Win32 numpad events to canonical bind names while preserving unbound typing
- document numpad names, configuration, and terminal caveats

## Testing
- `go test ./... -count=1`
- `go test -race ./...`
- `go vet ./...`
- Windows `ui/tui` cross-compile
- website build
- headless tmux input and terminal-lifecycle verification