### PR TITLE
Make mouse capture opt-in

### DIFF
--- a/lua/api_config.go
+++ b/lua/api_config.go
@@ -15,6 +15,7 @@ type Config struct {
 	HistoryCharacter string
 	KeepInput        bool
 	Numpad           bool
+	Mouse            bool
 }
 
 func defaultConfig() Config {
@@ -23,6 +24,7 @@ func defaultConfig() Config {
 		HistoryCharacter: "!",
 		KeepInput:        false,
 		Numpad:           false,
+		Mouse:            false,
 	}
 }
 
@@ -54,6 +56,8 @@ func (e *Engine) registerConfigFuncs() {
 				c.Return(e.config.KeepInput)
 			case "numpad":
 				c.Return(e.config.Numpad)
+			case "mouse":
+				c.Return(e.config.Mouse)
 			default:
 				return c.Errorf("unknown config key %q", key)
 			}
@@ -91,6 +95,8 @@ func (e *Engine) registerConfigFuncs() {
 				e.config.KeepInput = c.Bool(2)
 			case "numpad":
 				e.config.Numpad = c.Bool(2)
+			case "mouse":
+				e.config.Mouse = c.Bool(2)
 			default:
 				return c.Errorf("unknown config key %q", key)
 			}

--- a/lua/config_test.go
+++ b/lua/config_test.go
@@ -14,6 +14,7 @@ func TestConfigGetReturnsGoDefaults(t *testing.T) {
 		assert(rune.config.get("history_character") == "!")
 		assert(rune.config.get("keep_input") == false)
 		assert(rune.config.get("numpad") == false)
+		assert(rune.config.get("mouse") == false)
 	`); err != nil {
 		t.Fatalf("read config defaults: %v", err)
 	}
@@ -28,6 +29,8 @@ func TestConfigSetUpdatesRecognizedValue(t *testing.T) {
 		assert(rune.config.get("keep_input") == true)
 		rune.config.set("numpad", true)
 		assert(rune.config.get("numpad") == true)
+		rune.config.set("mouse", true)
+		assert(rune.config.get("mouse") == true)
 	`); err != nil {
 		t.Fatalf("set recognized config value: %v", err)
 	}
@@ -150,6 +153,7 @@ func TestConfigBootPublishesOneFinalTypedConfig(t *testing.T) {
 		rune.config.set("history_character", "^")
 		rune.config.set("keep_input", true)
 		rune.config.set("numpad", true)
+		rune.config.set("mouse", true)
 	`); err != nil {
 		t.Fatalf("stage config during boot: %v", err)
 	}
@@ -160,7 +164,7 @@ func TestConfigBootPublishesOneFinalTypedConfig(t *testing.T) {
 	engine.CommitConfig()
 	engine.CommitConfig()
 
-	want := []Config{{CommandSeparator: "|", HistoryCharacter: "^", KeepInput: true, Numpad: true}}
+	want := []Config{{CommandSeparator: "|", HistoryCharacter: "^", KeepInput: true, Numpad: true, Mouse: true}}
 	if got := host.DrainConfigChanges(); !reflect.DeepEqual(got, want) {
 		t.Fatalf("committed config publications = %+v, want %+v", got, want)
 	}
@@ -230,6 +234,24 @@ func TestConfigNumpadRuntimeChangePublishesImmediately(t *testing.T) {
 	}
 }
 
+func TestConfigMouseRuntimeChangePublishesImmediately(t *testing.T) {
+	engine, host, cleanup := setupTest(t)
+	defer cleanup()
+	engine.CommitConfig()
+	host.DrainConfigChanges()
+
+	if err := engine.DoString("enable mouse", `
+		rune.config.set("mouse", true)
+	`); err != nil {
+		t.Fatalf("change mouse config: %v", err)
+	}
+
+	want := []Config{{CommandSeparator: ";", HistoryCharacter: "!", Mouse: true}}
+	if got := host.DrainConfigChanges(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("mouse config publications = %+v, want %+v", got, want)
+	}
+}
+
 func TestPresentationChangesDoNotRepublishConfig(t *testing.T) {
 	engine, host, cleanup := setupTest(t)
 	defer cleanup()
@@ -267,6 +289,9 @@ func TestConfigRejectsWrongTypeWithoutMutation(t *testing.T) {
 		ok = pcall(rune.config.set, "numpad", "yes")
 		assert(not ok)
 		assert(rune.config.get("numpad") == false)
+		ok = pcall(rune.config.set, "mouse", "yes")
+		assert(not ok)
+		assert(rune.config.get("mouse") == false)
 	`); err != nil {
 		t.Fatalf("validate config type before mutation: %v", err)
 	}
@@ -286,6 +311,7 @@ func TestConfigRejectsUnknownKeys(t *testing.T) {
 		assert(rune.config.get("history_character") == "!")
 		assert(rune.config.get("keep_input") == false)
 		assert(rune.config.get("numpad") == false)
+		assert(rune.config.get("mouse") == false)
 	`); err != nil {
 		t.Fatalf("reject unknown config keys: %v", err)
 	}

--- a/session/lua_state.go
+++ b/session/lua_state.go
@@ -12,6 +12,7 @@ func (s *Session) OnConfigChange(config lua.Config) {
 	s.ui.UpdateConfig(ui.Config{
 		KeepInput: config.KeepInput,
 		Numpad:    config.Numpad,
+		Mouse:     config.Mouse,
 	})
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1325,6 +1325,9 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 	if uiMock.pushedConfig().Numpad {
 		t.Fatal("numpad must default off")
 	}
+	if uiMock.pushedConfig().Mouse {
+		t.Fatal("mouse must default off")
+	}
 
 	assertSessionLua(t, s.engine, `rune.config.set("keep_input", true)`)
 	if !uiMock.pushedConfig().KeepInput {
@@ -1343,6 +1346,14 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 		t.Fatalf("runtime config pushes = %+v, want one numpad=true", pushes)
 	}
 
+	assertSessionLua(t, s.engine, `rune.config.set("mouse", true)`)
+	if !uiMock.pushedConfig().Mouse {
+		t.Fatal("mouse=true did not reach the UI")
+	}
+	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || !pushes[0].Mouse {
+		t.Fatalf("runtime config pushes = %+v, want one mouse=true", pushes)
+	}
+
 	// Parser settings use the same config publication path. Each update must
 	// retain the current UI-facing values.
 	assertSessionLua(t, s.engine, `
@@ -1354,7 +1365,7 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 		t.Fatalf("parser config pushes = %+v, want exactly two snapshots", pushes)
 	}
 	for i, push := range pushes {
-		if !push.KeepInput || !push.Numpad {
+		if !push.KeepInput || !push.Numpad || !push.Mouse {
 			t.Fatalf("parser config push %d reset UI config: %+v", i, push)
 		}
 	}
@@ -1367,7 +1378,10 @@ func TestConfigSetPublishesRuntimeChangesAndOneFinalReloadSnapshot(t *testing.T)
 	if uiMock.pushedConfig().Numpad {
 		t.Fatal("reload did not reset numpad to its default")
 	}
-	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || pushes[0].KeepInput || pushes[0].Numpad {
+	if uiMock.pushedConfig().Mouse {
+		t.Fatal("reload did not reset mouse to its default")
+	}
+	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || pushes[0].KeepInput || pushes[0].Numpad || pushes[0].Mouse {
 		t.Fatalf("default reload pushes = %+v, want exactly one final false snapshot", pushes)
 	}
 	assertSessionLua(t, s.engine, `
@@ -1382,6 +1396,7 @@ rune.config.set("command_separator", "||")
 rune.config.set("history_character", "?")
 rune.config.set("keep_input", true)
 rune.config.set("numpad", true)
+rune.config.set("mouse", true)
 `
 	if err := os.WriteFile(initPath, []byte(initLua), 0o644); err != nil {
 		t.Fatal(err)
@@ -1393,7 +1408,10 @@ rune.config.set("numpad", true)
 	if !uiMock.pushedConfig().Numpad {
 		t.Fatal("reload did not reapply numpad from init.lua")
 	}
-	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || !pushes[0].KeepInput || !pushes[0].Numpad {
+	if !uiMock.pushedConfig().Mouse {
+		t.Fatal("reload did not reapply mouse from init.lua")
+	}
+	if pushes := uiMock.drainConfigPushes(); len(pushes) != 1 || !pushes[0].KeepInput || !pushes[0].Numpad || !pushes[0].Mouse {
 		t.Fatalf("configured reload pushes = %+v, want exactly one final true snapshot", pushes)
 	}
 	assertSessionLua(t, s.engine, `
@@ -1401,6 +1419,7 @@ rune.config.set("numpad", true)
 		assert(rune.config.get("history_character") == "?")
 		assert(rune.config.get("keep_input") == true)
 		assert(rune.config.get("numpad") == true)
+		assert(rune.config.get("mouse") == true)
 	`)
 }
 

--- a/ui/messages.go
+++ b/ui/messages.go
@@ -75,6 +75,9 @@ type Config struct {
 	// Numpad asks terminals with legacy keypad support to report physical
 	// numpad keys separately from their number-row equivalents.
 	Numpad bool
+	// Mouse captures terminal mouse events so the wheel can scroll Rune's
+	// viewport. When disabled, the terminal retains native text selection.
+	Mouse bool
 }
 
 // UpdateConfigMsg pushes UI-facing configuration from Session to UI.

--- a/ui/tui/layout.go
+++ b/ui/tui/layout.go
@@ -120,7 +120,9 @@ func (m *Model) syncViewportSize() {
 func (m *Model) View() tea.View {
 	view := tea.View{
 		AltScreen: true,
-		MouseMode: tea.MouseModeCellMotion,
+	}
+	if m.mouseEnabled {
+		view.MouseMode = tea.MouseModeCellMotion
 	}
 	if !m.initialized {
 		view.Content = "Loading..."

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -58,12 +58,13 @@ type Model struct {
 	}
 
 	// State
-	promptText  string
-	width       int
-	height      int
-	events      chan<- ui.UIEvent
-	initialized bool
-	pendingRows []string
+	promptText   string
+	width        int
+	height       int
+	events       chan<- ui.UIEvent
+	mouseEnabled bool
+	initialized  bool
+	pendingRows  []string
 	// flushScheduled is true while a batch-window tick is outstanding.
 	// At most one tick is ever in flight: it is armed only on the
 	// idle->hot transition and re-armed only from handleTick while
@@ -248,6 +249,7 @@ func (m *Model) handleConfigUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 		layoutChanged = true
 	case ui.UpdateConfigMsg:
 		m.inputCtl.SetKeepOnSubmit(msg.KeepInput)
+		m.mouseEnabled = msg.Mouse
 	}
 	if layoutChanged {
 		m.syncViewportSize()
@@ -343,9 +345,8 @@ func (m *Model) handlePaneMsg(msg tea.Msg) (tea.Model, tea.Cmd) {
 // viewport. Matches the common terminal-emulator default.
 const wheelScrollLines = 3
 
-// handleMouse scrolls the main viewport on wheel events. The terminal
-// mouse is captured for this (which is why text selection needs
-// shift+drag); everything else is ignored.
+// handleMouse scrolls the main viewport on wheel events when the terminal
+// reports them; everything else is ignored.
 func (m *Model) handleMouse(msg tea.MouseWheelMsg) (tea.Model, tea.Cmd) {
 	switch msg.Button {
 	case tea.MouseWheelUp:

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -45,8 +45,32 @@ func TestTerminalStateIsDeclaredOnInitialView(t *testing.T) {
 	if !view.AltScreen {
 		t.Fatal("initial view does not request the alternate screen")
 	}
+	if view.MouseMode != tea.MouseModeNone {
+		t.Fatalf("initial mouse mode = %v, want none", view.MouseMode)
+	}
+}
+
+func TestMouseModeFollowsRuntimeConfig(t *testing.T) {
+	m := NewModel(make(chan ui.UIEvent, 1))
+
+	next, _ := m.Update(ui.UpdateConfigMsg{Mouse: true})
+	m = next.(*Model)
+	view := m.View()
+	if !view.AltScreen {
+		t.Fatal("mouse-enabled view does not request the alternate screen")
+	}
 	if view.MouseMode != tea.MouseModeCellMotion {
-		t.Fatalf("initial mouse mode = %v, want cell motion", view.MouseMode)
+		t.Fatalf("enabled mouse mode = %v, want cell motion", view.MouseMode)
+	}
+
+	next, _ = m.Update(ui.UpdateConfigMsg{Mouse: false})
+	m = next.(*Model)
+	view = m.View()
+	if !view.AltScreen {
+		t.Fatal("mouse-disabled view does not request the alternate screen")
+	}
+	if view.MouseMode != tea.MouseModeNone {
+		t.Fatalf("disabled mouse mode = %v, want none", view.MouseMode)
 	}
 }
 
@@ -54,17 +78,23 @@ func TestTerminalStateIsDeclaredOnInitialView(t *testing.T) {
 // viewport - the reason the terminal mouse is captured at all.
 func TestMouseWheelScrollsViewport(t *testing.T) {
 	m := newTestModel(t)
+	next, _ := m.Update(ui.UpdateConfigMsg{Mouse: true})
+	m = next.(*Model)
 
 	if m.viewport.Mode() != widget.ModeLive {
 		t.Fatal("expected viewport to start at bottom")
 	}
+	liveBottom := m.viewport.SaveScroll().BottomSeq
 
 	wheelUp := tea.MouseWheelMsg{Button: tea.MouseWheelUp}
-	next, _ := m.Update(wheelUp)
+	next, _ = m.Update(wheelUp)
 	m = next.(*Model)
 
 	if m.viewport.Mode() == widget.ModeLive {
 		t.Fatal("wheel up did not scroll the viewport")
+	}
+	if got := liveBottom - m.viewport.SaveScroll().BottomSeq; got != wheelScrollLines {
+		t.Fatalf("wheel up scrolled %d lines, want %d", got, wheelScrollLines)
 	}
 
 	// Wheel down returns toward the bottom
@@ -81,9 +111,11 @@ func TestMouseWheelScrollsViewport(t *testing.T) {
 // disturb the viewport.
 func TestMouseNonWheelEventsIgnored(t *testing.T) {
 	m := newTestModel(t)
+	next, _ := m.Update(ui.UpdateConfigMsg{Mouse: true})
+	m = next.(*Model)
 
 	click := tea.MouseClickMsg{Button: tea.MouseLeft}
-	next, _ := m.Update(click)
+	next, _ = m.Update(click)
 	m = next.(*Model)
 
 	if m.viewport.Mode() != widget.ModeLive {
@@ -862,6 +894,8 @@ func TestSearchFocusUsesFinalLayoutGeometry(t *testing.T) {
 	assertViewportRowHighlighted(t, m.viewport.View(), "SELECTED thief")
 
 	// Deliberate viewport navigation retires the accepted marker.
+	next, _ = m.Update(ui.UpdateConfigMsg{Mouse: true})
+	m = next.(*Model)
 	next, _ = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
 	m = next.(*Model)
 	if m.searchView.focus != nil {
@@ -894,16 +928,18 @@ func TestSearchReportsInteractionStateSeparatelyFromScrollState(t *testing.T) {
 
 func TestManualViewportEntryPointsClearCommittedSearchFocus(t *testing.T) {
 	tests := []struct {
-		name string
-		msg  tea.Msg
+		name  string
+		msg   tea.Msg
+		mouse bool
 	}{
 		{
 			name: "fallback scroll key",
 			msg:  tea.KeyPressMsg{Code: tea.KeyPgUp},
 		},
 		{
-			name: "mouse wheel",
-			msg:  tea.MouseWheelMsg{Button: tea.MouseWheelUp},
+			name:  "mouse wheel",
+			msg:   tea.MouseWheelMsg{Button: tea.MouseWheelUp},
+			mouse: true,
 		},
 		{
 			name: "Lua main-pane navigation",
@@ -914,6 +950,10 @@ func TestManualViewportEntryPointsClearCommittedSearchFocus(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			m := newTestModel(t)
+			if tt.mouse {
+				next, _ := m.Update(ui.UpdateConfigMsg{Mouse: true})
+				m = next.(*Model)
+			}
 			focus := widget.SearchMatch{Seq: m.scrollback.Seq(50)}
 			m.searchView.focus = &focus
 			m.viewport.SetHighlight(focus.Seq, focus.Ranges)
@@ -929,6 +969,8 @@ func TestManualViewportEntryPointsClearCommittedSearchFocus(t *testing.T) {
 
 func TestMouseWheelNavigatesActiveSearchMatches(t *testing.T) {
 	m := newBareModel(t)
+	next, _ := m.Update(ui.UpdateConfigMsg{Mouse: true})
+	m = next.(*Model)
 	for _, line := range []string{"thief oldest", "quiet", "thief middle", "quiet", "thief newest"} {
 		m.appendMessage(line)
 	}
@@ -939,7 +981,7 @@ func TestMouseWheelNavigatesActiveSearchMatches(t *testing.T) {
 		t.Fatalf("initial selection = (%q, %v), want newest match", newest.Stripped, ok)
 	}
 
-	next, _ := m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
+	next, _ = m.Update(tea.MouseWheelMsg{Button: tea.MouseWheelUp})
 	m = next.(*Model)
 	middle, ok := m.input.SearchSelected()
 	if !ok || middle.Stripped != "thief middle" {

--- a/website/src/content/docs/getting-started/first-session.md
+++ b/website/src/content/docs/getting-started/first-session.md
@@ -36,8 +36,8 @@ across restarts.
 - `Up`/`Down` navigate history with prefix matching: type `tell ` and press
   `Up` to cycle only through your previous tells. `Ctrl+R` searches history.
 - `Tab` completes words the server has used recently.
-- `PageUp`/`PageDown` or the mouse wheel scroll the output. The status bar
-  shows `SCROLL (n new)` while you're off the bottom.
+- `PageUp`/`PageDown` scroll the output. The status bar shows `SCROLL (n new)`
+  while you're off the bottom.
 - `Ctrl+C` clears the input line; pressed twice on an empty line it quits.
 
 The full tour of the input line (editing keys, `Ctrl+E` into `$EDITOR`,

--- a/website/src/content/docs/interface/input.md
+++ b/website/src/content/docs/interface/input.md
@@ -95,12 +95,21 @@ in the status bar, with `Shift+Tab` going backward.
 
 `PageUp`/`PageDown` scroll the output viewport; `Ctrl+Home`/`Ctrl+End` jump to
 the top and bottom (`Home`/`End` stay on the input line; rebind them if you
-prefer they scroll). The mouse wheel scrolls too. While you're off the bottom,
-the status bar shows `SCROLL (n new)` so you know what's piling up, and it
-returns to `LIVE` when you catch up.
+prefer they scroll). While you're off the bottom, the status bar shows
+`SCROLL (n new)` so you know what's piling up, and it returns to `LIVE` when
+you catch up.
 
-The mouse is captured for scrolling, so select text with shift+drag, the
-standard convention in terminal apps like tmux.
+Rune leaves the mouse to the terminal by default, so click-drag selects text
+normally. To capture it for wheel scrolling, enable the `mouse` setting:
+
+```lua
+rune.config.set("mouse", true)
+```
+
+The change takes effect immediately and does not require a restart. Put it in
+`init.lua` to enable it on each start. While capture is enabled, each wheel tick
+scrolls three lines and most terminals require holding `Shift` while dragging
+for native text selection.
 
 ## Multiline verbatim composer
 
@@ -131,8 +140,8 @@ or discard the draft.
 
 Composer editing keys are handled locally rather than by Lua binds. `Up`/`Down`
 move through the draft's visual rows, `PageUp`/`PageDown` move by a composer
-page, and the mouse wheel still scrolls output. The ordinary one-line input and
-its bindings return after the composer closes.
+page, and the mouse wheel still scrolls output when mouse capture is enabled.
+The ordinary one-line input and its bindings return after the composer closes.
 
 So that an accidental paste can't flood the connection, a verbatim submission
 is capped at 1,000 physical lines and 256 KiB; over either limit Rune rejects

--- a/website/src/content/docs/reference/api/core.md
+++ b/website/src/content/docs/reference/api/core.md
@@ -170,6 +170,7 @@ rune.config.set(key, value)
 | `history_character` | empty or one visible, non-space character | `"!"` | Character used for history expansion (`!`, `!!`, `!prefix`); empty disables it |
 | `keep_input` | boolean | `false` | After `Enter`, leave the text you typed selected; `Enter` repeats it and typing replaces it |
 | `numpad` | boolean | `false` | Ask legacy terminals to report physical numpad keys separately; see [Numpad keys](/scripting/keybindings/#numpad-keys) |
+| `mouse` | boolean | `false` | Capture the mouse so its wheel scrolls Rune; see [Scrolling and the mouse](/interface/input/#scrolling-and-the-mouse) |
 
 An unknown key, a value of the wrong type, an empty `command_separator`, or an
 invalid history character raises an error and leaves the configuration unchanged.
@@ -179,6 +180,7 @@ rune.config.set("keep_input", true)
 rune.config.set("command_separator", "|")
 rune.config.set("history_character", "^")
 rune.config.set("numpad", true)
+rune.config.set("mouse", true)
 assert(rune.config.get("keep_input") == true)
 ```
 


### PR DESCRIPTION
Closes #59.

## Summary
- add a live `mouse` setting with terminal capture disabled by default
- preserve three-line wheel scrolling when enabled and restore the configured mode around `$EDITOR`
- document native selection and the opt-in capture behavior

## Testing
- `go test ./...`
- `go test -race ./...`
- `go vet ./...`
- Windows `ui/tui` cross-compile
- website build
- headless tmux mouse-mode, wheel, and editor-lifecycle verification