### PR TITLE
Share dividers between adjacent panes

### DIFF
--- a/ui/layout.go
+++ b/ui/layout.go
@@ -3,7 +3,7 @@ package ui
 // LayoutEntry represents a single component in a layout dock.
 type LayoutEntry struct {
 	Name   string            // Component name (e.g., "input", "status", pane name)
-	Height int               // Explicit height in lines (0 = intrinsic/auto)
+	Height int               // Explicit height in lines (0 = intrinsic/auto); panes treat this as their standalone height
 	Opts   map[string]string // Component-specific options, passed through opaquely; only the named widget interprets its keys
 }
 

--- a/ui/tui/layout.go
+++ b/ui/tui/layout.go
@@ -4,10 +4,33 @@ import (
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/mmcdole/rune/ui"
+	"github.com/mmcdole/rune/ui/tui/util"
 	"github.com/mmcdole/rune/ui/tui/widget"
 )
+
+const (
+	defaultPaneContentHeight = 10
+	paneChromeHeight         = 2 // titled header + closing rule
+)
+
+// sizedDockEntry is the walker's private representation of one rendered
+// layout entry. Exactly one of widget or pane is set.
+type sizedDockEntry struct {
+	widget widget.Widget
+	pane   *widget.Pane
+	height int
+}
+
+// dockPart is the compositor-facing form of a sized entry. The walker owns
+// all pane-vs-widget dispatch; composition only deals with rendered blocks.
+type dockPart struct {
+	view                   string
+	closing                string
+	sharedWithPreviousPane bool
+}
 
 func (m *Model) getLayout() ui.LayoutConfig {
 	if len(m.luaLayout.Top) > 0 || len(m.luaLayout.Bottom) > 0 {
@@ -19,81 +42,126 @@ func (m *Model) getLayout() ui.LayoutConfig {
 	return ui.DefaultLayoutConfig()
 }
 
-// getWidget returns the Widget for a given name.
-func (m *Model) getWidget(name string) widget.Widget {
-	// Check widgets map (input, separator, bars)
-	if w, ok := m.widgets[name]; ok {
-		return w
+// sizeDockEntry resolves and sizes one layout entry. Named widgets take
+// precedence over panes, matching the existing collision policy.
+func (m *Model) sizeDockEntry(entry ui.LayoutEntry) (sizedDockEntry, bool) {
+	if w, ok := m.widgets[entry.Name]; ok {
+		// Options are per-entry but the widget instance is shared, so pass the
+		// bag unconditionally: an entry without options must reset whatever a
+		// previous entry configured in the same layout pass.
+		if c, ok := w.(widget.Configurable); ok {
+			c.SetOptions(entry.Opts)
+		}
+
+		// Width can affect intrinsic height (notably soft-wrapped composer text),
+		// so make the current width available before asking for it. Existing
+		// fixed-height widgets ignore the zero height.
+		w.SetSize(m.width, 0)
+		preferred := w.PreferredHeight()
+		if preferred == 0 {
+			return sizedDockEntry{}, false
+		}
+
+		h := entry.Height
+		if h == 0 {
+			h = preferred
+		}
+		w.SetSize(m.width, h)
+		return sizedDockEntry{widget: w, height: h}, true
 	}
 
-	// Panes (PaneManager returns *Pane which implements Widget)
-	if m.panes.Exists(name) {
-		return m.panes.Get(name)
+	pane, ok := m.panes.Lookup(entry.Name)
+	if !ok || !pane.Visible {
+		return sizedDockEntry{}, false
 	}
-
-	return nil
+	height := entry.Height
+	if height == 0 {
+		height = defaultPaneContentHeight + paneChromeHeight
+	}
+	if height < paneChromeHeight {
+		height = paneChromeHeight
+	}
+	return sizedDockEntry{pane: pane, height: height}, true
 }
 
-// sizeDockEntry applies one layout entry and returns its widget and final
-// height. Measurement and rendering share this path so intrinsic-height
-// policy cannot drift between an Update-time reflow and the next View.
-func (m *Model) sizeDockEntry(entry ui.LayoutEntry) (widget.Widget, int, bool) {
-	w := m.getWidget(entry.Name)
-	if w == nil {
-		return nil, 0, false
-	}
-
-	// Options are per-entry but the widget instance is shared, so pass the
-	// bag unconditionally: an entry without options must reset whatever a
-	// previous entry configured in the same layout pass.
-	if c, ok := w.(widget.Configurable); ok {
-		c.SetOptions(entry.Opts)
-	}
-
-	// Width can affect intrinsic height (notably soft-wrapped composer text),
-	// so make the current width available before asking for it. Existing
-	// fixed-height widgets ignore the zero height.
-	w.SetSize(m.width, 0)
-	preferred := w.PreferredHeight()
-	if preferred == 0 {
-		return nil, 0, false
-	}
-
-	h := entry.Height
-	if h == 0 {
-		h = preferred
-	}
-	w.SetSize(m.width, h)
-	return w, h, true
-}
-
-// layoutDock sizes and renders one dock's widgets, returning the joined
-// view and total height. A zero-height widget is skipped entirely.
-func (m *Model) layoutDock(entries []ui.LayoutEntry) (string, int) {
-	var parts []string
+// walkDock is the single dispatch and geometry path for dock entries. When
+// visit is non-nil it snapshots each entry's rendering before a repeated,
+// shared widget can be resized by the next entry.
+func (m *Model) walkDock(entries []ui.LayoutEntry, visit func(dockPart)) int {
 	totalHeight := 0
+	previousWasPane := false
 	for _, entry := range entries {
-		w, h, ok := m.sizeDockEntry(entry)
+		sized, ok := m.sizeDockEntry(entry)
 		if !ok {
 			continue
 		}
-		parts = append(parts, w.View())
-		totalHeight += h
+
+		isPane := sized.pane != nil
+		shared := previousWasPane && isPane
+		if shared {
+			totalHeight--
+		}
+		totalHeight += sized.height
+
+		if visit != nil {
+			part := dockPart{sharedWithPreviousPane: shared}
+			if isPane {
+				part.view = m.renderPaneBody(sized.pane, sized.height)
+				part.closing = m.renderPaneClosing()
+			} else {
+				part.view = sized.widget.View()
+			}
+			visit(part)
+		}
+		previousWasPane = isPane
+	}
+	return totalHeight
+}
+
+func (m *Model) renderPaneBody(pane *widget.Pane, height int) string {
+	label := ansi.ResetStyle + m.styles.PaneHeader.Render(" "+pane.Title()+" ")
+	if pad := m.width - util.VisibleLen(label); pad > 0 {
+		label += m.styles.PaneBorder.Render(strings.Repeat("─", pad))
+	}
+
+	rows := make([]string, 1, height-1)
+	rows[0] = label
+	rows = append(rows, pane.ContentRows(m.width, height-paneChromeHeight)...)
+	return strings.Join(rows, "\n")
+}
+
+func (m *Model) renderPaneClosing() string {
+	return ansi.ResetStyle + m.styles.PaneBorder.Render(strings.Repeat("─", m.width))
+}
+
+// layoutDock renders one dock. A pane's closing rule stays pending until the
+// next rendered entry determines whether it is a real edge or a shared pane
+// boundary.
+func (m *Model) layoutDock(entries []ui.LayoutEntry) (string, int) {
+	var parts []string
+	pendingClosing := ""
+	totalHeight := m.walkDock(entries, func(part dockPart) {
+		if part.sharedWithPreviousPane {
+			pendingClosing = ""
+		} else if pendingClosing != "" {
+			parts = append(parts, pendingClosing)
+			pendingClosing = ""
+		}
+
+		parts = append(parts, part.view)
+		pendingClosing = part.closing
+	})
+	if pendingClosing != "" {
+		parts = append(parts, pendingClosing)
 	}
 	return strings.Join(parts, "\n"), totalHeight
 }
 
 // dockHeight measures a dock without rendering it. Search uses this during
-// Update so viewport positioning sees the same final geometry as View.
+// Update so viewport positioning sees the same walker and final geometry as
+// View.
 func (m *Model) dockHeight(entries []ui.LayoutEntry) int {
-	totalHeight := 0
-	for _, entry := range entries {
-		_, h, ok := m.sizeDockEntry(entry)
-		if ok {
-			totalHeight += h
-		}
-	}
-	return totalHeight
+	return m.walkDock(entries, nil)
 }
 
 func (m *Model) setViewportSize(topHeight, bottomHeight int) {

--- a/ui/tui/layout_test.go
+++ b/ui/tui/layout_test.go
@@ -1,0 +1,333 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+
+	runetext "github.com/mmcdole/rune/text"
+	"github.com/mmcdole/rune/ui"
+	"github.com/mmcdole/rune/ui/tui/util"
+)
+
+func addVisiblePane(t *testing.T, m *Model, name string, lines ...string) {
+	t.Helper()
+	m.panes.Create(name)
+	pane, ok := m.panes.Lookup(name)
+	if !ok {
+		t.Fatalf("pane %q was not created", name)
+	}
+	for _, line := range lines {
+		pane.Write(line)
+	}
+	pane.SetVisible(true)
+}
+
+func plainDockRows(view string) []string {
+	if view == "" {
+		return nil
+	}
+	return strings.Split(runetext.StripANSI(view), "\n")
+}
+
+func countRowsEqual(rows []string, want string) int {
+	count := 0
+	for _, row := range rows {
+		if row == want {
+			count++
+		}
+	}
+	return count
+}
+
+func TestPaneCompositorRendersStandaloneFrame(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha", "alpha one", "alpha two")
+	entries := []ui.LayoutEntry{{Name: "alpha", Height: 4}}
+
+	view, height := m.layoutDock(entries)
+	rows := plainDockRows(view)
+	if height != 4 || len(rows) != 4 {
+		t.Fatalf("standalone geometry = (%d measured, %d rendered), want 4", height, len(rows))
+	}
+	if got := m.dockHeight(entries); got != height {
+		t.Fatalf("dockHeight = %d, want rendered height %d", got, height)
+	}
+	if !strings.Contains(rows[0], " alpha ") {
+		t.Fatalf("header = %q, want alpha title", rows[0])
+	}
+	if rows[1] != "alpha one" || rows[2] != "alpha two" {
+		t.Fatalf("content rows = %q, want alpha lines", rows[1:3])
+	}
+	closing := strings.Repeat("─", m.width)
+	if rows[3] != closing {
+		t.Fatalf("closing row = %q, want full-width rule", rows[3])
+	}
+}
+
+func TestPaneCompositorSharesAdjacentBoundaries(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha", "a1", "a2")
+	addVisiblePane(t, m, "bravo", "b1", "b2", "b3", "b4")
+	addVisiblePane(t, m, "charlie", "c1", "c2")
+	bravo, _ := m.panes.Lookup("bravo")
+	bravo.ScrollUp(1)
+	bravo.Write("b5")
+
+	entries := []ui.LayoutEntry{
+		{Name: "alpha", Height: 4},
+		{Name: "bravo", Height: 4},
+		{Name: "charlie", Height: 4},
+	}
+	view, height := m.layoutDock(entries)
+	rows := plainDockRows(view)
+	if height != 10 || len(rows) != 10 {
+		t.Fatalf("three-pane geometry = (%d measured, %d rendered), want 10", height, len(rows))
+	}
+	if got := m.dockHeight(entries); got != height {
+		t.Fatalf("dockHeight = %d, want rendered height %d", got, height)
+	}
+	if !strings.Contains(rows[3], " bravo · scroll +1 ") {
+		t.Fatalf("first shared boundary = %q, want bravo new-line indicator", rows[3])
+	}
+	if !strings.Contains(rows[6], " charlie ") {
+		t.Fatalf("second shared boundary = %q, want charlie title", rows[6])
+	}
+	closing := strings.Repeat("─", m.width)
+	if got := countRowsEqual(rows, closing); got != 1 {
+		t.Fatalf("pure closing rules = %d, want only the final pane rule", got)
+	}
+}
+
+func TestPaneCompositorSnapshotsRepeatedPaneGeometry(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "shared", "line 1", "line 2", "line 3", "line 4", "line 5")
+	entries := []ui.LayoutEntry{
+		{Name: "shared", Height: 4},
+		{Name: "shared", Height: 5},
+	}
+
+	view, height := m.layoutDock(entries)
+	rows := plainDockRows(view)
+	if height != 8 || len(rows) != 8 {
+		t.Fatalf("repeated-pane geometry = (%d measured, %d rendered), want 8", height, len(rows))
+	}
+	if rows[1] != "line 4" || rows[2] != "line 5" {
+		t.Fatalf("first occurrence content = %q, want two-row tail", rows[1:3])
+	}
+	if !strings.Contains(rows[3], " shared ") {
+		t.Fatalf("shared boundary = %q, want second title", rows[3])
+	}
+	if got := rows[4:7]; strings.Join(got, "|") != "line 3|line 4|line 5" {
+		t.Fatalf("second occurrence content = %q, want three-row tail", got)
+	}
+}
+
+func TestPaneCompositorUsesRenderedAdjacency(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha", "a1", "a2")
+	addVisiblePane(t, m, "charlie", "c1", "c2")
+	m.panes.Create("hidden")
+	m.syncBars(map[string]ui.BarContent{
+		"empty":  {},
+		"middle": {Left: "middle bar"},
+	})
+
+	t.Run("skipped entries preserve adjacency", func(t *testing.T) {
+		entries := []ui.LayoutEntry{
+			{Name: "alpha", Height: 4},
+			{Name: "missing"},
+			{Name: "hidden", Height: 4},
+			{Name: "empty"},
+			{Name: "charlie", Height: 4},
+		}
+		view, height := m.layoutDock(entries)
+		rows := plainDockRows(view)
+		if height != 7 || len(rows) != 7 {
+			t.Fatalf("skipped-entry geometry = (%d measured, %d rendered), want 7", height, len(rows))
+		}
+		if !strings.Contains(rows[3], " charlie ") {
+			t.Fatalf("shared boundary = %q, want charlie title", rows[3])
+		}
+	})
+
+	tests := []struct {
+		name   string
+		middle ui.LayoutEntry
+	}{
+		{name: "separator", middle: ui.LayoutEntry{Name: "separator"}},
+		{name: "visible bar", middle: ui.LayoutEntry{Name: "middle"}},
+		{name: "input", middle: ui.LayoutEntry{Name: "input"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name+" breaks adjacency", func(t *testing.T) {
+			entries := []ui.LayoutEntry{
+				{Name: "alpha", Height: 4},
+				test.middle,
+				{Name: "charlie", Height: 4},
+			}
+			view, height := m.layoutDock(entries)
+			rows := plainDockRows(view)
+			if got := m.dockHeight(entries); got != height || len(rows) != height {
+				t.Fatalf("geometry = dock %d, measured %d, rendered %d", got, height, len(rows))
+			}
+			closing := strings.Repeat("─", m.width)
+			if got := countRowsEqual(rows, closing); got < 2 {
+				t.Fatalf("pure pane closing rules = %d, want a rule on both sides of rendered middle entry", got)
+			}
+		})
+	}
+
+	t.Run("rendered bar sits between pane frames", func(t *testing.T) {
+		entries := []ui.LayoutEntry{
+			{Name: "alpha", Height: 4},
+			{Name: "middle"},
+			{Name: "charlie", Height: 4},
+		}
+		view, _ := m.layoutDock(entries)
+		rows := plainDockRows(view)
+		closing := strings.Repeat("─", m.width)
+		if rows[3] != closing || !strings.Contains(rows[4], "middle bar") || !strings.Contains(rows[5], " charlie ") {
+			t.Fatalf("boundary rows = %q, want pane footer, bar, then pane header", rows[3:6])
+		}
+	})
+}
+
+func TestPaneCompositorRecomputesAfterVisibilityChanges(t *testing.T) {
+	m := newBareModel(t)
+	for _, name := range []string{"alpha", "bravo", "charlie"} {
+		addVisiblePane(t, m, name, name+" content")
+	}
+	entries := []ui.LayoutEntry{
+		{Name: "alpha", Height: 3},
+		{Name: "bravo", Height: 3},
+		{Name: "charlie", Height: 3},
+	}
+
+	assertHeight := func(want int) {
+		t.Helper()
+		view, got := m.layoutDock(entries)
+		if rows := plainDockRows(view); got != want || len(rows) != want || m.dockHeight(entries) != want {
+			t.Fatalf("geometry = (%d measured, %d rendered, %d dock), want %d", got, len(rows), m.dockHeight(entries), want)
+		}
+		if rules := countRowsEqual(plainDockRows(view), strings.Repeat("─", m.width)); rules != 1 {
+			t.Fatalf("closing rules = %d, want one final rule", rules)
+		}
+	}
+
+	assertHeight(7)
+	m.panes.SetVisible("bravo", false)
+	assertHeight(5)
+	m.panes.SetVisible("charlie", false)
+	assertHeight(3)
+}
+
+func TestPaneCompositorIntrinsicAndMinimumHeights(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha")
+	addVisiblePane(t, m, "bravo")
+
+	t.Run("intrinsic panes retain ten content rows", func(t *testing.T) {
+		entries := []ui.LayoutEntry{{Name: "alpha"}, {Name: "bravo"}}
+		view, height := m.layoutDock(entries)
+		rows := plainDockRows(view)
+		if height != 23 || len(rows) != 23 || m.dockHeight(entries) != 23 {
+			t.Fatalf("intrinsic geometry = (%d measured, %d rendered, %d dock), want 23", height, len(rows), m.dockHeight(entries))
+		}
+		if !strings.Contains(rows[0], " alpha ") || !strings.Contains(rows[11], " bravo ") {
+			t.Fatalf("intrinsic headers at rows 0 and 11 = %q, %q", rows[0], rows[11])
+		}
+	})
+
+	t.Run("height below chrome clamps to two", func(t *testing.T) {
+		entries := []ui.LayoutEntry{{Name: "alpha", Height: 1}}
+		view, height := m.layoutDock(entries)
+		rows := plainDockRows(view)
+		if height != 2 || len(rows) != 2 || m.dockHeight(entries) != 2 {
+			t.Fatalf("minimum geometry = (%d measured, %d rendered, %d dock), want 2", height, len(rows), m.dockHeight(entries))
+		}
+		if !strings.Contains(rows[0], " alpha ") || rows[1] != strings.Repeat("─", m.width) {
+			t.Fatalf("minimum pane rows = %q, want header and closing rule", rows)
+		}
+	})
+}
+
+func TestPaneCompositorKeepsDockEdgesIndependent(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "top", "top one", "top two")
+	addVisiblePane(t, m, "bottom", "bottom one", "bottom two")
+
+	next, _ := m.Update(ui.UpdateLayoutMsg{
+		Top:    []ui.LayoutEntry{{Name: "top", Height: 4}},
+		Bottom: []ui.LayoutEntry{{Name: "bottom", Height: 4}},
+	})
+	m = next.(*Model)
+	rows := plainDockRows(m.View().Content)
+	if len(rows) != m.height {
+		t.Fatalf("full frame has %d rows, want terminal height %d", len(rows), m.height)
+	}
+	closing := strings.Repeat("─", m.width)
+	if rows[3] != closing {
+		t.Fatalf("top dock edge = %q, want closing rule directly above viewport", rows[3])
+	}
+	if rows[len(rows)-1] != closing {
+		t.Fatalf("bottom dock edge = %q, want final closing rule", rows[len(rows)-1])
+	}
+	if got := countRowsEqual(rows, closing); got != 2 {
+		t.Fatalf("independent dock closing rules = %d, want 2", got)
+	}
+}
+
+func TestPaneCompositorReturnsSharedRowsToViewport(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha", "a1", "a2")
+	addVisiblePane(t, m, "bravo", "b1", "b2")
+
+	next, _ := m.Update(ui.UpdateLayoutMsg{
+		Top: []ui.LayoutEntry{
+			{Name: "alpha", Height: 4},
+			{Name: "bravo", Height: 4},
+		},
+	})
+	m = next.(*Model)
+	rows := plainDockRows(m.View().Content)
+	if len(rows) != m.height {
+		t.Fatalf("full frame has %d rows, want terminal height %d", len(rows), m.height)
+	}
+	if got, want := m.viewport.PreferredHeight(), m.height-7; got != want {
+		t.Fatalf("viewport height = %d, want %d after reclaiming shared row", got, want)
+	}
+	closing := strings.Repeat("─", m.width)
+	if rows[6] != closing {
+		t.Fatalf("top dock edge = %q, want final rule directly above viewport", rows[6])
+	}
+}
+
+func TestPaneCompositorHeaderWidths(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha")
+	view, _ := m.layoutDock([]ui.LayoutEntry{{Name: "alpha", Height: 2}})
+	for i, row := range strings.Split(view, "\n") {
+		if width := util.VisibleLen(row); width != m.width {
+			t.Fatalf("frame row %d width = %d, want %d", i, width, m.width)
+		}
+	}
+}
+
+func TestPaneCompositorResetsStylesBeforeChrome(t *testing.T) {
+	m := newBareModel(t)
+	addVisiblePane(t, m, "alpha", "\x1b[7munterminated reverse")
+	addVisiblePane(t, m, "bravo")
+
+	view, _ := m.layoutDock([]ui.LayoutEntry{
+		{Name: "alpha", Height: 3},
+		{Name: "bravo", Height: 2},
+	})
+	if !strings.Contains(view, "\x1b[7munterminated reverse\n"+ansi.ResetStyle) {
+		t.Fatalf("shared pane header does not reset preceding content style: %q", view)
+	}
+	if !strings.HasPrefix(m.renderPaneClosing(), ansi.ResetStyle) {
+		t.Fatalf("pane closing rule does not begin with a style reset: %q", m.renderPaneClosing())
+	}
+}

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -36,6 +36,7 @@ func doTick() tea.Cmd {
 type Model struct {
 	// Layout
 	widgets map[string]widget.Widget // all named widgets: input, separator, bars
+	styles  style.Styles
 
 	// Widgets
 	scrollback *widget.ScrollbackBuffer
@@ -79,7 +80,7 @@ func NewModel(events chan<- ui.UIEvent) *Model {
 	viewport := widget.NewViewport(scrollback, styles)
 	search := widget.NewSearch(scrollback, styles)
 	input := widget.NewInput(styles, search)
-	panes := widget.NewPaneManager(styles)
+	panes := widget.NewPaneManager()
 
 	m := &Model{
 		scrollback: scrollback,
@@ -88,6 +89,7 @@ func NewModel(events chan<- ui.UIEvent) *Model {
 		panes:      panes,
 		events:     events,
 		widgets:    make(map[string]widget.Widget),
+		styles:     styles,
 	}
 	m.inputCtl = newInputController(input, m.notifySession, m.submit, m.isBound, m.handleScrollKey, m)
 
@@ -167,8 +169,8 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.navigateMainViewport(func() {
 				m.viewport.ScrollUp(msg.Lines)
 			})
-		} else if m.panes.Exists(msg.Name) {
-			m.panes.Get(msg.Name).ScrollUp(msg.Lines)
+		} else if pane, ok := m.panes.Lookup(msg.Name); ok {
+			pane.ScrollUp(msg.Lines)
 		}
 		return m, nil
 	case ui.PaneScrollDownMsg:
@@ -176,22 +178,22 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.navigateMainViewport(func() {
 				m.viewport.ScrollDown(msg.Lines)
 			})
-		} else if m.panes.Exists(msg.Name) {
-			m.panes.Get(msg.Name).ScrollDown(msg.Lines)
+		} else if pane, ok := m.panes.Lookup(msg.Name); ok {
+			pane.ScrollDown(msg.Lines)
 		}
 		return m, nil
 	case ui.PaneScrollToTopMsg:
 		if msg.Name == "main" {
 			m.navigateMainViewport(m.viewport.GotoTop)
-		} else if m.panes.Exists(msg.Name) {
-			m.panes.Get(msg.Name).ScrollToTop()
+		} else if pane, ok := m.panes.Lookup(msg.Name); ok {
+			pane.ScrollToTop()
 		}
 		return m, nil
 	case ui.PaneScrollToBottomMsg:
 		if msg.Name == "main" {
 			m.navigateMainViewport(m.viewport.GotoBottom)
-		} else if m.panes.Exists(msg.Name) {
-			m.panes.Get(msg.Name).ScrollToBottom()
+		} else if pane, ok := m.panes.Lookup(msg.Name); ok {
+			pane.ScrollToBottom()
 		}
 		return m, nil
 	}

--- a/ui/tui/widget/pane.go
+++ b/ui/tui/widget/pane.go
@@ -2,125 +2,80 @@ package widget
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/mmcdole/rune/ui/tui/style"
 	"github.com/mmcdole/rune/ui/tui/util"
 )
-
-// Compile-time check that Pane implements Widget
-var _ Widget = (*Pane)(nil)
 
 // Pane represents a named buffer that can be shown/hidden.
 //
 // Lines are stored as written (logical lines) and soft-wrapped to the
-// pane width at render time, so a resize re-fits everything. Scrolling
-// is tracked as a logical-line offset from the newest line; while
-// scrolled the view stays anchored on the same history, new writes are
-// counted, and the header shows a scroll indicator.
+// requested width when ContentRows is called, so a resize re-fits
+// everything. Scrolling is tracked as a logical-line offset from the
+// newest line; while scrolled the view stays anchored on the same
+// history and new writes are counted for the title indicator.
 type Pane struct {
 	Name     string
 	Lines    []string
 	Visible  bool
-	height   int // Number of content lines to show when visible
-	styles   style.Styles
-	width    int
 	offset   int // logical lines scrolled back from the newest (0 = live)
 	newLines int // writes that arrived while scrolled
 }
 
-// NewPane creates a new pane widget.
-func NewPane(name string, styles style.Styles) *Pane {
+// NewPane creates a new pane.
+func NewPane(name string) *Pane {
 	return &Pane{
 		Name:    name,
 		Lines:   make([]string, 0, 100),
 		Visible: false,
-		height:  10,
-		styles:  styles,
 	}
 }
 
-// visibleRows renders exactly p.height rows of wrapped content for the
-// current scroll position. The window is anchored at the logical line
-// end = len(Lines)-offset; when a deep scroll leaves it underfull, it
-// extends forward so the pane stays full whenever the buffer allows.
-func (p *Pane) visibleRows() []string {
+// Title returns the unstyled pane title for its current scroll state.
+func (p *Pane) Title() string {
+	if p.offset == 0 {
+		return p.Name
+	}
+	if p.newLines > 0 {
+		return fmt.Sprintf("%s · scroll +%d", p.Name, p.newLines)
+	}
+	return p.Name + " · scroll"
+}
+
+// ContentRows returns exactly height rows of wrapped content for the current
+// scroll position. The window is anchored at the logical line end =
+// len(Lines)-offset; when a deep scroll leaves it underfull, it extends
+// forward so the pane stays full whenever the buffer allows. Visibility is a
+// layout concern and does not affect the returned content.
+func (p *Pane) ContentRows(width, height int) []string {
+	if height <= 0 {
+		return nil
+	}
+
 	end := len(p.Lines) - p.offset
 	if end < 0 {
 		end = 0
 	}
 
 	var rows []string
-	for i := end - 1; i >= 0 && len(rows) < p.height; i-- {
-		rows = append(util.WrapLine(p.Lines[i], p.width), rows...)
+	for i := end - 1; i >= 0 && len(rows) < height; i-- {
+		rows = append(util.WrapLine(p.Lines[i], width), rows...)
 	}
 
-	if len(rows) >= p.height {
-		rows = rows[len(rows)-p.height:]
+	if len(rows) >= height {
+		rows = rows[len(rows)-height:]
 	} else {
-		for i := end; i < len(p.Lines) && len(rows) < p.height; i++ {
-			rows = append(rows, util.WrapLine(p.Lines[i], p.width)...)
+		for i := end; i < len(p.Lines) && len(rows) < height; i++ {
+			rows = append(rows, util.WrapLine(p.Lines[i], width)...)
 		}
-		if len(rows) > p.height {
-			rows = rows[:p.height]
+		if len(rows) > height {
+			rows = rows[:height]
 		}
 	}
 
-	for len(rows) < p.height {
+	for len(rows) < height {
 		rows = append(rows, "")
 	}
 	return rows
-}
-
-// View implements Widget.
-func (p *Pane) View() string {
-	if !p.Visible {
-		return ""
-	}
-
-	var parts []string
-
-	// Header, with a scroll indicator while off the live tail
-	// (mirrors the status bar's SCROLL/LIVE vocabulary).
-	label := " " + p.Name + " "
-	if p.offset > 0 {
-		if p.newLines > 0 {
-			label = fmt.Sprintf(" %s · scroll +%d ", p.Name, p.newLines)
-		} else {
-			label = " " + p.Name + " · scroll "
-		}
-	}
-	title := p.styles.PaneHeader.Render(label)
-	titlePad := p.width - util.VisibleLen(title)
-	if titlePad > 0 {
-		title += p.styles.PaneBorder.Render(strings.Repeat("─", titlePad))
-	}
-	parts = append(parts, title)
-	parts = append(parts, p.visibleRows()...)
-
-	// Bottom border
-	parts = append(parts, p.styles.PaneBorder.Render(strings.Repeat("─", p.width)))
-
-	return strings.Join(parts, "\n")
-}
-
-// SetSize implements Widget.
-func (p *Pane) SetSize(width, height int) {
-	p.width = width
-	// Height includes header (1) + border (1), so content height = height - 2
-	if height > 2 {
-		p.height = height - 2
-	} else if height > 0 {
-		p.height = height
-	}
-}
-
-// PreferredHeight implements Widget. Returns 0 if hidden.
-func (p *Pane) PreferredHeight() int {
-	if !p.Visible {
-		return 0
-	}
-	return p.height + 2 // content + header + border
 }
 
 // Write appends text as logical lines, one per line break. While
@@ -203,15 +158,13 @@ func (p *Pane) Clear() {
 
 // PaneManager handles multiple named panes.
 type PaneManager struct {
-	panes  map[string]*Pane
-	styles style.Styles
+	panes map[string]*Pane
 }
 
 // NewPaneManager creates a new pane manager.
-func NewPaneManager(styles style.Styles) *PaneManager {
+func NewPaneManager() *PaneManager {
 	return &PaneManager{
-		panes:  make(map[string]*Pane),
-		styles: styles,
+		panes: make(map[string]*Pane),
 	}
 }
 
@@ -220,7 +173,7 @@ func (pm *PaneManager) Create(name string) {
 	if _, exists := pm.panes[name]; exists {
 		return
 	}
-	pm.panes[name] = NewPane(name, pm.styles)
+	pm.panes[name] = NewPane(name)
 }
 
 // Get returns a pane by name, creating it if needed.
@@ -229,6 +182,12 @@ func (pm *PaneManager) Get(name string) *Pane {
 		pm.Create(name)
 	}
 	return pm.panes[name]
+}
+
+// Lookup returns an existing pane without creating it.
+func (pm *PaneManager) Lookup(name string) (*Pane, bool) {
+	pane, ok := pm.panes[name]
+	return pane, ok
 }
 
 // Write appends a line to a pane (auto-creates if missing).
@@ -255,10 +214,4 @@ func (pm *PaneManager) Clear(name string) {
 	if pane, exists := pm.panes[name]; exists {
 		pane.Clear()
 	}
-}
-
-// Exists returns true if a pane exists.
-func (pm *PaneManager) Exists(name string) bool {
-	_, ok := pm.panes[name]
-	return ok
 }

--- a/ui/tui/widget/pane_test.go
+++ b/ui/tui/widget/pane_test.go
@@ -5,44 +5,39 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mmcdole/rune/ui/tui/style"
 	"github.com/mmcdole/rune/ui/tui/util"
 )
 
-// newTestPane returns a visible pane sized to width x (content+2),
-// matching how the layout sizes docked panes.
-func newTestPane(t *testing.T, width, contentHeight int) *Pane {
+func newTestPane(t *testing.T) *Pane {
 	t.Helper()
-	p := NewPane("test", style.DefaultStyles())
+	p := NewPane("test")
 	p.Visible = true
-	p.SetSize(width, contentHeight+2)
 	return p
 }
 
-// contentRows strips the header and bottom border from View.
-func contentRows(t *testing.T, p *Pane) []string {
+func contentRows(t *testing.T, p *Pane, width, height int) []string {
 	t.Helper()
-	rows := strings.Split(p.View(), "\n")
-	if len(rows) < 3 {
-		t.Fatalf("view too short: %d rows", len(rows))
+	rows := p.ContentRows(width, height)
+	if len(rows) != height {
+		t.Fatalf("content height = %d rows, want %d", len(rows), height)
 	}
-	return rows[1 : len(rows)-1]
+	return rows
 }
 
 // TestPaneMultilineWriteWhileScrolled verifies a multi-line write
 // counts each segment: the scrolled view stays anchored and the
 // header indicator reflects every new line.
 func TestPaneMultilineWriteWhileScrolled(t *testing.T) {
-	p := newTestPane(t, 40, 2)
+	p := newTestPane(t)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
 	p.ScrollUp(3)
-	before := contentRows(t, p)
+	before := contentRows(t, p, 40, 2)
 
 	p.Write("line 7\nline 8")
 
-	after := contentRows(t, p)
+	after := contentRows(t, p, 40, 2)
 	if before[0] != after[0] || before[1] != after[1] {
 		t.Fatalf("scrolled view moved: before %q, after %q", before, after)
 	}
@@ -55,7 +50,7 @@ func TestPaneMultilineWriteWhileScrolled(t *testing.T) {
 // write containing newlines stores one logical line per segment, and
 // the rendered view keeps its budgeted height.
 func TestPaneMultilineWriteSplitsIntoLines(t *testing.T) {
-	p := newTestPane(t, 40, 5)
+	p := newTestPane(t)
 	p.Write("a\rb\r\nc\nd")
 
 	if len(p.Lines) != 4 {
@@ -66,16 +61,16 @@ func TestPaneMultilineWriteSplitsIntoLines(t *testing.T) {
 			t.Fatalf("stored line %d contains a line break: %q", i, line)
 		}
 	}
-	if rows := contentRows(t, p); len(rows) != 5 {
+	if rows := contentRows(t, p, 40, 5); len(rows) != 5 {
 		t.Fatalf("view content height = %d rows, want the budgeted 5", len(rows))
 	}
 }
 
 func TestPaneWrapsLongLines(t *testing.T) {
-	p := newTestPane(t, 20, 4)
+	p := newTestPane(t)
 	p.Write("one two three four five six seven")
 
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 20, 4)
 	for i, r := range rows {
 		if util.VisibleLen(r) > 20 {
 			t.Errorf("row %d exceeds width: %q (%d cols)", i, r, util.VisibleLen(r))
@@ -89,12 +84,12 @@ func TestPaneWrapsLongLines(t *testing.T) {
 }
 
 func TestPaneTailShowsNewestRows(t *testing.T) {
-	p := newTestPane(t, 40, 3)
+	p := newTestPane(t)
 	for i := 1; i <= 10; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
 
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 3)
 	want := []string{"line 8", "line 9", "line 10"}
 	for i, w := range want {
 		if rows[i] != w {
@@ -106,10 +101,10 @@ func TestPaneTailShowsNewestRows(t *testing.T) {
 func TestPaneWrappedTailCountsVisualRows(t *testing.T) {
 	// One long line wraps to more rows than the pane height: the pane
 	// must show the newest rows of it, not blank out.
-	p := newTestPane(t, 10, 2)
+	p := newTestPane(t)
 	p.Write("aaaa bbbb cccc dddd eeee")
 
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 10, 2)
 	if strings.TrimSpace(rows[0]) == "" || strings.TrimSpace(rows[1]) == "" {
 		t.Errorf("expected the newest wrapped rows, got %q", rows)
 	}
@@ -119,58 +114,58 @@ func TestPaneWrappedTailCountsVisualRows(t *testing.T) {
 }
 
 func TestPaneScrollUpShowsHistoryAndIndicator(t *testing.T) {
-	p := newTestPane(t, 40, 2)
+	p := newTestPane(t)
 	for i := 1; i <= 10; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
 
 	p.ScrollUp(5)
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 2)
 	if rows[0] != "line 4" || rows[1] != "line 5" {
 		t.Errorf("scrolled view = %q, want lines 4-5", rows)
 	}
-	if header := strings.Split(p.View(), "\n")[0]; !strings.Contains(header, "scroll") {
-		t.Errorf("header should show scroll indicator, got %q", header)
+	if title := p.Title(); title != "test · scroll" {
+		t.Errorf("title = %q, want scroll indicator", title)
 	}
 }
 
 func TestPaneWritesWhileScrolledFreezeViewAndCount(t *testing.T) {
-	p := newTestPane(t, 40, 2)
+	p := newTestPane(t)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
 	p.ScrollUp(3)
-	before := contentRows(t, p)
+	before := contentRows(t, p, 40, 2)
 
 	p.Write("line 7")
 	p.Write("line 8")
 
-	after := contentRows(t, p)
+	after := contentRows(t, p, 40, 2)
 	if before[0] != after[0] || before[1] != after[1] {
 		t.Errorf("view should stay anchored while scrolled: %q -> %q", before, after)
 	}
-	if header := strings.Split(p.View(), "\n")[0]; !strings.Contains(header, "+2") {
-		t.Errorf("header should count new lines, got %q", header)
+	if title := p.Title(); title != "test · scroll +2" {
+		t.Errorf("title = %q, want new-line count", title)
 	}
 
 	p.ScrollToBottom()
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 2)
 	if rows[1] != "line 8" {
 		t.Errorf("bottom should show the newest line, got %q", rows)
 	}
-	if header := strings.Split(p.View(), "\n")[0]; strings.Contains(header, "scroll") {
-		t.Errorf("indicator should clear at bottom, got %q", header)
+	if title := p.Title(); title != "test" {
+		t.Errorf("title should clear its scroll indicator at bottom, got %q", title)
 	}
 }
 
 func TestPaneScrollClamps(t *testing.T) {
-	p := newTestPane(t, 40, 3)
+	p := newTestPane(t)
 	for i := 1; i <= 5; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
 
 	p.ScrollUp(1000)
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 3)
 	if rows[0] != "line 1" {
 		t.Errorf("over-scroll should clamp to the top, got %q", rows)
 	}
@@ -180,7 +175,7 @@ func TestPaneScrollClamps(t *testing.T) {
 	}
 
 	p.ScrollDown(1000)
-	rows = contentRows(t, p)
+	rows = contentRows(t, p, 40, 3)
 	if rows[2] != "line 5" {
 		t.Errorf("scroll down past the end should return to live, got %q", rows)
 	}
@@ -189,7 +184,7 @@ func TestPaneScrollClamps(t *testing.T) {
 // Visibility never touches scroll state. A pane hidden while scrolled
 // reopens on the same history, even as writes land while it is hidden.
 func TestPaneHiddenWhileScrolledKeepsPosition(t *testing.T) {
-	p := newTestPane(t, 40, 2)
+	p := newTestPane(t)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
@@ -198,14 +193,14 @@ func TestPaneHiddenWhileScrolledKeepsPosition(t *testing.T) {
 	p.Write("line 7")
 	p.SetVisible(true)
 
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 2)
 	if rows[0] != "line 2" {
 		t.Errorf("re-shown pane should keep its scroll anchor, got %q", rows)
 	}
 
 	p.Toggle() // hide
 	p.Toggle() // show again
-	rows = contentRows(t, p)
+	rows = contentRows(t, p, 40, 2)
 	if rows[0] != "line 2" {
 		t.Errorf("toggle must not touch scroll state either, got %q", rows)
 	}
@@ -214,7 +209,7 @@ func TestPaneHiddenWhileScrolledKeepsPosition(t *testing.T) {
 // A pane on the live tail when hidden stays in follow mode, so
 // reopening shows the newest lines.
 func TestPaneHiddenOnTailReopensLive(t *testing.T) {
-	p := newTestPane(t, 40, 2)
+	p := newTestPane(t)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
@@ -222,7 +217,7 @@ func TestPaneHiddenOnTailReopensLive(t *testing.T) {
 	p.Write("line 7")
 	p.SetVisible(true)
 
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 2)
 	if rows[1] != "line 7" {
 		t.Errorf("pane hidden on the tail should reopen live, got %q", rows)
 	}
@@ -232,7 +227,7 @@ func TestPaneHiddenOnTailReopensLive(t *testing.T) {
 // anchor clamps to the oldest remaining line instead of jumping to
 // the tail.
 func TestPaneHiddenAnchorClampsWhenTrimmed(t *testing.T) {
-	p := newTestPane(t, 40, 2)
+	p := newTestPane(t)
 	for i := 1; i <= 6; i++ {
 		p.Write(fmt.Sprintf("line %d", i))
 	}
@@ -243,15 +238,15 @@ func TestPaneHiddenAnchorClampsWhenTrimmed(t *testing.T) {
 	}
 	p.SetVisible(true)
 
-	rows := contentRows(t, p)
+	rows := contentRows(t, p, 40, 2)
 	if rows[0] != "line 502" {
 		t.Errorf("trimmed anchor should clamp to the oldest remaining line, got %q", rows)
 	}
 }
 
 func TestPaneEmptyAndClear(t *testing.T) {
-	p := newTestPane(t, 40, 3)
-	rows := contentRows(t, p)
+	p := newTestPane(t)
+	rows := contentRows(t, p, 40, 3)
 	for i, r := range rows {
 		if r != "" {
 			t.Errorf("empty pane row %d should be blank, got %q", i, r)
@@ -261,9 +256,50 @@ func TestPaneEmptyAndClear(t *testing.T) {
 	p.Write("something")
 	p.ScrollUp(1)
 	p.Clear()
-	rows = contentRows(t, p)
+	rows = contentRows(t, p, 40, 3)
 	if strings.TrimSpace(strings.Join(rows, "")) != "" {
 		t.Errorf("cleared pane should be blank, got %q", rows)
+	}
+}
+
+func TestPaneContentRowsUseRequestedGeometry(t *testing.T) {
+	p := newTestPane(t)
+	for i := 1; i <= 5; i++ {
+		p.Write(fmt.Sprintf("line %d", i))
+	}
+
+	short := contentRows(t, p, 40, 2)
+	if short[0] != "line 4" || short[1] != "line 5" {
+		t.Fatalf("two-row view = %q, want lines 4-5", short)
+	}
+
+	tall := contentRows(t, p, 40, 4)
+	if tall[0] != "line 2" || tall[3] != "line 5" {
+		t.Fatalf("four-row view = %q, want lines 2-5", tall)
+	}
+
+	again := contentRows(t, p, 40, 2)
+	if again[0] != "line 4" || again[1] != "line 5" {
+		t.Fatalf("second two-row view = %q, want lines 4-5", again)
+	}
+	if rows := p.ContentRows(40, 0); rows != nil {
+		t.Fatalf("zero-height content = %q, want nil", rows)
+	}
+}
+
+func TestPaneManagerLookupDoesNotCreate(t *testing.T) {
+	panes := NewPaneManager()
+	if pane, ok := panes.Lookup("missing"); ok || pane != nil {
+		t.Fatalf("missing lookup = (%v, %v), want (nil, false)", pane, ok)
+	}
+	if len(panes.panes) != 0 {
+		t.Fatal("lookup created a missing pane")
+	}
+
+	panes.Create("chat")
+	pane, ok := panes.Lookup("chat")
+	if !ok || pane == nil || pane.Name != "chat" {
+		t.Fatalf("created lookup = (%v, %v), want chat pane", pane, ok)
 	}
 }
 

--- a/website/src/content/docs/interface/layout.md
+++ b/website/src/content/docs/interface/layout.md
@@ -63,9 +63,16 @@ instead.
 ## Rules of the layout table
 
 - A table entry (`{ name = ..., height = n }`) sets an explicit height
-  in lines (a pane spends two of those on its header and bottom
-  border). Any other string-valued key is an option for the named
-  component, like the separator's `char`; unknown keys are ignored.
+  in lines. For a pane, omit `height` or set it to `0` to use the default
+  height of 12 lines; any other value below 2 is treated as 2. The value
+  is the pane's standalone height: two rows frame its content with a
+  titled header and bottom border. Adjacent visible panes still show the
+  same number of content rows but share a boundary: the upper pane drops
+  its bottom border, and the lower pane's titled header acts as the
+  divider. Two adjacent panes with `height = 12` therefore occupy 23 rows
+  instead of 24 while each still shows 10 content rows. Any other
+  string-valued key is an option for the named component, like the
+  separator's `char`; unknown keys are ignored.
 - `rune.ui.layout` replaces the whole layout. Always include `"input"`
   in a dock, because nothing re-adds it if you leave it out.
 - A component appears only if a dock names it. Registering a bar or

--- a/website/src/content/docs/interface/panes.md
+++ b/website/src/content/docs/interface/panes.md
@@ -27,11 +27,20 @@ rune.ui.layout({
 })
 ```
 
-A docked pane renders a title header and a bottom border, which use two of
-its `height` lines. Panes start hidden; `toggle` shows them. A hidden pane
-keeps accumulating writes (the buffer is capped at 1000 lines), so toggling
-it back shows the recent history. Lines longer than the pane width
-soft-wrap, and re-fit when the terminal resizes.
+A pane's configured `height` is its standalone height. Omit `height` or set it
+to `0` to use the default height of 12 lines; any other value below 2 is
+treated as 2. The titled header and bottom border use two rows, and the rest
+show content. When visible panes are adjacent in the same dock, Rune omits the
+upper pane's bottom border and uses the lower pane's titled header as their
+shared boundary. Each pane still shows the same number of content rows, so
+each shared boundary saves one row. For example, two adjacent panes with
+`height = 12` each still show 10 content rows apiece but occupy 23 rows
+together instead of 24.
+
+Panes start hidden; `toggle` shows them. A hidden pane keeps accumulating
+writes (the buffer is capped at 1000 lines), so toggling it back shows the
+recent history. Lines longer than the pane width soft-wrap, and re-fit when
+the terminal resizes.
 
 ## Scrolling
 


### PR DESCRIPTION
Closes #94.

## Summary
- move pane framing into the dock compositor while keeping pane state and content rendering independent
- share the lower pane title across adjacent visible panes without reducing the content rows in either pane
- preserve standalone and mixed-widget borders, and document the resulting height behavior

## Testing
- `go test ./... -count=1`
- `go test -race ./ui/tui/... -count=1`
- `go vet ./...`
- Windows `ui/tui` cross-compile
- website build
- headless tmux pane-stack, visibility-toggle, separator, scroll-title, and resize verification