### PR TITLE
Fix physical numpad input across terminals

### DIFF
--- a/ui/messages.go
+++ b/ui/messages.go
@@ -72,8 +72,8 @@ type Config struct {
 	// KeepInput keeps a submitted command selected in the input line, so Enter
 	// resends it and typing replaces it.
 	KeepInput bool
-	// Numpad asks terminals with legacy keypad support to report physical
-	// numpad keys separately from their number-row equivalents.
+	// Numpad enables terminal modes that preserve physical numpad keys. Rune
+	// still accepts an already-distinct numpad event when this is false.
 	Numpad bool
 	// Mouse captures terminal mouse events so the wheel can scroll Rune's
 	// viewport. When disabled, the terminal retains native text selection.

--- a/ui/tui/input_mode.go
+++ b/ui/tui/input_mode.go
@@ -214,11 +214,26 @@ func (c *inputController) SetSubmission(submission input.Submission) {
 }
 
 func (c *inputController) dispatchNumpadEnterBind(msg tea.KeyPressMsg) bool {
-	name, _, ok := numpadKey(msg)
-	if !ok || name != "numpad_enter" || msg.Mod&keyModifiers != 0 || !c.isBound(name) {
+	info, ok := numpadKey(msg)
+	if !ok || info.name != "numpad_enter" || msg.Mod&keyModifiers != 0 || !c.isBound(info.name) {
 		return false
 	}
-	c.notify(ui.ExecuteBindMsg(name))
+	c.notify(ui.ExecuteBindMsg(info.name))
+	return true
+}
+
+// tryNormalBind applies normal mode's typing-safety rule. Text-bearing
+// keys dispatch only when the draft is empty or selected; non-text keys can
+// remain useful as movement binds while a command is being composed.
+func (c *inputController) tryNormalBind(msg tea.KeyPressMsg) bool {
+	key := keyToString(msg)
+	if key == "" || !c.isBound(key) {
+		return false
+	}
+	if msg.Text != "" && c.input.Value() != "" && !c.input.Selected() {
+		return false
+	}
+	c.notify(ui.ExecuteBindMsg(key))
 	return true
 }
 
@@ -237,17 +252,17 @@ func (c *inputController) handleNormalKey(msg tea.KeyPressMsg) {
 		return
 	}
 
-	keyStr := keyToString(msg)
-	if keyStr != "" && c.isBound(keyStr) {
-		// Text-bearing events are typing, including AltGr input. Modifier
-		// chords have no text, so the empty-input guard does not apply.
-		// A fully selected line counts as empty: its text is about to
-		// be replaced anyway, so movement binds keep firing.
-		isPrintable := msg.Text != ""
-		if !isPrintable || c.input.Value() == "" || c.input.Selected() {
-			c.notify(ui.ExecuteBindMsg(keyStr))
+	// A NumLock-off physical bind gets first refusal. If there is no such
+	// bind, route the key through its ordinary navigation meaning, including
+	// any Lua bind on that base key.
+	if info, ok := numpadNavigation(msg); ok {
+		if c.tryNormalBind(msg) {
 			return
 		}
+		msg = info.navigationFallback(msg)
+	}
+	if c.tryNormalBind(msg) {
+		return
 	}
 	// Unbound scroll keys: Go fallback (keeps degraded mode scrollable)
 	if c.scroll(msg) {
@@ -264,6 +279,17 @@ func (c *inputController) handleComposeKey(msg tea.KeyPressMsg) {
 	if matchesEnterKey(msg, 0) {
 		c.submitInput()
 		return
+	}
+
+	// Compose owns editing mechanics. Give NumLock-off keypad keys their
+	// semantic navigation meaning first, but retain the physical name so an
+	// unconsumed modified chord can still be delegated to Lua.
+	physicalKey := ""
+	physicalModified := false
+	if info, ok := numpadNavigation(msg); ok {
+		physicalKey = keyToString(msg)
+		physicalModified = msg.Mod&keyModifiers != 0
+		msg = info.navigationFallback(msg)
 	}
 	if c.historyRecall {
 		key := ""
@@ -289,6 +315,11 @@ func (c *inputController) handleComposeKey(msg tea.KeyPressMsg) {
 		if !c.input.IsComposing() {
 			c.mode = ModeNormal
 		}
+		return
+	}
+
+	if physicalModified && physicalKey != "" && c.isBound(physicalKey) {
+		c.notify(ui.ExecuteBindMsg(physicalKey))
 		return
 	}
 
@@ -370,6 +401,15 @@ func (c *inputController) handleInlineKey(msg tea.KeyPressMsg) {
 		c.handlePaste("\n")
 		return
 	}
+	// An exact physical numpad bind wins in the inline picker. Without one,
+	// the NumLock-off form becomes the local navigation key engraved on it.
+	if info, ok := numpadNavigation(msg); ok {
+		if key := keyToString(msg); key != "" && c.isBound(key) {
+			c.notify(ui.ExecuteBindMsg(key))
+			return
+		}
+		msg = info.navigationFallback(msg)
+	}
 	keyStr := keyToString(msg)
 	// Don't send picker navigation keys to Lua - handle them locally
 	if keyStr != "" && c.isBound(keyStr) && !inlinePickerLocalKeys[keyStr] {
@@ -425,6 +465,9 @@ func isComposerNewline(msg tea.KeyPressMsg) bool {
 }
 
 func (c *inputController) handleModalKey(msg tea.KeyPressMsg) {
+	if info, ok := numpadNavigation(msg); ok {
+		msg = info.navigationFallback(msg)
+	}
 	switch {
 	case matchesKey(msg, tea.KeyUp, 0):
 		c.input.PickerSelectUp()
@@ -514,6 +557,9 @@ func (c *inputController) ShowSearch(opts ui.ShowSearchMsg) {
 // handleSearchKey traps all keys while the search overlay is open,
 // like the modal picker: bound keys do not dispatch to Lua.
 func (c *inputController) handleSearchKey(msg tea.KeyPressMsg) {
+	if info, ok := numpadNavigation(msg); ok {
+		msg = info.navigationFallback(msg)
+	}
 	switch {
 	case matchesKey(msg, tea.KeyUp, 0):
 		c.selectOlderSearch()

--- a/ui/tui/input_mode_test.go
+++ b/ui/tui/input_mode_test.go
@@ -359,6 +359,230 @@ func TestModifiedNumpadBindUsesSameNameAcrossInputEncodings(t *testing.T) {
 	}
 }
 
+func TestNormalBoundKpNavigationWinsWithDraft(t *testing.T) {
+	h := newControllerHarness()
+	h.bound["numpad8"] = true
+	h.bound["up"] = true
+	h.ctl.SetText("look")
+	h.events = nil
+	wantCursor := h.ctl.input.Position()
+
+	h.ctl.HandleKey(keyPress(tea.KeyKpUp))
+
+	if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("numpad8") {
+		t.Fatalf("keypad Up binds = %v, want [numpad8]", binds)
+	}
+	if got := h.ctl.input.Value(); got != "look" {
+		t.Fatalf("bound keypad Up changed input to %q", got)
+	}
+	if got := h.ctl.input.Position(); got != wantCursor {
+		t.Fatalf("bound keypad Up moved cursor to %d, want %d", got, wantCursor)
+	}
+}
+
+func TestUnboundKpNavigationActsAsNavigationKey(t *testing.T) {
+	t.Run("bound base key dispatches", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["up"] = true
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpUp))
+
+		if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("up") {
+			t.Fatalf("keypad Up binds = %v, want [up]", binds)
+		}
+	})
+
+	t.Run("editing key moves the cursor", func(t *testing.T) {
+		h := newControllerHarness()
+		h.ctl.SetText("ab")
+		h.events = nil
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpLeft))
+
+		moved := false
+		for _, ev := range h.events {
+			if cur, ok := ev.(ui.CursorMovedMsg); ok && cur.Cursor == 1 {
+				moved = true
+			}
+		}
+		if !moved {
+			t.Fatalf("keypad Left did not move the cursor: %v", h.events)
+		}
+	})
+}
+
+func TestComposerKpNavigationUsesEditingBeforeBinds(t *testing.T) {
+	t.Run("unmodified key stays local", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["numpad8"] = true
+		h.ctl.input.SetSize(80, 0)
+		h.ctl.SetText("one\ntwo")
+		h.events = nil
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpUp))
+
+		if binds := h.executeBinds(); len(binds) != 0 {
+			t.Fatalf("composer dispatched keypad navigation bind: %v", binds)
+		}
+		if got := h.ctl.input.Position(); got != 3 {
+			t.Fatalf("keypad Up moved composer cursor to %d, want 3", got)
+		}
+		if got := h.ctl.input.Value(); got != "one\ntwo" {
+			t.Fatalf("keypad Up changed composer to %q", got)
+		}
+	})
+
+	t.Run("consumed modified key stays local", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["ctrl+numpad7"] = true
+		h.ctl.SetText("one\ntwo")
+		h.events = nil
+
+		h.ctl.HandleKey(tea.KeyPressMsg{Code: tea.KeyKpHome, Mod: tea.ModCtrl})
+
+		if binds := h.executeBinds(); len(binds) != 0 {
+			t.Fatalf("composer dispatched consumed keypad chord: %v", binds)
+		}
+		if got := h.ctl.input.Position(); got != 0 {
+			t.Fatalf("Ctrl+keypad Home moved composer cursor to %d, want 0", got)
+		}
+	})
+
+	t.Run("unconsumed modified key keeps physical bind", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["ctrl+numpad8"] = true
+		h.bound["ctrl+up"] = true
+		h.ctl.SetText("one\ntwo")
+		h.events = nil
+		wantCursor := h.ctl.input.Position()
+
+		h.ctl.HandleKey(tea.KeyPressMsg{Code: tea.KeyKpUp, Mod: tea.ModCtrl})
+
+		if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("ctrl+numpad8") {
+			t.Fatalf("composer keypad chord binds = %v, want [ctrl+numpad8]", binds)
+		}
+		if got := h.ctl.input.Position(); got != wantCursor {
+			t.Fatalf("unconsumed keypad chord moved cursor to %d, want %d", got, wantCursor)
+		}
+	})
+
+	t.Run("unconsumed unmodified key does not delegate", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["numpad5"] = true
+		h.ctl.SetText("one\ntwo")
+		h.events = nil
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpBegin))
+
+		if binds := h.executeBinds(); len(binds) != 0 {
+			t.Fatalf("composer dispatched unmodified keypad bind: %v", binds)
+		}
+	})
+
+	t.Run("unconsumed chord falls back to base bind", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["ctrl+up"] = true
+		h.ctl.SetText("one\ntwo")
+		h.events = nil
+
+		h.ctl.HandleKey(tea.KeyPressMsg{Code: tea.KeyKpUp, Mod: tea.ModCtrl})
+
+		if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("ctrl+up") {
+			t.Fatalf("composer fallback binds = %v, want [ctrl+up]", binds)
+		}
+	})
+}
+
+func TestPickerKpNavigationFollowsModePolicy(t *testing.T) {
+	t.Run("inline physical bind wins", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["numpad2"] = true
+		h.bound["down"] = true
+		h.ctl.ShowPicker(ui.ShowPickerMsg{Items: pickerTestItems, CallbackID: "cb", Inline: true})
+		h.events = nil
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpDown))
+
+		if binds := h.executeBinds(); len(binds) != 1 || binds[0] != ui.ExecuteBindMsg("numpad2") {
+			t.Fatalf("inline keypad binds = %v, want [numpad2]", binds)
+		}
+		selected, ok := h.ctl.input.PickerSelected()
+		if !ok || selected.Value != "/connect" {
+			t.Fatalf("inline physical bind moved selection to %+v", selected)
+		}
+	})
+
+	t.Run("inline unbound key navigates locally", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["down"] = true
+		h.ctl.ShowPicker(ui.ShowPickerMsg{Items: pickerTestItems, CallbackID: "cb", Inline: true})
+		h.events = nil
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpDown))
+
+		if binds := h.executeBinds(); len(binds) != 0 {
+			t.Fatalf("inline picker dispatched base bind: %v", binds)
+		}
+		selected, ok := h.ctl.input.PickerSelected()
+		if !ok || selected.Value != "/disconnect" {
+			t.Fatalf("inline keypad Down selected %+v, want /disconnect", selected)
+		}
+	})
+
+	t.Run("modal always navigates locally", func(t *testing.T) {
+		h := newControllerHarness()
+		h.bound["numpad2"] = true
+		h.bound["down"] = true
+		h.ctl.ShowPicker(ui.ShowPickerMsg{Items: pickerTestItems, CallbackID: "cb"})
+		h.events = nil
+
+		h.ctl.HandleKey(keyPress(tea.KeyKpDown))
+
+		if binds := h.executeBinds(); len(binds) != 0 {
+			t.Fatalf("modal picker dispatched keypad bind: %v", binds)
+		}
+		selected, ok := h.ctl.input.PickerSelected()
+		if !ok || selected.Value != "/disconnect" {
+			t.Fatalf("modal keypad Down selected %+v, want /disconnect", selected)
+		}
+	})
+}
+
+// TestSearchModeTreatsKpNavigationAsNavigation guards both the trap-all rule
+// and the direction of NumLock-off keypad navigation.
+func TestSearchModeTreatsKpNavigationAsNavigation(t *testing.T) {
+	h := newControllerHarness()
+	h.buf.Append("thief one")
+	h.buf.Append("quiet row")
+	h.buf.Append("thief two")
+	h.bound["numpad8"] = true
+	h.bound["numpad2"] = true
+	h.bound["up"] = true
+	h.bound["down"] = true
+	h.ctl.ShowSearch(ui.ShowSearchMsg{Query: "thief"})
+	h.events = nil
+
+	selected, ok := h.ctl.input.SearchSelected()
+	if !ok || selected.Stripped != "thief two" {
+		t.Fatalf("initial search selection = %+v, want thief two", selected)
+	}
+
+	h.ctl.HandleKey(keyPress(tea.KeyKpUp))
+	selected, ok = h.ctl.input.SearchSelected()
+	if !ok || selected.Stripped != "thief one" {
+		t.Fatalf("keypad Up selected %+v, want thief one", selected)
+	}
+
+	h.ctl.HandleKey(keyPress(tea.KeyKpDown))
+	selected, ok = h.ctl.input.SearchSelected()
+	if !ok || selected.Stripped != "thief two" {
+		t.Fatalf("keypad Down selected %+v, want thief two", selected)
+	}
+	if binds := h.executeBinds(); len(binds) != 0 {
+		t.Fatalf("search mode dispatched a keypad bind: %v", binds)
+	}
+}
+
 func TestUnboundDECKPAMKeysTypeTheirCharacters(t *testing.T) {
 	h := newControllerHarness()
 

--- a/ui/tui/keys.go
+++ b/ui/tui/keys.go
@@ -19,76 +19,127 @@ func matchesEnterKey(msg tea.KeyPressMsg, modifiers tea.KeyMod) bool {
 	return isEnterKey(msg) && msg.Mod&keyModifiers == modifiers
 }
 
-// numpadCode returns Rune's bind name and printable fallback for a physical
-// numpad key code. Enter has no printable fallback; equal and comma have no
-// public bind name but still type normally.
-func numpadCode(code rune) (name, text string, ok bool) {
+// numpadKeyInfo describes one physical numpad key. text is the character the
+// key types in numeric mode; nav is its semantic fallback when the terminal
+// reports the NumLock-off form.
+type numpadKeyInfo struct {
+	name string
+	text string
+	nav  rune
+}
+
+// numpadCode returns Rune's description of a physical numpad key code.
+// Enter has no printable fallback; equal and comma have no public bind name
+// but still type normally.
+func numpadCode(code rune) (numpadKeyInfo, bool) {
 	if code >= tea.KeyKp0 && code <= tea.KeyKp9 {
 		digit := string(rune('0') + code - tea.KeyKp0)
-		return "numpad" + digit, digit, true
+		return numpadKeyInfo{name: "numpad" + digit, text: digit}, true
 	}
 	switch code {
 	case tea.KeyKpEnter:
-		return "numpad_enter", "", true
+		return numpadKeyInfo{name: "numpad_enter"}, true
 	case tea.KeyKpPlus:
-		return "numpad_plus", "+", true
+		return numpadKeyInfo{name: "numpad_plus", text: "+"}, true
 	case tea.KeyKpMinus:
-		return "numpad_minus", "-", true
+		return numpadKeyInfo{name: "numpad_minus", text: "-"}, true
 	case tea.KeyKpMultiply:
-		return "numpad_star", "*", true
+		return numpadKeyInfo{name: "numpad_star", text: "*"}, true
 	case tea.KeyKpDivide:
-		return "numpad_slash", "/", true
+		return numpadKeyInfo{name: "numpad_slash", text: "/"}, true
 	case tea.KeyKpDecimal:
-		return "numpad_dot", ".", true
+		return numpadKeyInfo{name: "numpad_dot", text: "."}, true
 	case tea.KeyKpEqual:
-		return "", "=", true
+		return numpadKeyInfo{text: "="}, true
 	case tea.KeyKpComma, tea.KeyKpSep:
-		return "", ",", true
+		return numpadKeyInfo{text: ","}, true
+	case tea.KeyKpInsert:
+		return numpadKeyInfo{name: "numpad0", nav: tea.KeyInsert}, true
+	case tea.KeyKpEnd:
+		return numpadKeyInfo{name: "numpad1", nav: tea.KeyEnd}, true
+	case tea.KeyKpDown:
+		return numpadKeyInfo{name: "numpad2", nav: tea.KeyDown}, true
+	case tea.KeyKpPgDown:
+		return numpadKeyInfo{name: "numpad3", nav: tea.KeyPgDown}, true
+	case tea.KeyKpLeft:
+		return numpadKeyInfo{name: "numpad4", nav: tea.KeyLeft}, true
+	case tea.KeyKpBegin:
+		return numpadKeyInfo{name: "numpad5", nav: tea.KeyBegin}, true
+	case tea.KeyKpRight:
+		return numpadKeyInfo{name: "numpad6", nav: tea.KeyRight}, true
+	case tea.KeyKpHome:
+		return numpadKeyInfo{name: "numpad7", nav: tea.KeyHome}, true
+	case tea.KeyKpUp:
+		return numpadKeyInfo{name: "numpad8", nav: tea.KeyUp}, true
+	case tea.KeyKpPgUp:
+		return numpadKeyInfo{name: "numpad9", nav: tea.KeyPgUp}, true
+	case tea.KeyKpDelete:
+		return numpadKeyInfo{name: "numpad_dot", nav: tea.KeyDelete}, true
 	default:
-		return "", "", false
+		return numpadKeyInfo{}, false
 	}
 }
 
 // numpadKey recognizes both the direct KeyKp* form used by SS3/kitty input
 // and the BaseCode form used by win32 input.
-func numpadKey(msg tea.KeyPressMsg) (name, text string, ok bool) {
-	if name, text, ok = numpadCode(msg.BaseCode); ok {
-		return name, text, true
+func numpadKey(msg tea.KeyPressMsg) (numpadKeyInfo, bool) {
+	if info, ok := numpadCode(msg.BaseCode); ok {
+		return info, true
 	}
 	return numpadCode(msg.Code)
 }
 
+// numpadNavigation recognizes the actual NumLock-off code carried by an
+// event. Binding identity is BaseCode-first, but semantic fallback follows
+// Code so an alternate keyboard-layout code cannot change the key's action.
+func numpadNavigation(msg tea.KeyPressMsg) (numpadKeyInfo, bool) {
+	info, ok := numpadCode(msg.Code)
+	return info, ok && info.nav != 0
+}
+
+// navigationFallback converts a NumLock-off physical keypad event into the
+// ordinary navigation event engraved on that key. It is deliberately pure:
+// input modes decide when this fallback takes precedence over Lua binds.
+func (info numpadKeyInfo) navigationFallback(msg tea.KeyPressMsg) tea.KeyPressMsg {
+	if info.nav == 0 {
+		return msg
+	}
+	msg.Code = info.nav
+	msg.BaseCode = 0
+	return msg
+}
+
 func normalizeNumpadText(msg tea.KeyPressMsg) tea.KeyPressMsg {
-	_, text, ok := numpadKey(msg)
-	if !ok || text == "" {
+	info, ok := numpadKey(msg)
+	if !ok || info.text == "" || info.nav != 0 {
 		return msg
 	}
 	if msg.Mod&(keyModifiers&^tea.ModShift) != 0 {
 		// Win32 input supplies the ordinary keypad character even for
 		// modified chords. Remove that synthetic text so the same chord
 		// routes like SS3 and kitty input, while preserving real AltGr text.
-		if msg.Text == text {
+		if msg.Text == info.text {
 			msg.Text = ""
 		}
 		return msg
 	}
 	if msg.Text == "" {
-		msg.Text = text
+		msg.Text = info.text
 	}
 	return msg
 }
 
 // keyToString returns Rune's canonical name at the Go/Lua bind boundary.
 func keyToString(msg tea.KeyPressMsg) string {
-	if name, _, ok := numpadKey(msg); ok {
-		if name == "" {
+	if info, ok := numpadKey(msg); ok {
+		if info.name == "" {
 			return ""
 		}
 		// Reuse Bubble Tea's modifier spelling and ordering while replacing its
 		// deliberately collapsed keypad name with Rune's physical-key name.
 		msg.Code = tea.KeyExtended
 		msg.BaseCode = 0
-		msg.Text = name
+		msg.Text = info.name
 	}
 	return msg.Keystroke()
 }

--- a/ui/tui/keys_test.go
+++ b/ui/tui/keys_test.go
@@ -117,6 +117,54 @@ func TestNormalizeNumpadTextFillsOnlyPrintableUnmodifiedKeys(t *testing.T) {
 	}
 }
 
+// TestKpNavigationKeysShareDigitBindNames covers the NumLock-off keypad
+// reported by the kitty keyboard protocol: the physical key keeps its
+// numpad bind name but must not type a digit.
+func TestKpNavigationKeysShareDigitBindNames(t *testing.T) {
+	tests := []struct {
+		code rune
+		name string
+		nav  rune
+	}{
+		{tea.KeyKpInsert, "numpad0", tea.KeyInsert},
+		{tea.KeyKpEnd, "numpad1", tea.KeyEnd},
+		{tea.KeyKpDown, "numpad2", tea.KeyDown},
+		{tea.KeyKpPgDown, "numpad3", tea.KeyPgDown},
+		{tea.KeyKpLeft, "numpad4", tea.KeyLeft},
+		{tea.KeyKpBegin, "numpad5", tea.KeyBegin},
+		{tea.KeyKpRight, "numpad6", tea.KeyRight},
+		{tea.KeyKpHome, "numpad7", tea.KeyHome},
+		{tea.KeyKpUp, "numpad8", tea.KeyUp},
+		{tea.KeyKpPgUp, "numpad9", tea.KeyPgUp},
+		{tea.KeyKpDelete, "numpad_dot", tea.KeyDelete},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			msg := tea.KeyPressMsg{Code: tt.code, Mod: tea.ModCtrl}
+			if got := keyToString(msg); got != "ctrl+"+tt.name {
+				t.Fatalf("keyToString(Code=%v) = %q, want %q", tt.code, got, "ctrl+"+tt.name)
+			}
+			if got := normalizeNumpadText(msg).Text; got != "" {
+				t.Fatalf("NumLock-off keypad key produced text %q", got)
+			}
+
+			info, ok := numpadNavigation(msg)
+			if !ok || info.name != tt.name || info.nav != tt.nav || info.text != "" {
+				t.Fatalf("numpadNavigation(Code=%v) = %+v, %v", tt.code, info, ok)
+			}
+			routeMsg := tea.KeyPressMsg{Code: tt.code, BaseCode: 'q', Mod: tea.ModCtrl, Text: "preserved"}
+			fallback := info.navigationFallback(routeMsg)
+			if fallback.Code != tt.nav || fallback.BaseCode != 0 {
+				t.Fatalf("fallback = %#v, want Code=%v and no BaseCode", fallback, tt.nav)
+			}
+			if fallback.Mod != routeMsg.Mod || fallback.Text != routeMsg.Text {
+				t.Fatalf("fallback lost event metadata: got %#v, started %#v", fallback, routeMsg)
+			}
+		})
+	}
+}
+
 func TestUndocumentedNumpadKeysDoNotCollideWithOrdinaryBinds(t *testing.T) {
 	for _, code := range []rune{tea.KeyKpEqual, tea.KeyKpComma, tea.KeyKpSep} {
 		if got := keyToString(tea.KeyPressMsg{Code: code}); got != "" {

--- a/ui/tui/layout.go
+++ b/ui/tui/layout.go
@@ -192,6 +192,15 @@ func (m *Model) View() tea.View {
 	if m.mouseEnabled {
 		view.MouseMode = tea.MouseModeCellMotion
 	}
+	if m.numpadMode {
+		// The default kitty disambiguation flag reports NumLock-on keypad
+		// digits as plain text, indistinguishable from the number row.
+		// Encoding all keys as escape codes preserves the physical key;
+		// associated text keeps the typed characters coming from the
+		// terminal instead of being reconstructed from key codes.
+		view.KeyboardEnhancements.ReportAllKeysAsEscapeCodes = true
+		view.KeyboardEnhancements.ReportAssociatedText = true
+	}
 	if !m.initialized {
 		view.Content = "Loading..."
 		return view

--- a/ui/tui/model.go
+++ b/ui/tui/model.go
@@ -64,6 +64,7 @@ type Model struct {
 	height       int
 	events       chan<- ui.UIEvent
 	mouseEnabled bool
+	numpadMode   bool
 	initialized  bool
 	pendingRows  []string
 	// flushScheduled is true while a batch-window tick is outstanding.
@@ -252,6 +253,7 @@ func (m *Model) handleConfigUpdate(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ui.UpdateConfigMsg:
 		m.inputCtl.SetKeepOnSubmit(msg.KeepInput)
 		m.mouseEnabled = msg.Mouse
+		m.numpadMode = msg.Numpad
 	}
 	if layoutChanged {
 		m.syncViewportSize()

--- a/ui/tui/model_test.go
+++ b/ui/tui/model_test.go
@@ -74,6 +74,29 @@ func TestMouseModeFollowsRuntimeConfig(t *testing.T) {
 	}
 }
 
+// TestKeyboardEnhancementsFollowNumpadConfig verifies the numpad setting
+// requests the kitty keyboard flags that make NumLock-on keypad digits
+// distinguishable from the number row, and releases them when turned off.
+func TestKeyboardEnhancementsFollowNumpadConfig(t *testing.T) {
+	m := NewModel(make(chan ui.UIEvent, 1))
+	if ke := m.View().KeyboardEnhancements; ke.ReportAllKeysAsEscapeCodes || ke.ReportAssociatedText {
+		t.Fatal("numpad-off view enables enhanced key mode")
+	}
+
+	next, _ := m.Update(ui.UpdateConfigMsg{Numpad: true})
+	m = next.(*Model)
+	ke := m.View().KeyboardEnhancements
+	if !ke.ReportAllKeysAsEscapeCodes || !ke.ReportAssociatedText {
+		t.Fatalf("numpad-on view enhancements = %+v, want all keys as escape codes with associated text", ke)
+	}
+
+	next, _ = m.Update(ui.UpdateConfigMsg{Numpad: false})
+	m = next.(*Model)
+	if ke := m.View().KeyboardEnhancements; ke.ReportAllKeysAsEscapeCodes || ke.ReportAssociatedText {
+		t.Fatal("numpad-off view still enables enhanced key mode")
+	}
+}
+
 // TestMouseWheelScrollsViewport verifies wheel events scroll the main
 // viewport - the reason the terminal mouse is captured at all.
 func TestMouseWheelScrollsViewport(t *testing.T) {

--- a/website/src/content/docs/reference/api/core.md
+++ b/website/src/content/docs/reference/api/core.md
@@ -169,7 +169,7 @@ rune.config.set(key, value)
 | `command_separator` | non-empty string | `";"` | Text that separates multiple commands entered on one line |
 | `history_character` | empty or one visible, non-space character | `"!"` | Character used for history expansion (`!`, `!!`, `!prefix`); empty disables it |
 | `keep_input` | boolean | `false` | After `Enter`, leave the text you typed selected; `Enter` repeats it and typing replaces it |
-| `numpad` | boolean | `false` | Ask legacy terminals to report physical numpad keys separately; see [Numpad keys](/scripting/keybindings/#numpad-keys) |
+| `numpad` | boolean | `false` | Enable terminal support for physical numpad bindings; see [Numpad keys](/scripting/keybindings/#numpad-keys) |
 | `mouse` | boolean | `false` | Capture the mouse so its wheel scrolls Rune; see [Scrolling and the mouse](/interface/input/#scrolling-and-the-mouse) |
 
 An unknown key, a value of the wrong type, an empty `command_separator`, or an

--- a/website/src/content/docs/scripting/keybindings.md
+++ b/website/src/content/docs/scripting/keybindings.md
@@ -44,36 +44,33 @@ Key names are exact. Use `esc`, `pgup`, and `pgdown`; `escape`, `pageup`, and
 
 ### Numpad keys
 
-Terminals using an enhanced keyboard protocol report physical numpad keys to
-Rune automatically. Older terminals need application keypad mode, which is
-off by default. Enable it in `init.lua`:
+Numpad names refer to physical keys: `numpad8` is the key itself, whether
+NumLock makes it type `8` or act as Up. Add this to `init.lua` when you use
+numpad binds:
 
 ```lua
 rune.config.set("numpad", true)
 ```
 
-The setting takes effect immediately. Turning it off returns the terminal to
-numeric keypad mode; Rune also does that while `$EDITOR` is open and whenever
-the client exits.
+| Terminal | Terminal setup |
+|---|---|
+| Ghostty, Kitty, Alacritty, foot, iTerm2 | None |
+| WezTerm | Set `enable_kitty_keyboard = true` |
+| Windows Terminal | Version 1.25 or newer; 1.25 is currently Preview |
+| macOS Terminal | Enable **Profiles → Advanced → Allow VT100 application keypad mode** |
+| xterm | Launch `xterm -kt vt220` with NumLock off |
+| urxvt | Use NumLock off |
+| GNOME Terminal, Ptyxis, COSMIC Terminal | Not supported |
 
-NumLock generally needs to be on. Some legacy terminals, including urxvt and
-some xterm configurations, report application-keypad sequences only with it
-off. With no matching bind, numpad digits and operators type their usual
-characters, and `numpad_enter` acts like `enter`. In normal input, bound numpad
-digits and operators follow the same empty-or-selected rule as other printable
-binds.
+Current tmux releases do not pass modern numpad keys through. If numpad binds
+fail inside tmux, test Rune without tmux. Some older terminal setups can still
+work inside tmux.
 
-Terminal support varies. On a system with `timeout`, this probe requests
-application keypad mode for ten seconds and then restores the terminal:
-
-```sh
-(saved=$(stty -g); trap 'stty "$saved"; printf "\033>"' EXIT; printf '\033='; stty raw -echo; timeout 10 cat -v)
-```
-
-Press a numpad key while it runs. `^[Ox` for numpad 8 means the terminal
-supports application keypad mode; a bare `8` means it does not. Enhanced
-keyboard-protocol terminals may still support Rune's numpad binds even when
-this legacy probe prints a digit.
+On modern terminals, NumLock can be on or off. With NumLock off, unbound keys
+act like their arrows, while bound movement keys still work with a half-typed
+command. In the multiline composer, numpad arrows move around the draft
+instead of running movement binds. `numpad_enter` acts like `enter` when it has
+no bind.
 
 ### Reserved input keys
 
@@ -139,7 +136,7 @@ rune.bind("f6", function() rune.send("south") end, { group = "movement" })
 Numpad movement:
 
 ```lua
-rune.config.set("numpad", true) -- needed only for legacy terminal input
+rune.config.set("numpad", true) -- enable terminal numpad support
 rune.bind("numpad8", function() rune.send("north") end)
 rune.bind("numpad2", function() rune.send("south") end)
 rune.bind("numpad6", function() rune.send("east") end)


### PR DESCRIPTION
## Summary

- enable full physical-key encoding when `numpad` mode is on, so terminals such as Ghostty can distinguish keypad digits from the number row
- recognize NumLock-off keypad navigation codes and route them according to each input mode
- keep normal-mode movement binds usable with a half-typed command while keeping keypad navigation local in the multiline composer
- consolidate keypad names, text, and navigation fallbacks into one descriptor
- document the tested terminal matrix, xterm's VT220 requirement, and the current tmux limitation

## Root cause

The v0.10.0 implementation could handle a distinct keypad event after it reached Rune, but Rune did not request the keyboard mode Ghostty needs to send NumLock-on keypad digits distinctly. It also did not map the separate keypad navigation codes produced with NumLock off.

The protocol change is opt-in behind `rune.config.set("numpad", true)` and preserves the text associated with encoded keys.

## Verification

- `go test -count=1 ./...`
- `go vet ./...`
- `go test -race ./ui/tui ./ui/tui/widget`
- `npm run build` in `website/`
- headless TUI verification with raw keypad protocol input, including a bound NumLock-off `numpad8` while a partial command was present

Target: v0.10.1
