### PR TITLE
Remove vulncheck from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,18 +70,6 @@ jobs:
           disable_search: true
           fail_ci_if_error: true
 
-  vulncheck:
-    name: vulncheck
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-      - name: govulncheck
-        run: go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
-
   build:
     name: build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- remove the standalone `govulncheck` CI job
- leave quality, tests, coverage, builds, and LuaJIT checks unchanged

## Testing
- workflow YAML parse
- repository-wide `vulncheck` and `govulncheck` scan
- `git diff --check`